### PR TITLE
RFC: Callable spies

### DIFF
--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -93,8 +93,6 @@ class Mockery
      */
     public static function spy(...$args)
     {
-        $args = func_get_args();
-
         if (count($args) && $args[0] instanceof \Closure) {
             $args[0] = new ClosureWrapper($args[0]);
         }

--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -26,6 +26,7 @@ use Mockery\Generator\StringManipulationGenerator;
 use Mockery\Loader\EvalLoader;
 use Mockery\Loader\Loader;
 use Mockery\Matcher\MatcherAbstract;
+use Mockery\ClosureWrapper;
 
 class Mockery
 {
@@ -92,6 +93,12 @@ class Mockery
      */
     public static function spy(...$args)
     {
+        $args = func_get_args();
+
+        if (count($args) && $args[0] instanceof \Closure) {
+            $args[0] = new ClosureWrapper($args[0]);
+        }
+
         return call_user_func_array(array(self::getContainer(), 'mock'), $args)->shouldIgnoreMissing();
     }
 

--- a/library/Mockery/ClosureWrapper.php
+++ b/library/Mockery/ClosureWrapper.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/blob/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ *
+ * @category   Mockery
+ * @package    Mockery
+ * @copyright  Copyright (c) 2017 Dave Marshall https://github.com/davedevelopment
+ * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
+ */
+
+namespace Mockery;
+
+use Mockery\Matcher\Closure;
+
+/**
+ * @internal
+ */
+class ClosureWrapper
+{
+    private $closure;
+
+    public function __construct(\Closure $closure)
+    {
+        $this->closure = $closure;
+    }
+
+    public function __invoke()
+    {
+        return call_user_func_array($this->closure, func_get_args());
+    }
+}

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -707,6 +707,11 @@ class Mock implements MockInterface
         return $director;
     }
 
+    public function shouldHaveBeenCalled()
+    {
+        return $this->shouldHaveReceived("__invoke");
+    }
+
     public function shouldNotHaveReceived($method = null, $args = null)
     {
         if ($method === null) {
@@ -722,6 +727,11 @@ class Mock implements MockInterface
         $this->_mockery_expectations_count++;
         $director->verify();
         return null;
+    }
+
+    public function shouldNotHaveBeenCalled($args = null)
+    {
+        return $this->shouldNotHaveReceived("__invoke", $args);
     }
 
     protected static function _mockery_handleStaticMethodCall($method, array $args)

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -729,7 +729,7 @@ class Mock implements MockInterface
         return null;
     }
 
-    public function shouldNotHaveBeenCalled($args = null)
+    public function shouldNotHaveBeenCalled(array $args = null)
     {
         return $this->shouldNotHaveReceived("__invoke", $args);
     }

--- a/library/Mockery/MockInterface.php
+++ b/library/Mockery/MockInterface.php
@@ -91,12 +91,22 @@ interface MockInterface
     public function shouldHaveReceived($method, $args = null);
 
     /**
+     * @return mixed
+     */
+    public function shouldHaveBeenCalled();
+
+    /**
      * @param null|string $method
      * @param null $args
      * @return mixed
      */
     public function shouldNotHaveReceived($method, $args = null);
 
+    /**
+     * @param array $args (optional)
+     * @return mixed
+     */
+    public function shouldNotHaveBeenCalled(array $args = null);
 
     /**
      * In the event shouldReceive() accepting an array of methods/returns

--- a/tests/Mockery/CallableSpyTest.php
+++ b/tests/Mockery/CallableSpyTest.php
@@ -1,0 +1,199 @@
+<?php
+
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/blob/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ *
+ * @category   Mockery
+ * @package    Mockery
+ * @copyright  Copyright (c) 2017 Dave Marshall https://github.com/davedevelopment
+ * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
+ */
+
+namespace test\Mockery;
+
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Mockery\Exception\InvalidCountException;
+
+class CallableSpyTest extends MockeryTestCase
+{
+    /** @test */
+    public function it_verifies_the_closure_was_called()
+    {
+        $spy = spy(function() {});
+
+        $spy();
+
+        $spy->shouldHaveBeenCalled();
+    }
+
+    /** @test */
+    public function it_throws_if_the_callable_was_not_called_at_all()
+    {
+        $spy = spy(function() {});
+
+        $this->setExpectedException(InvalidCountException::class);
+        $spy->shouldHaveBeenCalled();
+    }
+
+    /** @test */
+    public function it_throws_if_there_were_no_arguments_but_we_expected_some()
+    {
+        $spy = spy(function() {});
+
+        $spy();
+
+        $this->setExpectedException(InvalidCountException::class);
+        $spy->shouldHaveBeenCalled()->with(123, 546);
+    }
+
+    /** @test */
+    public function it_throws_if_the_arguments_do_not_match()
+    {
+        $spy = spy(function() {});
+
+        $spy(123);
+
+        $this->setExpectedException(InvalidCountException::class);
+        $spy->shouldHaveBeenCalled()->with(123, 546);
+    }
+
+    /** @test */
+    public function it_verifies_the_closure_was_not_called()
+    {
+        $spy = spy(function () {});
+
+        $spy->shouldNotHaveBeenCalled();
+    }
+
+    /** @test */
+    public function it_throws_if_it_was_called_when_we_expected_it_to_not_have_been_called()
+    {
+        $spy = spy(function () {});
+
+        $spy();
+
+        $this->setExpectedException(InvalidCountException::class);
+        $spy->shouldNotHaveBeenCalled();
+    }
+
+    /** @test */
+    public function it_verifies_it_was_not_called_with_some_particular_arguments_when_called_with_no_args()
+    {
+        $spy = spy(function () {});
+
+        $spy();
+
+        $spy->shouldNotHaveBeenCalled([123]);
+    }
+
+    /** @test */
+    public function it_verifies_it_was_not_called_with_some_particular_arguments_when_called_with_different_args()
+    {
+        $spy = spy(function () {});
+
+        $spy(456);
+
+        $spy->shouldNotHaveBeenCalled([123]);
+    }
+
+    /** @test */
+    public function it_throws_if_it_was_called_with_the_args_we_were_not_expecting()
+    {
+        $spy = spy(function () {});
+
+        $spy(123);
+
+        $this->setExpectedException(InvalidCountException::class);
+        $spy->shouldNotHaveBeenCalled([123]);
+    }
+
+    /** @test */
+    public function it_can_verify_it_was_called_a_number_of_times()
+    {
+        $spy = spy(function () {});
+
+        $spy();
+        $spy();
+
+        $spy->shouldHaveBeenCalled()->twice();
+    }
+
+    /** @test */
+    public function it_can_verify_it_was_called_a_number_of_times_with_particular_arguments()
+    {
+        $spy = spy(function () {});
+
+        $spy(123);
+        $spy(123);
+
+        $spy->shouldHaveBeenCalled()->with(123)->twice();
+    }
+
+    /** @test */
+    public function it_throws_if_it_was_called_less_than_the_number_of_times_we_expected()
+    {
+        $spy = spy(function () {});
+
+        $spy();
+
+        $this->setExpectedException(InvalidCountException::class);
+        $spy->shouldHaveBeenCalled()->twice();
+    }
+
+    /** @test */
+    public function it_throws_if_it_was_called_less_than_the_number_of_times_we_expected_with_particular_arguments()
+    {
+        $spy = spy(function () {});
+
+        $spy();
+        $spy(123);
+
+        $this->setExpectedException(InvalidCountException::class);
+        $spy->shouldHaveBeenCalled()->with(123)->twice();
+    }
+
+    /** @test */
+    public function it_throws_if_it_was_called_more_than_the_number_of_times_we_expected()
+    {
+        $spy = spy(function () {});
+
+        $spy();
+        $spy();
+        $spy();
+
+        $this->setExpectedException(InvalidCountException::class);
+        $spy->shouldHaveBeenCalled()->twice();
+    }
+
+    /** @test */
+    public function it_throws_if_it_was_called_more_than_the_number_of_times_we_expected_with_particular_arguments()
+    {
+        $spy = spy(function () {});
+
+        $spy(123);
+        $spy(123);
+        $spy(123);
+
+        $this->setExpectedException(InvalidCountException::class);
+        $spy->shouldHaveBeenCalled()->with(123)->twice();
+    }
+
+    /** @test */
+    public function it_acts_as_partial()
+    {
+        $spy = spy(function ($number) { return $number + 1;});
+
+        $this->assertEquals(124, $spy(123));
+        $spy->shouldHaveBeenCalled();
+    }
+}


### PR DESCRIPTION
Here's a take on the request in #711

``` php
 $spy = spy(function($n) { return $n + 1;});

 array_map($spy, [1, 2]); // [2, 3]

 $spy->shouldHaveBeenCalled();
 $spy->shouldHaveBeenCalled()->twice();
 $spy->shouldHaveBeenCalled()->with(1)->once();
 $spy->shouldHaveBeenCalled()->with(2)->once();

 $spy->shouldHaveBeenCalled()->with(3); // throws...
```

# Todos/considerations

- [ ] Better error messages? Ideally we could identify that these are a special case and avoid complicating things showing the internals of `ClosureWrapper::__invoke` etc
- [ ] Make it available for mocking as well? It would mean coming up with some syntax or probably overloading `expects` and `allows` somehow. Might get too complicated.
- [ ] `shouldNotHaveBeenCalledWith(123, 456, 789)` ? I think I prefer this for specifying arguments with a `not`