### PR TITLE
Spies return `null` by default from ignored (non-mocked) methods with nullable return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * `Mockery\Matcher\MustBe` was deprecated
 * Marked `Mockery\MockInterface` as internal
 * Subset matcher matches recusively
+* BC BREAK - Spies return `null` by default from ignored (non-mocked) methods with nullable return type
  
 ## 0.9.4 (XXXX-XX-XX)
 

--- a/docs/reference/startup_methods.rst
+++ b/docs/reference/startup_methods.rst
@@ -205,6 +205,14 @@ mock object as a Passive Mock. In such a mock object, calls to methods which
 are not covered by expectations will return ``null`` instead of the usual
 complaining about there being no expectation matching the call.
 
+On PHP >= 7.0.0, methods with missing expectations that have a return type
+will return either a mock of the object (if return type is a class) or a
+"falsy" primitive value, e.g. empty string, empty array, zero for ints and
+floats, false for bools, or empty closures.
+
+On PHP >= 7.1.0, methods with missing expectations and nullable return type
+will return null.
+
 You can optionally prefer to return an object of type ``\Mockery\Undefined``
 (i.e.  a ``null`` object) (which was the 0.7.2 behaviour) by using an
 additional modifier:

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -659,7 +659,14 @@ class Mock implements MockInterface
             return;
         }
 
-        $type = (string) $rm->getReturnType();
+        $returnType = $rm->getReturnType();
+
+        // Default return value for methods with nullable type is null
+        if ($returnType->allowsNull()) {
+            return null;
+        }
+
+        $type = (string) $returnType;
         switch ($type) {
             case '':       return;
             case 'string': return '';

--- a/tests/Mockery/MockingNullableMethodsTest.php
+++ b/tests/Mockery/MockingNullableMethodsTest.php
@@ -211,4 +211,12 @@ class MockingNullableMethodsTest extends MockeryTestCase
 
         $this->assertEquals(null, $double->nullableInt());
     }
+
+    /** @test */
+    public function it_returns_null_on_calls_to_ignored_methods_of_spies_if_return_type_is_nullable()
+    {
+        $double = \Mockery::spy(MethodWithNullableReturnType::class);
+
+        $this->assertEquals(null, $double->nullableClass());
+    }
 }


### PR DESCRIPTION
- Fix + related test
- Documented BC BREAK on changelog
- Added a bit of documentation on how default return types work for mocks related to methods with return types
