### PR TITLE
[WIP] PHPUnit 6 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ matrix:
     - php: 5.6
       env:
         - DEPS=latest
+    - php: 5.6
+      env:
+        - PHPUNIT=minimum
+        - DEPS=latest
     - php: 7.0
       env:
         - DEPS=lowest
@@ -47,6 +51,7 @@ before_install:
   - alias composer=composer\ -n && composer self-update
 
 install:
+  - if [[ $PHPUNIT == 'minimum' ]]; then sed -i 's/~5.7|/5.4.*|/g' ./composer.json ; fi
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update --no-interaction ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable --no-interaction ; fi
 

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "hamcrest/hamcrest-php": "~2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7"
+        "phpunit/phpunit": "~5.7|~6.1"
     },
     "autoload": {
         "psr-0": {

--- a/library/Mockery/Exception/InvalidArgumentException.php
+++ b/library/Mockery/Exception/InvalidArgumentException.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/blob/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ *
+ * @category   Mockery
+ * @package    Mockery
+ * @copyright  Copyright (c) 2010 Pádraic Brady (http://blog.astrumfutura.com)
+ * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
+ */
+
+namespace Mockery\Exception;
+
+class InvalidArgumentException extends \InvalidArgumentException
+{
+}

--- a/library/Mockery/Matcher/PHPUnitConstraint.php
+++ b/library/Mockery/Matcher/PHPUnitConstraint.php
@@ -29,7 +29,7 @@ class PHPUnitConstraint extends MatcherAbstract
      * @param \PHPUnit_Framework_Constraint $constraint
      * @param bool $rethrow
      */
-    public function __construct(\PHPUnit_Framework_Constraint $constraint, $rethrow = false)
+    public function __construct(\PHPUnit\Framework\Constraint $constraint, $rethrow = false)
     {
         $this->constraint = $constraint;
         $this->rethrow = $rethrow;
@@ -44,7 +44,7 @@ class PHPUnitConstraint extends MatcherAbstract
         try {
             $this->constraint->evaluate($actual);
             return true;
-        } catch (\PHPUnit_Framework_AssertionFailedError $e) {
+        } catch (\PHPUnit\Framework\AssertionFailedError $e) {
             if ($this->rethrow) {
                 throw $e;
             }

--- a/library/Mockery/Matcher/PHPUnitConstraint.php
+++ b/library/Mockery/Matcher/PHPUnitConstraint.php
@@ -20,17 +20,26 @@
 
 namespace Mockery\Matcher;
 
+use Mockery\Exception\InvalidArgumentException;
+
 class PHPUnitConstraint extends MatcherAbstract
 {
     protected $constraint;
     protected $rethrow;
 
     /**
-     * @param \PHPUnit_Framework_Constraint $constraint
+     * @param \PHPUnit\Framework\Constraint $constraint
      * @param bool $rethrow
      */
-    public function __construct(\PHPUnit\Framework\Constraint $constraint, $rethrow = false)
+    public function __construct($constraint, $rethrow = false)
     {
+        if (!($constraint instanceof \PHPUnit_Framework_Constraint)
+        && !($constraint instanceof \PHPUnit\Framework\Constraint)) {
+            throw new InvalidArgumentException(
+                'Constraint must be one of \PHPUnit\Framework\Constraint or '.
+                '\PHPUnit_Framework_Constraint'
+            );
+        }
         $this->constraint = $constraint;
         $this->rethrow = $rethrow;
     }
@@ -44,12 +53,17 @@ class PHPUnitConstraint extends MatcherAbstract
         try {
             $this->constraint->evaluate($actual);
             return true;
+        } catch (\PHPUnit_Framework_AssertionFailedError $e) {
+            if ($this->rethrow) {
+                throw $e;
+            }
+            return false;
         } catch (\PHPUnit\Framework\AssertionFailedError $e) {
             if ($this->rethrow) {
                 throw $e;
             }
             return false;
-        }
+        } 
     }
 
     /**

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,6 +25,9 @@
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./library/</directory>
+            <exclude>
+                <file>./library/Mockery/Adapter/Phpunit/TestListener.php</file>
+            </exclude>
         </whitelist>
     </filter>
 </phpunit>

--- a/tests/Mockery/Adapter/Phpunit/TestListenerTest.php
+++ b/tests/Mockery/Adapter/Phpunit/TestListenerTest.php
@@ -29,7 +29,7 @@ class Mockery_Adapter_Phpunit_TestListenerTest extends TestCase
         /**
          * Skip all tests here if PHPUnit is less than 6.0.0
          */
-        if (class_exists('\PHPUnit\Runner\Version') {
+        if (class_exists('\PHPUnit\Runner\Version')) {
             $ver = \PHPUnit\Runner\Version::series();
         } else {
             $ver = \PHPUnit_Runner_Version::series();

--- a/tests/Mockery/Adapter/Phpunit/TestListenerTest.php
+++ b/tests/Mockery/Adapter/Phpunit/TestListenerTest.php
@@ -21,10 +21,18 @@
 
 use PHPUnit\Framework\TestCase;
 
+
 class Mockery_Adapter_Phpunit_TestListenerTest extends TestCase
 {
     protected function setUp()
     {
+        /**
+         * Skip all tests here if PHPUnit is less than 6.0.0
+         */
+        if (intval(\PHPUnit\Runner\Version::series()) > 5)
+        {
+            $this->markTestSkipped('The TestListener is not supported with PHPUnit 6+.');
+        }
         // We intentionally test the static container here. That is what the
         // listener will check.
         $this->container = \Mockery::getContainer();
@@ -68,7 +76,7 @@ class Mockery_Adapter_Phpunit_TestListenerTest extends TestCase
     }
 }
 
-class Mockery_Adapter_Phpunit_EmptyTestCase extends PHPUnit_Framework_TestCase
+class Mockery_Adapter_Phpunit_EmptyTestCase extends TestCase
 {
     public function getStatus()
     {

--- a/tests/Mockery/Adapter/Phpunit/TestListenerTest.php
+++ b/tests/Mockery/Adapter/Phpunit/TestListenerTest.php
@@ -19,7 +19,9 @@
  * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
  */
 
-class Mockery_Adapter_Phpunit_TestListenerTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class Mockery_Adapter_Phpunit_TestListenerTest extends TestCase
 {
     protected function setUp()
     {

--- a/tests/Mockery/Adapter/Phpunit/TestListenerTest.php
+++ b/tests/Mockery/Adapter/Phpunit/TestListenerTest.php
@@ -34,8 +34,7 @@ class Mockery_Adapter_Phpunit_TestListenerTest extends TestCase
         } else {
             $ver = \PHPUnit_Runner_Version::series();
         }
-        if (intval($ver) > 5)
-        {
+        if (intval($ver) > 5) {
             $this->markTestSkipped('The TestListener is not supported with PHPUnit 6+.');
             return;
         }

--- a/tests/Mockery/Adapter/Phpunit/TestListenerTest.php
+++ b/tests/Mockery/Adapter/Phpunit/TestListenerTest.php
@@ -29,9 +29,15 @@ class Mockery_Adapter_Phpunit_TestListenerTest extends TestCase
         /**
          * Skip all tests here if PHPUnit is less than 6.0.0
          */
-        if (intval(\PHPUnit\Runner\Version::series()) > 5)
+        if (class_exists('\PHPUnit\Runner\Version') {
+            $ver = \PHPUnit\Runner\Version::series();
+        } else {
+            $ver = \PHPUnit_Runner_Version::series();
+        }
+        if (intval($ver) > 5)
         {
             $this->markTestSkipped('The TestListener is not supported with PHPUnit 6+.');
+            return;
         }
         // We intentionally test the static container here. That is what the
         // listener will check.

--- a/tests/Mockery/AdhocTest.php
+++ b/tests/Mockery/AdhocTest.php
@@ -68,7 +68,7 @@ class Mockery_AdhocTest extends MockeryTestCase
 
     public function testInvalidCountExceptionThrowsRuntimeExceptionOnIllegalComparativeSymbol()
     {
-        $this->setExpectedException('Mockery\Exception\RuntimeException');
+        $this->expectException('Mockery\Exception\RuntimeException');
         $e = new \Mockery\Exception\InvalidCountException;
         $e->setExpectedCountComparative('X');
     }

--- a/tests/Mockery/AllowsExpectsSyntaxTest.php
+++ b/tests/Mockery/AllowsExpectsSyntaxTest.php
@@ -24,6 +24,7 @@ namespace test\Mockery;
 use Mockery as m;
 use Mockery\Spy;
 use Mockery\Exception\InvalidCountException;
+use PHPUnit\Framework\TestCase;
 
 class ClassWithAllowsMethod
 {
@@ -41,7 +42,7 @@ class ClassWithExpectsMethod
     }
 }
 
-class AllowsExpectsSyntaxTest extends \PHPUnit_Framework_TestCase
+class AllowsExpectsSyntaxTest extends TestCase
 {
     /** @test */
     public function allowsSetsUpMethodStub()
@@ -90,7 +91,7 @@ class AllowsExpectsSyntaxTest extends \PHPUnit_Framework_TestCase
         $mock = m::mock();
         $mock->expects()->foo(123);
 
-        $this->setExpectedException("Mockery\Exception\InvalidCountException");
+        $this->expectException("Mockery\Exception\InvalidCountException");
         m::close();
     }
 
@@ -101,7 +102,7 @@ class AllowsExpectsSyntaxTest extends \PHPUnit_Framework_TestCase
         $mock->expects()->foo(123)->twice();
 
         $mock->foo(123);
-        $this->setExpectedException("Mockery\Exception\InvalidCountException");
+        $this->expectException("Mockery\Exception\InvalidCountException");
         m::close();
     }
 

--- a/tests/Mockery/ContainerTest.php
+++ b/tests/Mockery/ContainerTest.php
@@ -1298,7 +1298,7 @@ class ContainerTest extends MockeryTestCase
         $mock = $this->container->mock('MyTestClass');
         $mock->shouldReceive("foo")->with(123);
 
-        $this->setExpectedException(
+        $this->expectException(
             "Mockery\Exception\NoMatchingExpectationException",
             "MyTestClass::foo(true, false, [0 => true, 1 => false])"
         );

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -246,7 +246,7 @@ class ExpectationTest extends MockeryTestCase
      */
     public function it_can_throw_a_throwable()
     {
-        $this->setExpectedException(\Error::class);
+        $this->expectException(\Error::class);
         $this->mock->shouldReceive('foo')->andThrow(new \Error());
         $this->mock->foo();
     }
@@ -2092,7 +2092,7 @@ class ExpectationTest extends MockeryTestCase
     {
         $mock = $this->container->mock('Mockery_Duck');
 
-        $this->setExpectedException(
+        $this->expectException(
             '\BadMethodCallException',
             'Method ' . get_class($mock) .
             '::nonExistent() does not exist on this mock object'
@@ -2105,7 +2105,7 @@ class ExpectationTest extends MockeryTestCase
     {
         $mock = $this->container->mock('Mockery_Duck');
 
-        $this->setExpectedException(
+        $this->expectException(
             '\BadMethodCallException',
             'Received ' . get_class($mock) .
             '::quack(), ' . 'but no expectations were specified'
@@ -2141,7 +2141,7 @@ class ExpectationTest extends MockeryTestCase
 
         $mock->expects()->foo(Mockery::hasKey('foo'));
 
-        $this->setExpectedException(
+        $this->expectException(
             InvalidCountException::class,
             "Method foo(<HasKey[foo]>)"
         );

--- a/tests/Mockery/Generator/DefinedTargetClassTest.php
+++ b/tests/Mockery/Generator/DefinedTargetClassTest.php
@@ -22,8 +22,9 @@
 namespace Mockery;
 
 use Mockery\Generator\DefinedTargetClass;
+use PHPUnit\Framework\TestCase;
 
-class DefinedTargetClassTest extends \PHPUnit_Framework_TestCase
+class DefinedTargetClassTest extends TestCase
 {
     /** @test */
     public function it_knows_if_one_of_its_ancestors_is_internal()

--- a/tests/Mockery/Generator/MockConfigurationTest.php
+++ b/tests/Mockery/Generator/MockConfigurationTest.php
@@ -21,7 +21,9 @@
 
 namespace Mockery\Generator;
 
-class MockConfigurationTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class MockConfigurationTest extends TestCase
 {
     /**
      * @test

--- a/tests/Mockery/Generator/StringManipulation/Pass/CallTypeHintPassTest.php
+++ b/tests/Mockery/Generator/StringManipulation/Pass/CallTypeHintPassTest.php
@@ -23,8 +23,9 @@ namespace Mockery\Test\Generator\StringManipulation\Pass;
 
 use Mockery as m;
 use Mockery\Generator\StringManipulation\Pass\CallTypeHintPass;
+use PHPUnit\Framework\TestCase;
 
-class CallTypeHintPassTest extends \PHPUnit_Framework_TestCase
+class CallTypeHintPassTest extends TestCase
 {
     const CODE = ' public function __call($method, array $args) {}
                    public static function __callStatic($method, array $args) {}

--- a/tests/Mockery/Generator/StringManipulation/Pass/ClassNamePassTest.php
+++ b/tests/Mockery/Generator/StringManipulation/Pass/ClassNamePassTest.php
@@ -24,8 +24,9 @@ namespace Mockery\Generator\StringManipulation\Pass;
 use Mockery as m;
 use Mockery\Generator\MockConfiguration;
 use Mockery\Generator\StringManipulation\Pass\ClassNamePass;
+use PHPUnit\Framework\TestCase;
 
-class ClassNamePassTest extends \PHPUnit_Framework_TestCase
+class ClassNamePassTest extends TestCase
 {
     const CODE = "namespace Mockery; class Mock {}";
 

--- a/tests/Mockery/Generator/StringManipulation/Pass/InstanceMockPassTest.php
+++ b/tests/Mockery/Generator/StringManipulation/Pass/InstanceMockPassTest.php
@@ -24,8 +24,9 @@ namespace Mockery\Test\Generator\StringManipulation\Pass;
 use Mockery as m;
 use Mockery\Generator\MockConfigurationBuilder;
 use Mockery\Generator\StringManipulation\Pass\InstanceMockPass;
+use PHPUnit\Framework\TestCase;
 
-class InstanceMockPassTest extends \PHPUnit_Framework_TestCase
+class InstanceMockPassTest extends TestCase
 {
     /**
      * @test

--- a/tests/Mockery/Generator/StringManipulation/Pass/InterfacePassTest.php
+++ b/tests/Mockery/Generator/StringManipulation/Pass/InterfacePassTest.php
@@ -24,8 +24,9 @@ namespace Mockery\Test\Generator\StringManipulation\Pass;
 use Mockery as m;
 use Mockery\Generator\MockConfiguration;
 use Mockery\Generator\StringManipulation\Pass\InterfacePass;
+use PHPUnit\Framework\TestCase;
 
-class InterfacePassTest extends \PHPUnit_Framework_TestCase
+class InterfacePassTest extends TestCase
 {
     const CODE = "class Mock implements MockInterface";
 

--- a/tests/Mockery/Generator/StringManipulation/Pass/MagicMethodTypeHintsPassTest.php
+++ b/tests/Mockery/Generator/StringManipulation/Pass/MagicMethodTypeHintsPassTest.php
@@ -26,8 +26,9 @@ namespace Mockery\Test\Generator\StringManipulation\Pass;
 use Mockery as m;
 use Mockery\Generator\DefinedTargetClass;
 use Mockery\Generator\StringManipulation\Pass\MagicMethodTypeHintsPass;
+use PHPUnit\Framework\TestCase;
 
-class MagicMethodTypeHintsPassTest extends \PHPUnit_Framework_TestCase
+class MagicMethodTypeHintsPassTest extends TestCase
 {
     /**
      * @var MagicMethodTypeHintsPass

--- a/tests/Mockery/GlobalHelpersTest.php
+++ b/tests/Mockery/GlobalHelpersTest.php
@@ -18,7 +18,9 @@
  * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
  */
 
-class GlobalHelpersTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class GlobalHelpersTest extends TestCase
 {
     public function setup()
     {
@@ -31,7 +33,7 @@ class GlobalHelpersTest extends PHPUnit_Framework_TestCase
         $double = mock();
 
         $this->assertInstanceOf(\Mockery\MockInterface::class, $double);
-        $this->setExpectedException(\Exception::class);
+        $this->expectException(\Exception::class);
         $double->foo();
     }
 

--- a/tests/Mockery/Loader/LoaderTestCase.php
+++ b/tests/Mockery/Loader/LoaderTestCase.php
@@ -23,8 +23,9 @@ namespace Mockery\Loader;
 
 use Mockery\Generator\MockConfiguration;
 use Mockery\Generator\MockDefinition;
+use PHPUnit\Framework\TestCase;
 
-abstract class LoaderTestCase extends \PHPUnit_Framework_TestCase
+abstract class LoaderTestCase extends TestCase
 {
     /**
      * @test

--- a/tests/Mockery/Matcher/PHPUnitConstraintTest.php
+++ b/tests/Mockery/Matcher/PHPUnitConstraintTest.php
@@ -75,11 +75,9 @@ class PHPUnitConstraintTest extends TestCase
         $this->assertTrue($this->rethrowingMatcher->match($value3));
     }
 
-    /**
-     * @expectedException \PHPUnit\Framework\AssertionFailedError
-     */
     public function testMatchesWhereNotMatchAndRethrowing()
     {
+        $this->expectException($this->assertionFailedError);
         $value = 'value';
         $this->constraint
             ->shouldReceive('evaluate')

--- a/tests/Mockery/Matcher/PHPUnitConstraintTest.php
+++ b/tests/Mockery/Matcher/PHPUnitConstraintTest.php
@@ -21,8 +21,9 @@
 
 use Mockery\MockInterface;
 use Mockery\Matcher\PHPUnitConstraint;
+use PHPUnit\Framework\TestCase;
 
-class PHPUnitConstraintTest extends \PHPUnit_Framework_TestCase
+class PHPUnitConstraintTest extends TestCase
 {
     /** @var  PHPUnitConstraint */
     protected $matcher;
@@ -33,7 +34,18 @@ class PHPUnitConstraintTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->constraint = \Mockery::mock('PHPUnit_Framework_Constraint');
+        /*
+         * Revise by PHPUnit version
+         */
+        if (class_exists('\PHPUnit\Framework\AssertionFailedError')) {
+            $this->assertionFailedError = '\PHPUnit\Framework\AssertionFailedError';
+            $this->frameworkConstraint = '\PHPUnit\Framework\Constraint';
+        } else {
+            $this->assertionFailedError = '\PHPUnit_Framework_AssertionFailedError';
+            $this->frameworkConstraint = '\PHPUnit_Framework_Constraint';
+        }
+
+        $this->constraint = \Mockery::mock($this->frameworkConstraint);
         $this->matcher = new PHPUnitConstraint($this->constraint);
         $this->rethrowingMatcher = new PHPUnitConstraint($this->constraint, true);
     }
@@ -51,7 +63,7 @@ class PHPUnitConstraintTest extends \PHPUnit_Framework_TestCase
             ->shouldReceive('evaluate')
             ->once()
             ->with($value2)
-            ->andThrow('PHPUnit_Framework_AssertionFailedError')
+            ->andThrow($this->assertionFailedError)
             ->getMock()
             ->shouldReceive('evaluate')
             ->once()
@@ -64,7 +76,7 @@ class PHPUnitConstraintTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \PHPUnit_Framework_AssertionFailedError
+     * @expectedException \PHPUnit\Framework\AssertionFailedError
      */
     public function testMatchesWhereNotMatchAndRethrowing()
     {
@@ -73,7 +85,7 @@ class PHPUnitConstraintTest extends \PHPUnit_Framework_TestCase
             ->shouldReceive('evaluate')
             ->once()
             ->with($value)
-            ->andThrow('PHPUnit_Framework_AssertionFailedError')
+            ->andThrow($this->assertionFailedError)
         ;
         $this->rethrowingMatcher->match($value);
     }

--- a/tests/Mockery/MockTest.php
+++ b/tests/Mockery/MockTest.php
@@ -152,7 +152,7 @@ class Mockery_MockTest extends MockeryTestCase
     {
         $mock = Mockery::mock();
 
-        $this->setExpectedException("InvalidArgumentException", "Received empty method name");
+        $this->expectException("InvalidArgumentException", "Received empty method name");
         $mock->shouldReceive("");
     }
 

--- a/tests/Mockery/MockeryCanMockClassesWithSemiReservedWordsTest.php
+++ b/tests/Mockery/MockeryCanMockClassesWithSemiReservedWordsTest.php
@@ -4,11 +4,12 @@ namespace Mockery;
 
 use Mockery as m;
 use Mockery\Fixtures\SemiReservedWordsAsMethods;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @requires PHP 7.0.0
  */
-class MockeryCanMockClassesWithSemiReservedWordsTest extends \PHPUnit_Framework_TestCase
+class MockeryCanMockClassesWithSemiReservedWordsTest extends TestCase
 {
     /**
      * @test

--- a/tests/Mockery/SpyTest.php
+++ b/tests/Mockery/SpyTest.php
@@ -23,8 +23,9 @@ namespace test\Mockery;
 
 use Mockery as m;
 use Mockery\Spy;
+use PHPUnit\Framework\TestCase;
 
-class SpyTest extends \PHPUnit_Framework_TestCase
+class SpyTest extends TestCase
 {
     public function setup()
     {
@@ -43,7 +44,7 @@ class SpyTest extends \PHPUnit_Framework_TestCase
         $spy->myMethod();
         $spy->shouldHaveReceived("myMethod");
 
-        $this->setExpectedException("Mockery\Exception\InvalidCountException");
+        $this->expectException("Mockery\Exception\InvalidCountException");
         $spy->shouldHaveReceived("someMethodThatWasNotCalled");
     }
 
@@ -53,7 +54,7 @@ class SpyTest extends \PHPUnit_Framework_TestCase
         $spy = m::spy();
         $spy->shouldNotHaveReceived("myMethod");
 
-        $this->setExpectedException("Mockery\Exception\InvalidCountException");
+        $this->expectException("Mockery\Exception\InvalidCountException");
         $spy->myMethod();
         $spy->shouldNotHaveReceived("myMethod");
     }
@@ -66,7 +67,7 @@ class SpyTest extends \PHPUnit_Framework_TestCase
 
         $spy->shouldNotHaveReceived("myMethod", array(789, 10));
 
-        $this->setExpectedException("Mockery\Exception\InvalidCountException");
+        $this->expectException("Mockery\Exception\InvalidCountException");
         $spy->shouldNotHaveReceived("myMethod", array(123, 456));
     }
 
@@ -78,7 +79,7 @@ class SpyTest extends \PHPUnit_Framework_TestCase
         $spy->myMethod();
         $spy->shouldHaveReceived("myMethod")->twice();
 
-        $this->setExpectedException("Mockery\Exception\InvalidCountException");
+        $this->expectException("Mockery\Exception\InvalidCountException");
         $spy->myMethod();
         $spy->shouldHaveReceived("myMethod")->twice();
     }
@@ -91,7 +92,7 @@ class SpyTest extends \PHPUnit_Framework_TestCase
         $spy->shouldHaveReceived("myMethod")->with(123, "a string");
         $spy->shouldHaveReceived("myMethod", array(123, "a string"));
 
-        $this->setExpectedException("Mockery\Exception\InvalidCountException");
+        $this->expectException("Mockery\Exception\InvalidCountException");
         $spy->shouldHaveReceived("myMethod")->with(123);
     }
 

--- a/tests/Mockery/Test/Generator/MockConfigurationBuilderTest.php
+++ b/tests/Mockery/Test/Generator/MockConfigurationBuilderTest.php
@@ -23,8 +23,9 @@ namespace Mockery\Generator;
 
 use Mockery as m;
 use Mockery\Generator\MockConfigurationBuilder;
+use PHPUnit\Framework\TestCase;
 
-class MockConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
+class MockConfigurationBuilderTest extends TestCase
 {
     /**
      * @test

--- a/tests/Mockery/WithFormatterExpectationTest.php
+++ b/tests/Mockery/WithFormatterExpectationTest.php
@@ -19,7 +19,9 @@
  * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
  */
 
-class WithFormatterExpectationTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class WithFormatterExpectationTest extends TestCase
 {
     /**
      * @dataProvider formatObjectsDataProvider


### PR DESCRIPTION
Initial run through of changes for #728. The main areas needing attention:
* PHPUnitConstraint - Incompatible between PHPUnit 5 and 6 as the referred to typehints and such are not part of the PHPUnit 5 forward compatibility shim.
* Deprecation error under PHP 7.0 (on one test where constructor shares class name).
* Numerous reports related "risky tests" under PHPUnit 6.0 though presumably that's all down to test framework in place which needs to be updated.
* The Listener is also incompatible with PHPUnit 6 (typehints again).