### PR TITLE
Don't extract getters of objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Marked `Mockery\MockInterface` as internal
 * Subset matcher matches recusively
 * BC BREAK - Spies return `null` by default from ignored (non-mocked) methods with nullable return type
+* Removed extracting getter methods of object instances
  
 ## 0.9.4 (XXXX-XX-XX)
 

--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -571,8 +571,7 @@ class Mockery
 
         return array(
             'class' => get_class($object),
-            'properties' => self::extractInstancePublicProperties($object, $nesting),
-            'getters' => self::extractGetters($object, $nesting)
+            'properties' => self::extractInstancePublicProperties($object, $nesting)
         );
     }
 
@@ -598,40 +597,6 @@ class Mockery
         }
 
         return $cleanedProperties;
-    }
-
-    /**
-     * Returns all object getters.
-     *
-     * @param $object
-     * @param $nesting
-     *
-     * @return array
-     */
-    private static function extractGetters($object, $nesting)
-    {
-        $reflection = new \ReflectionClass(get_class($object));
-        $publicMethods = $reflection->getMethods(\ReflectionMethod::IS_PUBLIC);
-        $getters = array();
-
-        foreach ($publicMethods as $publicMethod) {
-            $name = $publicMethod->getName();
-            $irrelevantName = (substr($name, 0, 3) !== 'get' && substr($name, 0, 2) !== 'is');
-            $isStatic = $publicMethod->isStatic();
-            $numberOfParameters = $publicMethod->getNumberOfParameters();
-
-            if ($irrelevantName || $numberOfParameters != 0 || $isStatic) {
-                continue;
-            }
-
-            try {
-                $getters[$name] = self::cleanupNesting($object->$name(), $nesting);
-            } catch (\Exception $e) {
-                $getters[$name] = '!! ' . get_class($e) . ': ' . $e->getMessage() . ' !!';
-            }
-        }
-
-        return $getters;
     }
 
     /**


### PR DESCRIPTION
While extracting getters for objects is a nice idea in theory,
in practice the whole idea of calling random get* and is* methods
on objects can backfire, because we can actually hide, or even worse,
accidentally cause calling methods that shouldn't be called in the
first place.

Fixes #619