### PR TITLE
Teardown Mockery on failed test cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Marked `Mockery\MockInterface` as internal
 * Subset matcher matches recusively
 * BC BREAK - Spies return `null` by default from ignored (non-mocked) methods with nullable return type
+* Fix Mockery not getting closed in cases of failing test cases
  
 ## 0.9.4 (XXXX-XX-XX)
 

--- a/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegration.php
+++ b/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegration.php
@@ -52,5 +52,25 @@ trait MockeryPHPUnitIntegration
     protected function closeMockery()
     {
         Mockery::close();
+        $this->mockeryOpen = false;
+    }
+
+    /**
+     * @before
+     */
+    protected function startMockery()
+    {
+        $this->mockeryOpen = true;
+    }
+
+    /**
+     * @after
+     */
+    protected function purgeMockeryContainer()
+    {
+        if ($this->mockeryOpen) {
+            // post conditions wasn't called, so test probably failed
+            Mockery::getContainer()->mockery_teardown();
+        }
     }
 }


### PR DESCRIPTION
PHPUnit calls assertPostConditions only on passing test cases,
which causes Mockery to not get closed on failing test cases.
This solution, originally provided by @davedevelopment uses
the @before and @after annotations to teardown the Mockery container
for the failing test cases.

Fixes #639