### PR TITLE
Add explicit pattern matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Marked `Mockery\MockInterface` as internal
 * Subset matcher matches recusively
 * BC BREAK - Spies return `null` by default from ignored (non-mocked) methods with nullable return type
+* BC BREAK - Remove implicit regex matching when trying to match string arguments, introduce `\Mockery::pattern()` when regex matching is needed
  
 ## 0.9.4 (XXXX-XX-XX)
 

--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -428,6 +428,18 @@ class Mockery
     }
 
     /**
+     * Return instance of PATTERN matcher.
+     *
+     * @param $expected
+     *
+     * @return \Mockery\Matcher\Pattern
+     */
+    public static function pattern($expected)
+    {
+        return new \Mockery\Matcher\Pattern($expected);
+    }
+
+    /**
      * Lazy loader and Getter for the global
      * configuration container.
      *

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -345,17 +345,6 @@ class Expectation implements ExpectationInterface
         if (!is_object($expected) && !is_object($actual) && $expected == $actual) {
             return true;
         }
-        if (is_string($expected) && !is_array($actual) && !is_object($actual)) {
-            # push/pop an error handler here to to make sure no error/exception thrown if $expected is not a regex
-            set_error_handler(function () {
-            });
-            $result = preg_match($expected, (string) $actual);
-            restore_error_handler();
-
-            if ($result) {
-                return true;
-            }
-        }
         if (is_string($expected) && is_object($actual)) {
             $result = $actual instanceof $expected;
             if ($result) {

--- a/library/Mockery/Matcher/Pattern.php
+++ b/library/Mockery/Matcher/Pattern.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/blob/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ *
+ * @category   Mockery
+ * @package    Mockery
+ * @copyright  Copyright (c) 2010 Pádraic Brady (http://blog.astrumfutura.com)
+ * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
+ */
+
+namespace Mockery\Matcher;
+
+class Pattern extends MatcherAbstract
+{
+    /**
+     * Check if the actual value matches the expected pattern.
+     *
+     * @param mixed $actual
+     * @return bool
+     */
+    public function match(&$actual)
+    {
+        return preg_match($this->_expected, (string) $actual) >= 1;
+    }
+
+    /**
+     * Return a string representation of this Matcher
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return '<Pattern>';
+    }
+}

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -467,12 +467,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, 'k', new stdClass);
     }
 
-    public function testExpectsArgumentMatchingRegularExpression()
-    {
-        $this->mock->shouldReceive('foo')->with('/bar/i');
-        $this->mock->foo('xxBARxx');
-    }
-
     public function testExpectsArgumentMatchingObjectType()
     {
         $this->mock->shouldReceive('foo')->with('\stdClass');
@@ -1900,6 +1894,31 @@ class ExpectationTest extends MockeryTestCase
         $this->container->mockery_verify();
     }
 
+    public function testPatternConstraintMatchesArgument()
+    {
+        $this->mock->shouldReceive('foo')->with(Mockery::pattern('/foo.*/'))->once();
+        $this->mock->foo('foobar');
+        $this->container->mockery_verify();
+    }
+
+    public function testPatternConstraintNonMatchingCase()
+    {
+        $this->mock->shouldReceive('foo')->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::pattern('/foo.*/'))->never();
+        $this->mock->foo('bar');
+        $this->container->mockery_verify();
+    }
+
+    /**
+     * @expectedException \Mockery\Exception
+     */
+    public function testPatternConstraintThrowsExceptionWhenConstraintUnmatched()
+    {
+        $this->mock->shouldReceive('foo')->with(Mockery::pattern('/foo.*/'))->once();
+        $this->mock->foo('bar');
+        $this->container->mockery_verify();
+    }
+
     /**
      * @expectedException \Mockery\Exception
      */
@@ -1936,7 +1955,7 @@ class ExpectationTest extends MockeryTestCase
         $service = $this->container->mock('MyService');
         $service->shouldReceive('login')->with('user', 'pass')->once()->andReturn(true);
         $service->shouldReceive('hasBookmarksTagged')->with('php')->once()->andReturn(false);
-        $service->shouldReceive('addBookmark')->with('/^http:/', \Mockery::type('string'))->times(3)->andReturn(true);
+        $service->shouldReceive('addBookmark')->with(Mockery::pattern('/^http:/'), \Mockery::type('string'))->times(3)->andReturn(true);
         $service->shouldReceive('hasBookmarksTagged')->with('php')->once()->andReturn(true);
 
         $this->assertTrue($service->login('user', 'pass'));
@@ -1954,7 +1973,7 @@ class ExpectationTest extends MockeryTestCase
         $service = $this->container->mock('MyService');
         $service->shouldReceive('login')->with('user', 'pass')->once()->andReturn(true);
         $service->shouldReceive('hasBookmarksTagged')->with('php')->once()->andReturn(false);
-        $service->shouldReceive('addBookmark')->with('/^http:/', \Mockery::type('string'))->times(3)->andReturn(true);
+        $service->shouldReceive('addBookmark')->with(Mockery::pattern('/^http:/'), \Mockery::type('string'))->times(3)->andReturn(true);
         $service->shouldReceive('hasBookmarksTagged')->with('php')->twice()->andReturn(true);
 
         $this->assertTrue($service->login('user', 'pass'));


### PR DESCRIPTION
Stop trying to do implicit regex matching when matching
string arguments, as it tends to not play nicely with
JSON strings as arguments - PHP thinks it's a regex pattern
to match against.

Introduce \Mockery::pattern() and the Pattern matcher to do
explicit regex pattern matching when it's required by the user.

Fixes #338