### PR TITLE
Set property values on all related mocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Removed extracting getter methods of object instances
 * BC BREAK - Remove implicit regex matching when trying to match string arguments, introduce `\Mockery::pattern()` when regex matching is needed
 * Fix Mockery not getting closed in cases of failing test cases
+* Fix Mockery not setting properties on overloaded instance mocks
 
  
 ## 0.9.4 (XXXX-XX-XX)

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -214,10 +214,17 @@ class Expectation implements ExpectationInterface
      */
     protected function _setValues()
     {
+        $mockClass = get_class($this->_mock);
+        $container = $this->_mock->mockery_getContainer();
+        $mocks = $container->getMocks();
         foreach ($this->_setQueue as $name => &$values) {
             if (count($values) > 0) {
                 $value = array_shift($values);
-                $this->_mock->{$name} = $value;
+                foreach ($mocks as $mock) {
+                    if (is_a($mock, $mockClass)) {
+                        $mock->{$name} = $value;
+                    }
+                }
             }
         }
     }

--- a/tests/Mockery/ContainerTest.php
+++ b/tests/Mockery/ContainerTest.php
@@ -753,6 +753,21 @@ class ContainerTest extends MockeryTestCase
         Mockery::resetContainer();
     }
 
+    /**
+     * @group issue/451
+     */
+    public function testSettingPropertyOnInstanceMockWillSetItOnActualInstance()
+    {
+        Mockery::setContainer($this->container);
+        $m = $this->container->mock('overload:MyNamespace\MyClass13');
+        $m->shouldReceive('foo')->andSet('bar', 'baz');
+        $instance = new MyNamespace\MyClass13;
+        $instance->foo();
+        $this->assertEquals('baz', $m->bar);
+        $this->assertEquals('baz', $instance->bar);
+        Mockery::resetContainer();
+    }
+
     public function testMethodParamsPassedByReferenceHaveReferencePreserved()
     {
         $m = $this->container->mock('MockeryTestRef1');


### PR DESCRIPTION
When setting values for properties, don't set them just on
the current mock, but set them on all the related mocks that
are in the container.

This way the overloaded instance mocks will get the properties
set, just as the mock itself.

Fixes #451