### PR TITLE
Fixes all risky tests

### DIFF
--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -159,9 +159,11 @@ class Mockery
             return;
         }
 
-        self::$_container->mockery_teardown();
-        self::$_container->mockery_close();
+        $container = self::$_container;
         self::$_container = null;
+
+        $container->mockery_teardown();
+        $container->mockery_close();
     }
 
     /**

--- a/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegration.php
+++ b/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegration.php
@@ -70,7 +70,7 @@ trait MockeryPHPUnitIntegration
     {
         if ($this->mockeryOpen) {
             // post conditions wasn't called, so test probably failed
-            Mockery::getContainer()->mockery_teardown();
+            Mockery::close();
         }
     }
 }

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -21,19 +21,20 @@
 
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\Exception\InvalidCountException;
+use Mockery\MockInterface;
 
 class ExpectationTest extends MockeryTestCase
 {
     public function setup()
     {
-        $this->container = new \Mockery\Container(\Mockery::getDefaultGenerator(), \Mockery::getDefaultLoader());
-        $this->mock = $this->container->mock('foo');
+        parent::setUp();
+        $this->mock = mock();
     }
 
     public function teardown()
     {
+        parent::tearDown();
         \Mockery::getConfiguration()->allowMockingNonExistentMethods(true);
-        $this->container->mockery_close();
     }
 
     public function testReturnsNullWhenNoArgs()
@@ -62,14 +63,14 @@ class ExpectationTest extends MockeryTestCase
 
     public function testReturnsNullForMockedExistingClassIfAndreturnnullCalled()
     {
-        $mock = $this->container->mock('MockeryTest_Foo');
+        $mock = mock('MockeryTest_Foo');
         $mock->shouldReceive('foo')->andReturn(null);
         $this->assertNull($mock->foo());
     }
 
     public function testReturnsNullForMockedExistingClassIfNullIsReturnValue()
     {
-        $mock = $this->container->mock('MockeryTest_Foo');
+        $mock = mock('MockeryTest_Foo');
         $mock->shouldReceive('foo')->andReturnNull();
         $this->assertNull($mock->foo());
     }
@@ -238,6 +239,7 @@ class ExpectationTest extends MockeryTestCase
     {
         $this->mock->shouldReceive('foo')->andThrow(new OutOfBoundsException);
         $this->mock->foo();
+        Mockery::close();
     }
 
     /**
@@ -258,6 +260,7 @@ class ExpectationTest extends MockeryTestCase
     {
         $this->mock->shouldReceive('foo')->andThrow('OutOfBoundsException');
         $this->mock->foo();
+        Mockery::close();
     }
 
     public function testThrowsExceptionBasedOnArgsWithMessage()
@@ -281,6 +284,7 @@ class ExpectationTest extends MockeryTestCase
         } catch (Exception $e) {
         }
         $this->mock->foo();
+        Mockery::close();
     }
 
     public function testAndThrowExceptions()
@@ -314,6 +318,7 @@ class ExpectationTest extends MockeryTestCase
         $this->mock
             ->shouldReceive('foo')
             ->andThrowExceptions(array('NotAnException'));
+        Mockery::close();
     }
 
     public function testMultipleExpectationsWithReturns()
@@ -337,6 +342,7 @@ class ExpectationTest extends MockeryTestCase
     {
         $this->mock->shouldReceive('foo')->withNoArgs();
         $this->mock->foo(1);
+        Mockery::close();
     }
 
     public function testExpectsArgumentsArray()
@@ -352,6 +358,7 @@ class ExpectationTest extends MockeryTestCase
     {
         $this->mock->shouldReceive('foo')->withArgs(array());
         $this->mock->foo(1, 2);
+        Mockery::close();
     }
 
     /**
@@ -361,6 +368,7 @@ class ExpectationTest extends MockeryTestCase
     {
         $this->mock->shouldReceive('foo')->with();
         $this->mock->foo(1);
+        Mockery::close();
     }
 
     /**
@@ -370,6 +378,7 @@ class ExpectationTest extends MockeryTestCase
     {
         $this->mock->shouldReceive('foo')->withArgs(array(1, 2));
         $this->mock->foo(3, 4);
+        Mockery::close();
     }
 
     /**
@@ -380,6 +389,7 @@ class ExpectationTest extends MockeryTestCase
     {
         $this->mock->shouldReceive('foo')->withArgs(array('a string'));
         $this->mock->foo(null);
+        Mockery::close();
     }
 
     /**
@@ -389,6 +399,7 @@ class ExpectationTest extends MockeryTestCase
     public function testExpectsArgumentsArrayThrowsExceptionIfPassedWrongArgumentType()
     {
         $this->mock->shouldReceive('foo')->withArgs(5);
+        Mockery::close();
     }
 
     public function testExpectsArgumentsArrayAcceptAClosureThatValidatesPassedArguments()
@@ -398,7 +409,6 @@ class ExpectationTest extends MockeryTestCase
         };
         $this->mock->shouldReceive('foo')->withArgs($closure);
         $this->mock->foo(1, 2);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -411,7 +421,7 @@ class ExpectationTest extends MockeryTestCase
         };
         $this->mock->shouldReceive('foo')->withArgs($closure);
         $this->mock->foo(4, 2);
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testExpectsArgumentsArrayClosureDoesNotThrowExceptionIfOptionalArgumentsAreMissing()
@@ -425,7 +435,6 @@ class ExpectationTest extends MockeryTestCase
         };
         $this->mock->shouldReceive('foo')->withArgs($closure);
         $this->mock->foo(1, 4);
-        $this->container->mockery_verify();
     }
 
     public function testExpectsArgumentsArrayClosureDoesNotThrowExceptionIfOptionalArgumentsMathTheExpectation()
@@ -439,7 +448,6 @@ class ExpectationTest extends MockeryTestCase
         };
         $this->mock->shouldReceive('foo')->withArgs($closure);
         $this->mock->foo(1, 4, 5);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -456,7 +464,7 @@ class ExpectationTest extends MockeryTestCase
         };
         $this->mock->shouldReceive('foo')->withArgs($closure);
         $this->mock->foo(1, 4, 2);
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testExpectsAnyArguments()
@@ -480,18 +488,17 @@ class ExpectationTest extends MockeryTestCase
     {
         $this->mock->shouldReceive('foo')->with(1);
         $this->mock->foo(2);
+        Mockery::close();
     }
 
     public function testNeverCalled()
     {
         $this->mock->shouldReceive('foo')->never();
-        $this->container->mockery_verify();
     }
 
     public function testShouldNotReceive()
     {
         $this->mock->shouldNotReceive('foo');
-        $this->container->mockery_verify();
     }
 
     /**
@@ -501,7 +508,7 @@ class ExpectationTest extends MockeryTestCase
     {
         $this->mock->shouldNotReceive('foo');
         $this->mock->foo();
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     /**
@@ -511,7 +518,7 @@ class ExpectationTest extends MockeryTestCase
     {
         $this->mock->shouldNotReceive('foo')->with(2);
         $this->mock->foo(2);
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     /**
@@ -521,14 +528,13 @@ class ExpectationTest extends MockeryTestCase
     {
         $this->mock->shouldReceive('foo')->never();
         $this->mock->foo();
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testCalledOnce()
     {
         $this->mock->shouldReceive('foo')->once();
         $this->mock->foo();
-        $this->container->mockery_verify();
     }
 
     /**
@@ -537,7 +543,7 @@ class ExpectationTest extends MockeryTestCase
     public function testCalledOnceThrowsExceptionIfNotCalled()
     {
         $this->mock->shouldReceive('foo')->once();
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     /**
@@ -548,7 +554,7 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->shouldReceive('foo')->once();
         $this->mock->foo();
         $this->mock->foo();
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testCalledTwice()
@@ -556,7 +562,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->shouldReceive('foo')->twice();
         $this->mock->foo();
         $this->mock->foo();
-        $this->container->mockery_verify();
     }
 
     /**
@@ -565,7 +570,7 @@ class ExpectationTest extends MockeryTestCase
     public function testCalledTwiceThrowsExceptionIfNotCalled()
     {
         $this->mock->shouldReceive('foo')->twice();
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     /**
@@ -577,13 +582,12 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo();
         $this->mock->foo();
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testCalledZeroOrMoreTimesAtZeroCalls()
     {
         $this->mock->shouldReceive('foo')->zeroOrMoreTimes();
-        $this->container->mockery_verify();
     }
 
     public function testCalledZeroOrMoreTimesAtThreeCalls()
@@ -592,7 +596,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo();
         $this->mock->foo();
-        $this->container->mockery_verify();
     }
 
     public function testTimesCountCalls()
@@ -602,7 +605,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo();
         $this->mock->foo();
-        $this->container->mockery_verify();
     }
 
     /**
@@ -612,7 +614,7 @@ class ExpectationTest extends MockeryTestCase
     {
         $this->mock->shouldReceive('foo')->times(2);
         $this->mock->foo();
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     /**
@@ -624,14 +626,13 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo();
         $this->mock->foo();
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testCalledAtLeastOnceAtExactlyOneCall()
     {
         $this->mock->shouldReceive('foo')->atLeast()->once();
         $this->mock->foo();
-        $this->container->mockery_verify();
     }
 
     public function testCalledAtLeastOnceAtExactlyThreeCalls()
@@ -640,7 +641,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo();
         $this->mock->foo();
-        $this->container->mockery_verify();
     }
 
     /**
@@ -650,14 +650,13 @@ class ExpectationTest extends MockeryTestCase
     {
         $this->mock->shouldReceive('foo')->atLeast()->twice();
         $this->mock->foo();
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testCalledAtMostOnceAtExactlyOneCall()
     {
         $this->mock->shouldReceive('foo')->atMost()->once();
         $this->mock->foo();
-        $this->container->mockery_verify();
     }
 
     public function testCalledAtMostAtExactlyThreeCalls()
@@ -666,7 +665,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo();
         $this->mock->foo();
-        $this->container->mockery_verify();
     }
 
     /**
@@ -678,7 +676,7 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo();
         $this->mock->foo();
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     /**
@@ -689,14 +687,13 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->shouldReceive('foo')->atLeast()->once()->once();
         $this->mock->foo();
         $this->mock->foo();
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testComboOfLeastAndMostCallsWithOneCall()
     {
         $this->mock->shouldReceive('foo')->atleast()->once()->atMost()->twice();
         $this->mock->foo();
-        $this->container->mockery_verify();
     }
 
     public function testComboOfLeastAndMostCallsWithTwoCalls()
@@ -704,7 +701,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->shouldReceive('foo')->atleast()->once()->atMost()->twice();
         $this->mock->foo();
         $this->mock->foo();
-        $this->container->mockery_verify();
     }
 
     /**
@@ -713,7 +709,7 @@ class ExpectationTest extends MockeryTestCase
     public function testComboOfLeastAndMostCallsThrowsExceptionAtTooFewCalls()
     {
         $this->mock->shouldReceive('foo')->atleast()->once()->atMost()->twice();
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     /**
@@ -725,7 +721,7 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo();
         $this->mock->foo();
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testCallCountingOnlyAppliesToMatchedExpectations()
@@ -737,7 +733,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(2);
         $this->mock->foo(2);
         $this->mock->foo(3);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -753,7 +748,7 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(2);
         $this->mock->foo(3);
         $this->mock->bar();
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     /**
@@ -772,7 +767,7 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1);
         $this->mock->foo(1);
         $this->mock->foo(1);
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testOrderedCallsWithoutError()
@@ -781,7 +776,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->shouldReceive('bar')->ordered();
         $this->mock->foo();
         $this->mock->bar();
-        $this->container->mockery_verify();
     }
 
     /**
@@ -793,7 +787,7 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->shouldReceive('bar')->ordered();
         $this->mock->bar();
         $this->mock->foo();
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testDifferentArgumentsAndOrderingsPassWithoutException()
@@ -802,7 +796,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->shouldReceive('foo')->with(2)->ordered();
         $this->mock->foo(1);
         $this->mock->foo(2);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -814,7 +807,7 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->shouldReceive('foo')->with(2)->ordered();
         $this->mock->foo(2);
         $this->mock->foo(1);
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testUnorderedCallsIgnoredForOrdering()
@@ -827,7 +820,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(2);
         $this->mock->foo(3);
         $this->mock->foo(2);
-        $this->container->mockery_verify();
     }
 
     public function testOrderingOfDefaultGrouping()
@@ -836,7 +828,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->shouldReceive('bar')->ordered();
         $this->mock->foo();
         $this->mock->bar();
-        $this->container->mockery_verify();
     }
 
     /**
@@ -848,7 +839,7 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->shouldReceive('bar')->ordered();
         $this->mock->bar();
         $this->mock->foo();
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testOrderingUsingNumberedGroups()
@@ -862,7 +853,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->bar();
         $this->mock->final();
-        $this->container->mockery_verify();
     }
 
     public function testOrderingUsingNamedGroups()
@@ -876,7 +866,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->bar();
         $this->mock->final();
-        $this->container->mockery_verify();
     }
 
     /**
@@ -900,7 +889,7 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->shouldReceive('bar')->ordered('second');
         $this->mock->bar();
         $this->mock->foo();
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testExpectationMatchingWithNoArgsOrderings()
@@ -911,7 +900,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->bar();
         $this->mock->foo();
-        $this->container->mockery_verify();
     }
 
     public function testExpectationMatchingWithAnyArgsOrderings()
@@ -922,13 +910,12 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->bar();
         $this->mock->foo();
-        $this->container->mockery_verify();
     }
 
     public function testEnsuresOrderingIsNotCrossMockByDefault()
     {
         $this->mock->shouldReceive('foo')->ordered();
-        $mock2 = $this->container->mock('bar');
+        $mock2 = mock('bar');
         $mock2->shouldReceive('bar')->ordered();
         $mock2->bar();
         $this->mock->foo();
@@ -940,10 +927,11 @@ class ExpectationTest extends MockeryTestCase
     public function testEnsuresOrderingIsCrossMockWhenGloballyFlagSet()
     {
         $this->mock->shouldReceive('foo')->globally()->ordered();
-        $mock2 = $this->container->mock('bar');
+        $mock2 = mock('bar');
         $mock2->shouldReceive('bar')->globally()->ordered();
         $mock2->bar();
         $this->mock->foo();
+        Mockery::close();
     }
 
     public function testExpectationCastToStringFormatting()
@@ -975,14 +963,12 @@ class ExpectationTest extends MockeryTestCase
         $this->assertEquals('infinity', $this->mock->foo(2));
         $this->assertEquals('infinity', $this->mock->foo(2));
         $this->assertEquals('infinity', $this->mock->foo(2));
-        $this->container->mockery_verify();
     }
 
     public function testExpectationsCanBeMarkedAsDefaults()
     {
         $this->mock->shouldReceive('foo')->andReturn('bar')->byDefault();
         $this->assertEquals('bar', $this->mock->foo());
-        $this->container->mockery_verify();
     }
 
     public function testDefaultExpectationsValidatedInCorrectOrder()
@@ -991,7 +977,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->shouldReceive('foo')->with(2)->once()->andReturn('second')->byDefault();
         $this->assertEquals('first', $this->mock->foo(1));
         $this->assertEquals('second', $this->mock->foo(2));
-        $this->container->mockery_verify();
     }
 
     public function testDefaultExpectationsAreReplacedByLaterConcreteExpectations()
@@ -1000,7 +985,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->shouldReceive('foo')->andReturn('baz')->twice();
         $this->assertEquals('baz', $this->mock->foo());
         $this->assertEquals('baz', $this->mock->foo());
-        $this->container->mockery_verify();
     }
 
     public function testExpectationFallsBackToDefaultExpectationWhenConcreteExpectationsAreUsedUp()
@@ -1009,7 +993,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->shouldReceive('foo')->with(2)->andReturn('baz')->once();
         $this->assertEquals('baz', $this->mock->foo(2));
         $this->assertEquals('bar', $this->mock->foo(1));
-        $this->container->mockery_verify();
     }
 
     /**
@@ -1021,7 +1004,7 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->shouldReceive('bar')->ordered()->byDefault();
         $this->mock->bar();
         $this->mock->foo();
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testDefaultExpectationsCanBeOrderedAndReplaced()
@@ -1032,7 +1015,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->shouldReceive('foo')->ordered();
         $this->mock->bar();
         $this->mock->foo();
-        $this->container->mockery_verify();
     }
 
     public function testByDefaultOperatesFromMockConstruction()
@@ -1043,13 +1025,11 @@ class ExpectationTest extends MockeryTestCase
         $this->assertEquals('foobar', $mock->foo());
         $this->assertEquals('rbar', $mock->bar());
         $this->assertEquals('rbaz', $mock->baz());
-        $mock->mockery_verify();
     }
 
     public function testByDefaultOnAMockDoesSquatWithoutExpectations()
     {
-        $container = new \Mockery\Container(\Mockery::getDefaultGenerator(), \Mockery::getDefaultLoader());
-        $mock = $container->mock('f')->byDefault();
+        $this->assertInstanceOf(MockInterface::class, mock('f')->byDefault());
     }
 
     public function testDefaultExpectationsCanBeOverridden()
@@ -1068,6 +1048,7 @@ class ExpectationTest extends MockeryTestCase
         $exp = $this->mock->shouldReceive('foo')->andReturn(1);
         $this->mock->shouldReceive('foo')->andReturn(2);
         $exp->byDefault();
+        Mockery::close();
     }
 
     /**
@@ -1079,7 +1060,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->shouldReceive('foo')->with(1, Mockery::any())->twice();
         $this->mock->foo(1, 2);
         $this->mock->foo(1, 'str');
-        $this->container->mockery_verify();
     }
 
     public function testAnyConstraintNonMatchingCase()
@@ -1089,14 +1069,12 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo(1);
         $this->mock->foo(1, 2, 3);
-        $this->container->mockery_verify();
     }
 
     public function testArrayConstraintMatchesArgument()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::type('array'))->once();
         $this->mock->foo(array());
-        $this->container->mockery_verify();
     }
 
     public function testArrayConstraintNonMatchingCase()
@@ -1106,7 +1084,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo(1);
         $this->mock->foo(1, 2, 3);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -1114,16 +1091,15 @@ class ExpectationTest extends MockeryTestCase
      */
     public function testArrayConstraintThrowsExceptionWhenConstraintUnmatched()
     {
-        $this->mock->shouldReceive('foo')->with(Mockery::type('array'))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::type('array'));
         $this->mock->foo(1);
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testBoolConstraintMatchesArgument()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::type('bool'))->once();
         $this->mock->foo(true);
-        $this->container->mockery_verify();
     }
 
     public function testBoolConstraintNonMatchingCase()
@@ -1133,7 +1109,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo(1);
         $this->mock->foo(1, 2, 3);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -1141,9 +1116,9 @@ class ExpectationTest extends MockeryTestCase
      */
     public function testBoolConstraintThrowsExceptionWhenConstraintUnmatched()
     {
-        $this->mock->shouldReceive('foo')->with(Mockery::type('bool'))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::type('bool'));
         $this->mock->foo(1);
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testCallableConstraintMatchesArgument()
@@ -1152,7 +1127,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(function () {
             return 'f';
         });
-        $this->container->mockery_verify();
     }
 
     public function testCallableConstraintNonMatchingCase()
@@ -1162,7 +1136,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo(1);
         $this->mock->foo(1, 2, 3);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -1170,16 +1143,15 @@ class ExpectationTest extends MockeryTestCase
      */
     public function testCallableConstraintThrowsExceptionWhenConstraintUnmatched()
     {
-        $this->mock->shouldReceive('foo')->with(Mockery::type('callable'))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::type('callable'));
         $this->mock->foo(1);
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testDoubleConstraintMatchesArgument()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::type('double'))->once();
         $this->mock->foo(2.25);
-        $this->container->mockery_verify();
     }
 
     public function testDoubleConstraintNonMatchingCase()
@@ -1189,7 +1161,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo(1);
         $this->mock->foo(1, 2, 3);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -1197,16 +1168,15 @@ class ExpectationTest extends MockeryTestCase
      */
     public function testDoubleConstraintThrowsExceptionWhenConstraintUnmatched()
     {
-        $this->mock->shouldReceive('foo')->with(Mockery::type('double'))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::type('double'));
         $this->mock->foo(1);
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testFloatConstraintMatchesArgument()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::type('float'))->once();
         $this->mock->foo(2.25);
-        $this->container->mockery_verify();
     }
 
     public function testFloatConstraintNonMatchingCase()
@@ -1216,7 +1186,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo(1);
         $this->mock->foo(1, 2, 3);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -1224,16 +1193,15 @@ class ExpectationTest extends MockeryTestCase
      */
     public function testFloatConstraintThrowsExceptionWhenConstraintUnmatched()
     {
-        $this->mock->shouldReceive('foo')->with(Mockery::type('float'))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::type('float'));
         $this->mock->foo(1);
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testIntConstraintMatchesArgument()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::type('int'))->once();
         $this->mock->foo(2);
-        $this->container->mockery_verify();
     }
 
     public function testIntConstraintNonMatchingCase()
@@ -1243,7 +1211,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo(1);
         $this->mock->foo(1, 2, 3);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -1251,16 +1218,15 @@ class ExpectationTest extends MockeryTestCase
      */
     public function testIntConstraintThrowsExceptionWhenConstraintUnmatched()
     {
-        $this->mock->shouldReceive('foo')->with(Mockery::type('int'))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::type('int'));
         $this->mock->foo('f');
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testLongConstraintMatchesArgument()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::type('long'))->once();
         $this->mock->foo(2);
-        $this->container->mockery_verify();
     }
 
     public function testLongConstraintNonMatchingCase()
@@ -1270,7 +1236,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo(1);
         $this->mock->foo(1, 2, 3);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -1278,16 +1243,15 @@ class ExpectationTest extends MockeryTestCase
      */
     public function testLongConstraintThrowsExceptionWhenConstraintUnmatched()
     {
-        $this->mock->shouldReceive('foo')->with(Mockery::type('long'))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::type('long'));
         $this->mock->foo('f');
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testNullConstraintMatchesArgument()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::type('null'))->once();
         $this->mock->foo(null);
-        $this->container->mockery_verify();
     }
 
     public function testNullConstraintNonMatchingCase()
@@ -1297,7 +1261,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo(1);
         $this->mock->foo(1, 2, 3);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -1305,16 +1268,15 @@ class ExpectationTest extends MockeryTestCase
      */
     public function testNullConstraintThrowsExceptionWhenConstraintUnmatched()
     {
-        $this->mock->shouldReceive('foo')->with(Mockery::type('null'))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::type('null'));
         $this->mock->foo('f');
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testNumericConstraintMatchesArgument()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::type('numeric'))->once();
         $this->mock->foo('2');
-        $this->container->mockery_verify();
     }
 
     public function testNumericConstraintNonMatchingCase()
@@ -1324,7 +1286,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo(1);
         $this->mock->foo(1, 2, 3);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -1332,16 +1293,15 @@ class ExpectationTest extends MockeryTestCase
      */
     public function testNumericConstraintThrowsExceptionWhenConstraintUnmatched()
     {
-        $this->mock->shouldReceive('foo')->with(Mockery::type('numeric'))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::type('numeric'));
         $this->mock->foo('f');
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testObjectConstraintMatchesArgument()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::type('object'))->once();
         $this->mock->foo(new stdClass);
-        $this->container->mockery_verify();
     }
 
     public function testObjectConstraintNonMatchingCase()
@@ -1351,7 +1311,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo(1);
         $this->mock->foo(1, 2, 3);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -1359,16 +1318,15 @@ class ExpectationTest extends MockeryTestCase
      */
     public function testObjectConstraintThrowsExceptionWhenConstraintUnmatched()
     {
-        $this->mock->shouldReceive('foo')->with(Mockery::type('object'))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::type('object'));
         $this->mock->foo('f');
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testRealConstraintMatchesArgument()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::type('real'))->once();
         $this->mock->foo(2.25);
-        $this->container->mockery_verify();
     }
 
     public function testRealConstraintNonMatchingCase()
@@ -1378,7 +1336,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo(1);
         $this->mock->foo(1, 2, 3);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -1386,9 +1343,9 @@ class ExpectationTest extends MockeryTestCase
      */
     public function testRealConstraintThrowsExceptionWhenConstraintUnmatched()
     {
-        $this->mock->shouldReceive('foo')->with(Mockery::type('real'))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::type('real'));
         $this->mock->foo('f');
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testResourceConstraintMatchesArgument()
@@ -1396,7 +1353,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->shouldReceive('foo')->with(Mockery::type('resource'))->once();
         $r = fopen(dirname(__FILE__) . '/_files/file.txt', 'r');
         $this->mock->foo($r);
-        $this->container->mockery_verify();
     }
 
     public function testResourceConstraintNonMatchingCase()
@@ -1406,7 +1362,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo(1);
         $this->mock->foo(1, 2, 3);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -1414,16 +1369,15 @@ class ExpectationTest extends MockeryTestCase
      */
     public function testResourceConstraintThrowsExceptionWhenConstraintUnmatched()
     {
-        $this->mock->shouldReceive('foo')->with(Mockery::type('resource'))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::type('resource'));
         $this->mock->foo('f');
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testScalarConstraintMatchesArgument()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::type('scalar'))->once();
         $this->mock->foo(2);
-        $this->container->mockery_verify();
     }
 
     public function testScalarConstraintNonMatchingCase()
@@ -1433,7 +1387,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo(1);
         $this->mock->foo(1, 2, 3);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -1441,16 +1394,15 @@ class ExpectationTest extends MockeryTestCase
      */
     public function testScalarConstraintThrowsExceptionWhenConstraintUnmatched()
     {
-        $this->mock->shouldReceive('foo')->with(Mockery::type('scalar'))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::type('scalar'));
         $this->mock->foo(array());
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testStringConstraintMatchesArgument()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::type('string'))->once();
         $this->mock->foo('2');
-        $this->container->mockery_verify();
     }
 
     public function testStringConstraintNonMatchingCase()
@@ -1460,7 +1412,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo(1);
         $this->mock->foo(1, 2, 3);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -1468,16 +1419,15 @@ class ExpectationTest extends MockeryTestCase
      */
     public function testStringConstraintThrowsExceptionWhenConstraintUnmatched()
     {
-        $this->mock->shouldReceive('foo')->with(Mockery::type('string'))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::type('string'));
         $this->mock->foo(1);
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testClassConstraintMatchesArgument()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::type('stdClass'))->once();
         $this->mock->foo(new stdClass);
-        $this->container->mockery_verify();
     }
 
     public function testClassConstraintNonMatchingCase()
@@ -1487,7 +1437,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo(1);
         $this->mock->foo(1, 2, 3);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -1495,16 +1444,15 @@ class ExpectationTest extends MockeryTestCase
      */
     public function testClassConstraintThrowsExceptionWhenConstraintUnmatched()
     {
-        $this->mock->shouldReceive('foo')->with(Mockery::type('stdClass'))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::type('stdClass'));
         $this->mock->foo(new Exception);
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testDucktypeConstraintMatchesArgument()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::ducktype('quack', 'swim'))->once();
         $this->mock->foo(new Mockery_Duck);
-        $this->container->mockery_verify();
     }
 
     public function testDucktypeConstraintNonMatchingCase()
@@ -1514,7 +1462,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo(1);
         $this->mock->foo(1, 2, 3);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -1522,16 +1469,15 @@ class ExpectationTest extends MockeryTestCase
      */
     public function testDucktypeConstraintThrowsExceptionWhenConstraintUnmatched()
     {
-        $this->mock->shouldReceive('foo')->with(Mockery::ducktype('quack', 'swim'))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::ducktype('quack', 'swim'));
         $this->mock->foo(new Mockery_Duck_Nonswimmer);
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testArrayContentConstraintMatchesArgument()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::subset(array('a'=>1, 'b'=>2)))->once();
         $this->mock->foo(array('a'=>1, 'b'=>2, 'c'=>3));
-        $this->container->mockery_verify();
     }
 
     public function testArrayContentConstraintNonMatchingCase()
@@ -1541,7 +1487,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo(1);
         $this->mock->foo(1, 2, 3);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -1549,16 +1494,15 @@ class ExpectationTest extends MockeryTestCase
      */
     public function testArrayContentConstraintThrowsExceptionWhenConstraintUnmatched()
     {
-        $this->mock->shouldReceive('foo')->with(Mockery::subset(array('a'=>1, 'b'=>2)))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::subset(array('a'=>1, 'b'=>2)));
         $this->mock->foo(array('a'=>1, 'c'=>3));
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testContainsConstraintMatchesArgument()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::contains(1, 2))->once();
         $this->mock->foo(array('a'=>1, 'b'=>2, 'c'=>3));
-        $this->container->mockery_verify();
     }
 
     public function testContainsConstraintNonMatchingCase()
@@ -1568,7 +1512,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo(1);
         $this->mock->foo(1, 2, 3);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -1576,16 +1519,15 @@ class ExpectationTest extends MockeryTestCase
      */
     public function testContainsConstraintThrowsExceptionWhenConstraintUnmatched()
     {
-        $this->mock->shouldReceive('foo')->with(Mockery::contains(1, 2))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::contains(1, 2));
         $this->mock->foo(array('a'=>1, 'c'=>3));
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testHasKeyConstraintMatchesArgument()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::hasKey('c'))->once();
         $this->mock->foo(array('a'=>1, 'b'=>2, 'c'=>3));
-        $this->container->mockery_verify();
     }
 
     public function testHasKeyConstraintNonMatchingCase()
@@ -1595,7 +1537,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo(1);
         $this->mock->foo(1, array('a'=>1), 3);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -1603,16 +1544,15 @@ class ExpectationTest extends MockeryTestCase
      */
     public function testHasKeyConstraintThrowsExceptionWhenConstraintUnmatched()
     {
-        $this->mock->shouldReceive('foo')->with(Mockery::hasKey('c'))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::hasKey('c'));
         $this->mock->foo(array('a'=>1, 'b'=>3));
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testHasValueConstraintMatchesArgument()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::hasValue(1))->once();
         $this->mock->foo(array('a'=>1, 'b'=>2, 'c'=>3));
-        $this->container->mockery_verify();
     }
 
     public function testHasValueConstraintNonMatchingCase()
@@ -1622,7 +1562,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo(1);
         $this->mock->foo(1, array('a'=>1), 3);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -1630,9 +1569,9 @@ class ExpectationTest extends MockeryTestCase
      */
     public function testHasValueConstraintThrowsExceptionWhenConstraintUnmatched()
     {
-        $this->mock->shouldReceive('foo')->with(Mockery::hasValue(2))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::hasValue(2));
         $this->mock->foo(array('a'=>1, 'b'=>3));
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testOnConstraintMatchesArgument_ClosureEvaluatesToTrue()
@@ -1642,7 +1581,6 @@ class ExpectationTest extends MockeryTestCase
         };
         $this->mock->shouldReceive('foo')->with(Mockery::on($function))->once();
         $this->mock->foo(4);
-        $this->container->mockery_verify();
     }
 
     public function testOnConstraintMatchesArgumentOfTypeArray_ClosureEvaluatesToTrue()
@@ -1652,7 +1590,6 @@ class ExpectationTest extends MockeryTestCase
         };
         $this->mock->shouldReceive('foo')->with(Mockery::on($function))->once();
         $this->mock->foo([4, 5]);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -1663,16 +1600,15 @@ class ExpectationTest extends MockeryTestCase
         $function = function ($arg) {
             return $arg % 2 == 0;
         };
-        $this->mock->shouldReceive('foo')->with(Mockery::on($function))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::on($function));
         $this->mock->foo(5);
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testMustBeConstraintMatchesArgument()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::mustBe(2))->once();
         $this->mock->foo(2);
-        $this->container->mockery_verify();
     }
 
     public function testMustBeConstraintNonMatchingCase()
@@ -1682,7 +1618,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo(1);
         $this->mock->foo(1, 2, 3);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -1690,9 +1625,9 @@ class ExpectationTest extends MockeryTestCase
      */
     public function testMustBeConstraintThrowsExceptionWhenConstraintUnmatched()
     {
-        $this->mock->shouldReceive('foo')->with(Mockery::mustBe(2))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::mustBe(2));
         $this->mock->foo('2');
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testMustBeConstraintMatchesObjectArgumentWithEqualsComparisonNotIdentical()
@@ -1703,7 +1638,6 @@ class ExpectationTest extends MockeryTestCase
         $b->foo = 1;
         $this->mock->shouldReceive('foo')->with(Mockery::mustBe($a))->once();
         $this->mock->foo($b);
-        $this->container->mockery_verify();
     }
 
     public function testMustBeConstraintNonMatchingCaseWithObject()
@@ -1715,7 +1649,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo(1);
         $this->mock->foo(1, $a, 3);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -1727,9 +1660,9 @@ class ExpectationTest extends MockeryTestCase
         $a->foo = 1;
         $b = new stdClass;
         $b->foo = 2;
-        $this->mock->shouldReceive('foo')->with(Mockery::mustBe($a))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::mustBe($a));
         $this->mock->foo($b);
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testMatchPrecedenceBasedOnExpectedCallsFavouringExplicitMatch()
@@ -1737,7 +1670,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->shouldReceive('foo')->with(1)->once();
         $this->mock->shouldReceive('foo')->with(Mockery::any())->never();
         $this->mock->foo(1);
-        $this->container->mockery_verify();
     }
 
     public function testMatchPrecedenceBasedOnExpectedCallsFavouringAnyMatch()
@@ -1745,7 +1677,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->shouldReceive('foo')->with(Mockery::any())->once();
         $this->mock->shouldReceive('foo')->with(1)->never();
         $this->mock->foo(1);
-        $this->container->mockery_verify();
     }
 
     public function testReturnNullIfIgnoreMissingMethodsSet()
@@ -1779,8 +1710,8 @@ class ExpectationTest extends MockeryTestCase
     public function testShouldIgnoreMissingAsDefinedProxiesToUndefinedAllowingToString()
     {
         $this->mock->shouldIgnoreMissing()->asUndefined();
-        $string = "Method call: {$this->mock->g()}";
-        $string = "Mock: {$this->mock}";
+        $this->assertInternalType('string', "{$this->mock->g()}");
+        $this->assertInternalType('string', "{$this->mock}");
     }
 
     public function testShouldIgnoreMissingDefaultReturnValue()
@@ -1792,7 +1723,7 @@ class ExpectationTest extends MockeryTestCase
     /** @issue #253 */
     public function testShouldIgnoreMissingDefaultSelfAndReturnsSelf()
     {
-        $this->mock->shouldIgnoreMissing($this->container->self());
+        $this->mock->shouldIgnoreMissing(\Mockery::self());
         $this->assertSame($this->mock, $this->mock->a()->b());
     }
 
@@ -1804,7 +1735,7 @@ class ExpectationTest extends MockeryTestCase
 
     public function testOptionalMockRetrieval()
     {
-        $m = $this->container->mock('f')->shouldReceive('foo')->with(1)->andReturn(3)->mock();
+        $m = mock('f')->shouldReceive('foo')->with(1)->andReturn(3)->mock();
         $this->assertTrue($m instanceof \Mockery\MockInterface);
     }
 
@@ -1812,7 +1743,6 @@ class ExpectationTest extends MockeryTestCase
     {
         $this->mock->shouldReceive('foo')->with(Mockery::not(1))->once();
         $this->mock->foo(2);
-        $this->container->mockery_verify();
     }
 
     public function testNotConstraintNonMatchingCase()
@@ -1822,7 +1752,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo(1);
         $this->mock->foo(1, 2, 3);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -1830,9 +1759,9 @@ class ExpectationTest extends MockeryTestCase
      */
     public function testNotConstraintThrowsExceptionWhenConstraintUnmatched()
     {
-        $this->mock->shouldReceive('foo')->with(Mockery::not(2))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::not(2));
         $this->mock->foo(2);
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testAnyOfConstraintMatchesArgument()
@@ -1840,7 +1769,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->shouldReceive('foo')->with(Mockery::anyOf(1, 2))->twice();
         $this->mock->foo(2);
         $this->mock->foo(1);
-        $this->container->mockery_verify();
     }
 
     public function testAnyOfConstraintNonMatchingCase()
@@ -1850,7 +1778,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo(1);
         $this->mock->foo(1, 2, 3);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -1858,9 +1785,9 @@ class ExpectationTest extends MockeryTestCase
      */
     public function testAnyOfConstraintThrowsExceptionWhenConstraintUnmatched()
     {
-        $this->mock->shouldReceive('foo')->with(Mockery::anyOf(1, 2))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::anyOf(1, 2));
         $this->mock->foo(3);
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     /**
@@ -1868,9 +1795,8 @@ class ExpectationTest extends MockeryTestCase
      */
     public function testAnyOfConstraintThrowsExceptionWhenTrueIsNotAnExpectedArgument()
     {
-        $this->mock->shouldReceive('foo')->with(Mockery::anyOf(1, 2))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::anyOf(1, 2));
         $this->mock->foo(true);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -1878,16 +1804,14 @@ class ExpectationTest extends MockeryTestCase
      */
     public function testAnyOfConstraintThrowsExceptionWhenFalseIsNotAnExpectedArgument()
     {
-        $this->mock->shouldReceive('foo')->with(Mockery::anyOf(0, 1, 2))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::anyOf(0, 1, 2));
         $this->mock->foo(false);
-        $this->container->mockery_verify();
     }
 
     public function testNotAnyOfConstraintMatchesArgument()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::notAnyOf(1, 2))->once();
         $this->mock->foo(3);
-        $this->container->mockery_verify();
     }
 
     public function testNotAnyOfConstraintNonMatchingCase()
@@ -1897,7 +1821,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->mock->foo(1);
         $this->mock->foo(1, 4, 3);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -1905,16 +1828,15 @@ class ExpectationTest extends MockeryTestCase
      */
     public function testNotAnyOfConstraintThrowsExceptionWhenConstraintUnmatched()
     {
-        $this->mock->shouldReceive('foo')->with(Mockery::notAnyOf(1, 2))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::notAnyOf(1, 2));
         $this->mock->foo(2);
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     public function testPatternConstraintMatchesArgument()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::pattern('/foo.*/'))->once();
         $this->mock->foo('foobar');
-        $this->container->mockery_verify();
     }
 
     public function testPatternConstraintNonMatchingCase()
@@ -1922,7 +1844,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->shouldReceive('foo')->once();
         $this->mock->shouldReceive('foo')->with(Mockery::pattern('/foo.*/'))->never();
         $this->mock->foo('bar');
-        $this->container->mockery_verify();
     }
 
     /**
@@ -1930,9 +1851,9 @@ class ExpectationTest extends MockeryTestCase
      */
     public function testPatternConstraintThrowsExceptionWhenConstraintUnmatched()
     {
-        $this->mock->shouldReceive('foo')->with(Mockery::pattern('/foo.*/'))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::pattern('/foo.*/'));
         $this->mock->foo('bar');
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 
     /**
@@ -1941,8 +1862,9 @@ class ExpectationTest extends MockeryTestCase
     public function testGlobalConfigMayForbidMockingNonExistentMethodsOnClasses()
     {
         \Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
-        $mock = $this->container->mock('stdClass');
+        $mock = mock('stdClass');
         $mock->shouldReceive('foo');
+        Mockery::close();
     }
 
     /**
@@ -1952,8 +1874,9 @@ class ExpectationTest extends MockeryTestCase
     public function testGlobalConfigMayForbidMockingNonExistentMethodsOnAutoDeclaredClasses()
     {
         \Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
-        $mock = $this->container->mock('SomeMadeUpClass');
+        $mock = mock('SomeMadeUpClass');
         $mock->shouldReceive('foo');
+        Mockery::close();
     }
 
     /**
@@ -1962,13 +1885,14 @@ class ExpectationTest extends MockeryTestCase
     public function testGlobalConfigMayForbidMockingNonExistentMethodsOnObjects()
     {
         \Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
-        $mock = $this->container->mock(new stdClass);
+        $mock = mock(new stdClass);
         $mock->shouldReceive('foo');
+        Mockery::close();
     }
 
     public function testAnExampleWithSomeExpectationAmends()
     {
-        $service = $this->container->mock('MyService');
+        $service = mock('MyService');
         $service->shouldReceive('login')->with('user', 'pass')->once()->andReturn(true);
         $service->shouldReceive('hasBookmarksTagged')->with('php')->once()->andReturn(false);
         $service->shouldReceive('addBookmark')->with(Mockery::pattern('/^http:/'), \Mockery::type('string'))->times(3)->andReturn(true);
@@ -1980,13 +1904,11 @@ class ExpectationTest extends MockeryTestCase
         $this->assertTrue($service->addBookmark('http://example.com/2', 'some_tag2'));
         $this->assertTrue($service->addBookmark('http://example.com/3', 'some_tag3'));
         $this->assertTrue($service->hasBookmarksTagged('php'));
-
-        $this->container->mockery_verify();
     }
 
     public function testAnExampleWithSomeExpectationAmendsOnCallCounts()
     {
-        $service = $this->container->mock('MyService');
+        $service = mock('MyService');
         $service->shouldReceive('login')->with('user', 'pass')->once()->andReturn(true);
         $service->shouldReceive('hasBookmarksTagged')->with('php')->once()->andReturn(false);
         $service->shouldReceive('addBookmark')->with(Mockery::pattern('/^http:/'), \Mockery::type('string'))->times(3)->andReturn(true);
@@ -2000,7 +1922,6 @@ class ExpectationTest extends MockeryTestCase
         $this->assertTrue($service->hasBookmarksTagged('php'));
         $this->assertTrue($service->hasBookmarksTagged('php'));
 
-        $this->container->mockery_verify();
     }
 
     public function testAnExampleWithSomeExpectationAmendsOnCallCounts_PHPUnitTest()
@@ -2024,7 +1945,7 @@ class ExpectationTest extends MockeryTestCase
 
     public function testMockedMethodsCallableFromWithinOriginalClass()
     {
-        $mock = $this->container->mock('MockeryTest_InterMethod1[doThird]');
+        $mock = mock('MockeryTest_InterMethod1[doThird]');
         $mock->shouldReceive('doThird')->andReturn(true);
         $this->assertTrue($mock->doFirst());
     }
@@ -2034,7 +1955,7 @@ class ExpectationTest extends MockeryTestCase
      */
     public function testMockingDemeterChainsPassesMockeryExpectationToCompositeExpectation()
     {
-        $mock = $this->container->mock('Mockery_Demeterowski');
+        $mock = mock('Mockery_Demeterowski');
         $mock->shouldReceive('foo->bar->baz')->andReturn('Spam!');
         $demeter = new Mockery_UseDemeter($mock);
         $this->assertSame('Spam!', $demeter->doit());
@@ -2045,7 +1966,7 @@ class ExpectationTest extends MockeryTestCase
      */
     public function testMockingDemeterChainsPassesMockeryExpectationToCompositeExpectationWithArgs()
     {
-        $mock = $this->container->mock('Mockery_Demeterowski');
+        $mock = mock('Mockery_Demeterowski');
         $mock->shouldReceive('foo->bar->baz')->andReturn('Spam!');
         $demeter = new Mockery_UseDemeter($mock);
         $this->assertSame('Spam!', $demeter->doitWithArgs());
@@ -2053,24 +1974,22 @@ class ExpectationTest extends MockeryTestCase
 
     public function testPassthruEnsuresRealMethodCalledForReturnValues()
     {
-        $mock = $this->container->mock('MockeryTest_SubjectCall1');
+        $mock = mock('MockeryTest_SubjectCall1');
         $mock->shouldReceive('foo')->once()->passthru();
         $this->assertEquals('bar', $mock->foo());
-        $this->container->mockery_verify();
     }
 
     public function testShouldIgnoreMissingExpectationBasedOnArgs()
     {
-        $mock = $this->container->mock("MyService2")->shouldIgnoreMissing();
+        $mock = mock("MyService2")->shouldIgnoreMissing();
         $mock->shouldReceive("hasBookmarksTagged")->with("dave")->once();
         $mock->hasBookmarksTagged("dave");
         $mock->hasBookmarksTagged("padraic");
-        $this->container->mockery_verify();
     }
 
     public function testShouldDeferMissingExpectationBasedOnArgs()
     {
-        $mock = $this->container->mock("MockeryTest_SubjectCall1")->shouldDeferMissing();
+        $mock = mock("MockeryTest_SubjectCall1")->shouldDeferMissing();
 
         $this->assertEquals('bar', $mock->foo());
         $this->assertEquals('bar', $mock->foo("baz"));
@@ -2086,7 +2005,6 @@ class ExpectationTest extends MockeryTestCase
         $this->assertEquals('123', $mock->foo("baz"));
         $this->assertEquals('bar', $mock->foo("qux"));
 
-        $this->container->mockery_verify();
     }
 
     public function testCanReturnSelf()
@@ -2121,11 +2039,12 @@ class ExpectationTest extends MockeryTestCase
     public function testTimesExpectationForbidsFloatNumbers()
     {
         $this->mock->shouldReceive('foo')->times(1.3);
+        Mockery::close();
     }
 
     public function testIfExceptionIndicatesAbsenceOfMethodAndExpectationsOnMock()
     {
-        $mock = $this->container->mock('Mockery_Duck');
+        $mock = mock('Mockery_Duck');
 
         $this->expectException(
             '\BadMethodCallException',
@@ -2134,11 +2053,12 @@ class ExpectationTest extends MockeryTestCase
         );
 
         $mock->nonExistent();
+        Mockery::close();
     }
 
     public function testIfCallingMethodWithNoExpectationsHasSpecificExceptionMessage()
     {
-        $mock = $this->container->mock('Mockery_Duck');
+        $mock = mock('Mockery_Duck');
 
         $this->expectException(
             '\BadMethodCallException',
@@ -2147,11 +2067,12 @@ class ExpectationTest extends MockeryTestCase
         );
 
         $mock->quack();
+        Mockery::close();
     }
 
     public function testMockShouldNotBeAnonymousWhenImplementingSpecificInterface()
     {
-        $waterMock = $this->container->mock('IWater');
+        $waterMock = mock('IWater');
         $this->assertFalse($waterMock->mockery_isAnonymous());
     }
 

--- a/tests/Mockery/HamcrestExpectationTest.php
+++ b/tests/Mockery/HamcrestExpectationTest.php
@@ -25,15 +25,15 @@ class HamcrestExpectationTest extends MockeryTestCase
 {
     public function setUp()
     {
-        $this->container = new \Mockery\Container(\Mockery::getDefaultGenerator(), \Mockery::getDefaultLoader());
-        $this->mock = $this->container->mock('foo');
+        parent::setUp();
+        $this->mock = mock('foo');
     }
 
 
     public function tearDown()
     {
         \Mockery::getConfiguration()->allowMockingNonExistentMethods(true);
-        $this->container->mockery_close();
+        parent::tearDown();
     }
 
     /** Just a quickie roundup of a few Hamcrest matchers to check nothing obvious out of place **/
@@ -42,14 +42,12 @@ class HamcrestExpectationTest extends MockeryTestCase
     {
         $this->mock->shouldReceive('foo')->with(anything())->once();
         $this->mock->foo(2);
-        $this->container->mockery_verify();
     }
 
     public function testGreaterThanConstraintMatchesArgument()
     {
         $this->mock->shouldReceive('foo')->with(greaterThan(1))->once();
         $this->mock->foo(2);
-        $this->container->mockery_verify();
     }
 
     /**
@@ -57,8 +55,8 @@ class HamcrestExpectationTest extends MockeryTestCase
      */
     public function testGreaterThanConstraintNotMatchesArgument()
     {
-        $this->mock->shouldReceive('foo')->with(greaterThan(1))->once();
+        $this->mock->shouldReceive('foo')->with(greaterThan(1));
         $this->mock->foo(1);
-        $this->container->mockery_verify();
+        Mockery::close();
     }
 }

--- a/tests/Mockery/MockClassWithMethodOverloadingTest.php
+++ b/tests/Mockery/MockClassWithMethodOverloadingTest.php
@@ -6,24 +6,12 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 class MockClassWithMethodOverloadingTest extends MockeryTestCase
 {
-    private $container;
-
-    protected function setUp()
-    {
-        $this->container = new \Mockery\Container;
-    }
-
-    protected function tearDown()
-    {
-        $this->container->mockery_close();
-    }
-
     /**
      * @expectedException BadMethodCallException
      */
     public function testCreateMockForClassWithMethodOverloading()
     {
-        $mock = $this->container->mock('test\Mockery\TestWithMethodOverloading')
+        $mock = mock('test\Mockery\TestWithMethodOverloading')
             ->makePartial();
         $this->assertInstanceOf('test\Mockery\TestWithMethodOverloading', $mock);
 
@@ -33,7 +21,7 @@ class MockClassWithMethodOverloadingTest extends MockeryTestCase
 
     public function testCreateMockForClassWithMethodOverloadingWithExistingMethod()
     {
-        $mock = $this->container->mock('test\Mockery\TestWithMethodOverloading')
+        $mock = mock('test\Mockery\TestWithMethodOverloading')
             ->makePartial();
         $this->assertInstanceOf('test\Mockery\TestWithMethodOverloading', $mock);
 

--- a/tests/Mockery/MockClassWithUnknownTypeHintTest.php
+++ b/tests/Mockery/MockClassWithUnknownTypeHintTest.php
@@ -21,24 +21,17 @@
 
 namespace test\Mockery;
 
+use Mockery\MockInterface;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 class MockClassWithUnknownTypeHintTest extends MockeryTestCase
 {
-    protected function setUp()
-    {
-        $this->container = new \Mockery\Container;
-    }
-
-    protected function tearDown()
-    {
-        $this->container->mockery_close();
-    }
-
     /** @test */
     public function itShouldSuccessfullyBuildTheMock()
     {
-        $this->container->mock("test\Mockery\HasUnknownClassAsTypeHintOnMethod");
+        $mock = mock("test\Mockery\HasUnknownClassAsTypeHintOnMethod");
+
+        $this->assertInstanceOf(MockInterface::class, $mock);
     }
 }
 

--- a/tests/Mockery/MockTest.php
+++ b/tests/Mockery/MockTest.php
@@ -23,20 +23,10 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 class Mockery_MockTest extends MockeryTestCase
 {
-    public function setup()
-    {
-        $this->container = new \Mockery\Container(\Mockery::getDefaultGenerator(), \Mockery::getDefaultLoader());
-    }
-
-    public function teardown()
-    {
-        $this->container->mockery_close();
-    }
-
     public function testAnonymousMockWorksWithNotAllowingMockingOfNonExistentMethods()
     {
         \Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
-        $m = $this->container->mock();
+        $m = mock();
         $m->shouldReceive("test123")->andReturn(true);
         assertThat($m->test123(), equalTo(true));
         \Mockery::getConfiguration()->allowMockingNonExistentMethods(true);
@@ -45,7 +35,7 @@ class Mockery_MockTest extends MockeryTestCase
     public function testMockWithNotAllowingMockingOfNonExistentMethodsCanBeGivenAdditionalMethodsToMockEvenIfTheyDontExistOnClass()
     {
         \Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
-        $m = $this->container->mock('ExampleClassForTestingNonExistentMethod');
+        $m = mock('ExampleClassForTestingNonExistentMethod');
         $m->shouldAllowMockingMethod('testSomeNonExistentMethod');
         $m->shouldReceive("testSomeNonExistentMethod")->andReturn(true);
         assertThat($m->testSomeNonExistentMethod(), equalTo(true));
@@ -66,29 +56,29 @@ class Mockery_MockTest extends MockeryTestCase
 
     public function testMockAddsToString()
     {
-        $mock = $this->container->mock('ClassWithNoToString');
-        assertThat(hasToString($mock));
+        $mock = mock('ClassWithNoToString');
+        $this->assertTrue(method_exists($mock, '__toString'));
     }
 
     public function testMockToStringMayBeDeferred()
     {
-        $mock = $this->container->mock('ClassWithToString')->shouldDeferMissing();
-        assertThat((string)$mock, equalTo("foo"));
+        $mock = mock('ClassWithToString')->shouldDeferMissing();
+        $this->assertEquals("foo", (string)$mock);
     }
 
     public function testMockToStringShouldIgnoreMissingAlwaysReturnsString()
     {
-        $mock = $this->container->mock('ClassWithNoToString')->shouldIgnoreMissing();
-        assertThat(isNonEmptyString((string)$mock));
+        $mock = mock('ClassWithNoToString')->shouldIgnoreMissing();
+        $this->assertNotEquals('', (string)$mock);
 
         $mock->asUndefined();
-        assertThat(isNonEmptyString((string)$mock));
+        $this->assertNotEquals('', (string)$mock);
     }
 
     public function testShouldIgnoreMissing()
     {
-        $mock = $this->container->mock('ClassWithNoToString')->shouldIgnoreMissing();
-        assertThat(nullValue($mock->nonExistingMethod()));
+        $mock = mock('ClassWithNoToString')->shouldIgnoreMissing();
+        $this->assertNull($mock->nonExistingMethod());
     }
 
     /**
@@ -97,7 +87,7 @@ class Mockery_MockTest extends MockeryTestCase
     public function testShouldIgnoreMissingDisallowMockingNonExistentMethodsUsingGlobalConfiguration()
     {
         Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
-        $mock = $this->container->mock('ClassWithMethods')->shouldIgnoreMissing();
+        $mock = mock('ClassWithMethods')->shouldIgnoreMissing();
         $mock->shouldReceive('nonExistentMethod');
     }
 
@@ -107,14 +97,14 @@ class Mockery_MockTest extends MockeryTestCase
     public function testShouldIgnoreMissingCallingNonExistentMethodsUsingGlobalConfiguration()
     {
         Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
-        $mock = $this->container->mock('ClassWithMethods')->shouldIgnoreMissing();
+        $mock = mock('ClassWithMethods')->shouldIgnoreMissing();
         $mock->nonExistentMethod();
     }
 
     public function testShouldIgnoreMissingCallingExistentMethods()
     {
         Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
-        $mock = $this->container->mock('ClassWithMethods')->shouldIgnoreMissing();
+        $mock = mock('ClassWithMethods')->shouldIgnoreMissing();
         assertThat(nullValue($mock->foo()));
         $mock->shouldReceive('bar')->passthru();
         assertThat($mock->bar(), equalTo('bar'));
@@ -123,7 +113,7 @@ class Mockery_MockTest extends MockeryTestCase
     public function testShouldIgnoreMissingCallingNonExistentMethods()
     {
         Mockery::getConfiguration()->allowMockingNonExistentMethods(true);
-        $mock = $this->container->mock('ClassWithMethods')->shouldIgnoreMissing();
+        $mock = mock('ClassWithMethods')->shouldIgnoreMissing();
         assertThat(nullValue($mock->foo()));
         assertThat(nullValue($mock->bar()));
         assertThat(nullValue($mock->nonExistentMethod()));
@@ -161,7 +151,7 @@ class Mockery_MockTest extends MockeryTestCase
      */
     public function testShouldThrowExceptionWithInvalidClassName()
     {
-        $this->container->mock('ClassName.CannotContainDot');
+        mock('ClassName.CannotContainDot');
     }
 }
 

--- a/tests/Mockery/MockingMethodsWithIterableTypeHintsTest.php
+++ b/tests/Mockery/MockingMethodsWithIterableTypeHintsTest.php
@@ -28,21 +28,11 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
  */
 class MockingMethodsWithIterableTypeHintsTest extends MockeryTestCase
 {
-    protected function setUp()
-    {
-        $this->container = new \Mockery\Container;
-    }
-
-    protected function tearDown()
-    {
-        $this->container->mockery_close();
-    }
-
     /** @test */
     public function itShouldSuccessfullyBuildTheMock()
     {
         require __DIR__."/Fixtures/MethodWithIterableTypeHints.php";
-        $mock = $this->container->mock("test\Mockery\Fixtures\MethodWithIterableTypeHints");
+        $mock = mock("test\Mockery\Fixtures\MethodWithIterableTypeHints");
 
         $this->assertTrue($mock instanceof \test\Mockery\Fixtures\MethodWithIterableTypeHints);
     }

--- a/tests/Mockery/MockingMethodsWithNullableParametersTest.php
+++ b/tests/Mockery/MockingMethodsWithNullableParametersTest.php
@@ -27,16 +27,6 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
  */
 class MockingMethodsWithNullableParametersTest extends MockeryTestCase
 {
-    protected function setUp()
-    {
-        $this->container = new \Mockery\Container;
-    }
-
-    protected function tearDown()
-    {
-        $this->container->mockery_close();
-    }
-
     /**
      * @test
      * @requires PHP 7.1.0RC3
@@ -44,7 +34,7 @@ class MockingMethodsWithNullableParametersTest extends MockeryTestCase
     public function it_can_handle_nullable_typed_parameters()
     {
         require __DIR__."/Fixtures/MethodWithNullableTypedParameter.php";
-        $mock = $this->container->mock("test\Mockery\Fixtures\MethodWithNullableTypedParameter");
+        $mock = mock("test\Mockery\Fixtures\MethodWithNullableTypedParameter");
 
         $this->assertTrue($mock instanceof \test\Mockery\Fixtures\MethodWithNullableTypedParameter);
     }
@@ -55,7 +45,7 @@ class MockingMethodsWithNullableParametersTest extends MockeryTestCase
     public function it_can_handle_default_parameters()
     {
         require __DIR__."/Fixtures/MethodWithParametersWithDefaultValues.php";
-        $mock = $this->container->mock("test\Mockery\Fixtures\MethodWithParametersWithDefaultValues");
+        $mock = mock("test\Mockery\Fixtures\MethodWithParametersWithDefaultValues");
 
         $this->assertTrue($mock instanceof \test\Mockery\Fixtures\MethodWithParametersWithDefaultValues);
     }

--- a/tests/Mockery/MockingNullableMethodsTest.php
+++ b/tests/Mockery/MockingNullableMethodsTest.php
@@ -37,14 +37,9 @@ class MockingNullableMethodsTest extends MockeryTestCase
 
     protected function setUp()
     {
+        parent::setUp();
+
         require_once __DIR__."/Fixtures/MethodWithNullableReturnType.php";
-
-        $this->container = new \Mockery\Container;
-    }
-
-    protected function tearDown()
-    {
-        $this->container->mockery_close();
     }
 
     /**
@@ -52,7 +47,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
      */
     public function itShouldAllowNonNullableTypeToBeSet()
     {
-        $mock = $this->container->mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
+        $mock = mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
 
         $mock->shouldReceive('nonNullablePrimitive')->andReturn('a string');
         $mock->nonNullablePrimitive();
@@ -64,7 +59,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
      */
     public function itShouldNotAllowNonNullToBeNull()
     {
-        $mock = $this->container->mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
+        $mock = mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
 
         $mock->shouldReceive('nonNullablePrimitive')->andReturn(null);
         $mock->nonNullablePrimitive();
@@ -75,7 +70,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
      */
     public function itShouldAllowPrimitiveNullableToBeNull()
     {
-        $mock = $this->container->mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
+        $mock = mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
 
         $mock->shouldReceive('nullablePrimitive')->andReturn(null);
         $mock->nullablePrimitive();
@@ -86,7 +81,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
      */
     public function itShouldAllowPrimitiveNullabeToBeSet()
     {
-        $mock = $this->container->mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
+        $mock = mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
 
         $mock->shouldReceive('nullablePrimitive')->andReturn('a string');
         $mock->nullablePrimitive();
@@ -97,7 +92,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
      */
     public function itShouldAllowSelfToBeSet()
     {
-        $mock = $this->container->mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
+        $mock = mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
 
         $mock->shouldReceive('nonNullableSelf')->andReturn(new MethodWithNullableReturnType());
         $mock->nonNullableSelf();
@@ -109,7 +104,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
      */
     public function itShouldNotAllowSelfToBeNull()
     {
-        $mock = $this->container->mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
+        $mock = mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
 
         $mock->shouldReceive('nonNullableSelf')->andReturn(null);
         $mock->nonNullableSelf();
@@ -120,7 +115,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
      */
     public function itShouldAllowNullableSelfToBeSet()
     {
-        $mock = $this->container->mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
+        $mock = mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
 
         $mock->shouldReceive('nullableSelf')->andReturn(new MethodWithNullableReturnType());
         $mock->nullableSelf();
@@ -131,7 +126,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
      */
     public function itShouldAllowNullableSelfToBeNull()
     {
-        $mock = $this->container->mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
+        $mock = mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
 
         $mock->shouldReceive('nullableSelf')->andReturn(null);
         $mock->nullableSelf();
@@ -142,7 +137,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
      */
     public function itShouldAllowClassToBeSet()
     {
-        $mock = $this->container->mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
+        $mock = mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
 
         $mock->shouldReceive('nonNullableClass')->andReturn(new MethodWithNullableReturnType());
         $mock->nonNullableClass();
@@ -154,7 +149,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
      */
     public function itShouldNotAllowClassToBeNull()
     {
-        $mock = $this->container->mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
+        $mock = mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
 
         $mock->shouldReceive('nonNullableClass')->andReturn(null);
         $mock->nonNullableClass();
@@ -165,7 +160,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
      */
     public function itShouldAllowNullalbeClassToBeSet()
     {
-        $mock = $this->container->mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
+        $mock = mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
 
         $mock->shouldReceive('nullableClass')->andReturn(new MethodWithNullableReturnType());
         $mock->nullableClass();
@@ -176,7 +171,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
      */
     public function itShouldAllowNullableClassToBeNull()
     {
-        $mock = $this->container->mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
+        $mock = mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
 
         $mock->shouldReceive('nullableClass')->andReturn(null);
         $mock->nullableClass();

--- a/tests/Mockery/MockingParameterAndReturnTypesTest.php
+++ b/tests/Mockery/MockingParameterAndReturnTypesTest.php
@@ -27,19 +27,9 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 class MockingParameterAndReturnTypesTest extends MockeryTestCase
 {
-    public function setup()
-    {
-        $this->container = new \Mockery\Container;
-    }
-
-    public function teardown()
-    {
-        $this->container->mockery_close();
-    }
-
     public function testMockingStringReturnType()
     {
-        $mock = $this->container->mock("test\Mockery\TestWithParameterAndReturnType");
+        $mock = mock("test\Mockery\TestWithParameterAndReturnType");
 
         $mock->shouldReceive("returnString");
         $this->assertSame("", $mock->returnString());
@@ -47,7 +37,7 @@ class MockingParameterAndReturnTypesTest extends MockeryTestCase
 
     public function testMockingIntegerReturnType()
     {
-        $mock = $this->container->mock("test\Mockery\TestWithParameterAndReturnType");
+        $mock = mock("test\Mockery\TestWithParameterAndReturnType");
 
         $mock->shouldReceive("returnInteger");
         $this->assertSame(0, $mock->returnInteger());
@@ -55,7 +45,7 @@ class MockingParameterAndReturnTypesTest extends MockeryTestCase
 
     public function testMockingFloatReturnType()
     {
-        $mock = $this->container->mock("test\Mockery\TestWithParameterAndReturnType");
+        $mock = mock("test\Mockery\TestWithParameterAndReturnType");
 
         $mock->shouldReceive("returnFloat");
         $this->assertSame(0.0, $mock->returnFloat());
@@ -63,7 +53,7 @@ class MockingParameterAndReturnTypesTest extends MockeryTestCase
 
     public function testMockingBooleanReturnType()
     {
-        $mock = $this->container->mock("test\Mockery\TestWithParameterAndReturnType");
+        $mock = mock("test\Mockery\TestWithParameterAndReturnType");
 
         $mock->shouldReceive("returnBoolean");
         $this->assertSame(false, $mock->returnBoolean());
@@ -71,7 +61,7 @@ class MockingParameterAndReturnTypesTest extends MockeryTestCase
 
     public function testMockingArrayReturnType()
     {
-        $mock = $this->container->mock("test\Mockery\TestWithParameterAndReturnType");
+        $mock = mock("test\Mockery\TestWithParameterAndReturnType");
 
         $mock->shouldReceive("returnArray");
         $this->assertSame([], $mock->returnArray());
@@ -79,7 +69,7 @@ class MockingParameterAndReturnTypesTest extends MockeryTestCase
 
     public function testMockingGeneratorReturnTyps()
     {
-        $mock = $this->container->mock("test\Mockery\TestWithParameterAndReturnType");
+        $mock = mock("test\Mockery\TestWithParameterAndReturnType");
 
         $mock->shouldReceive("returnGenerator");
         $this->assertInstanceOf("\Generator", $mock->returnGenerator());
@@ -87,7 +77,7 @@ class MockingParameterAndReturnTypesTest extends MockeryTestCase
 
     public function testMockingCallableReturnType()
     {
-        $mock = $this->container->mock("test\Mockery\TestWithParameterAndReturnType");
+        $mock = mock("test\Mockery\TestWithParameterAndReturnType");
 
         $mock->shouldReceive("returnCallable");
         $this->assertTrue(is_callable($mock->returnCallable()));
@@ -95,7 +85,7 @@ class MockingParameterAndReturnTypesTest extends MockeryTestCase
 
     public function testMockingClassReturnTypes()
     {
-        $mock = $this->container->mock("test\Mockery\TestWithParameterAndReturnType");
+        $mock = mock("test\Mockery\TestWithParameterAndReturnType");
 
         $mock->shouldReceive("withClassReturnType");
         $this->assertInstanceOf("test\Mockery\TestWithParameterAndReturnType", $mock->withClassReturnType());
@@ -103,7 +93,7 @@ class MockingParameterAndReturnTypesTest extends MockeryTestCase
 
     public function testMockingParameterTypes()
     {
-        $mock = $this->container->mock("test\Mockery\TestWithParameterAndReturnType");
+        $mock = mock("test\Mockery\TestWithParameterAndReturnType");
 
         $mock->shouldReceive("withScalarParameters");
         $mock->withScalarParameters(1, 1.0, true, 'string');
@@ -111,7 +101,7 @@ class MockingParameterAndReturnTypesTest extends MockeryTestCase
 
     public function testIgnoringMissingReturnsType()
     {
-        $mock = $this->container->mock("test\Mockery\TestWithParameterAndReturnType");
+        $mock = mock("test\Mockery\TestWithParameterAndReturnType");
 
         $mock->shouldIgnoreMissing();
 

--- a/tests/Mockery/MockingProtectedMethodsTest.php
+++ b/tests/Mockery/MockingProtectedMethodsTest.php
@@ -25,16 +25,6 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 class MockingProtectedMethodsTest extends MockeryTestCase
 {
-    public function setup()
-    {
-        $this->container = new \Mockery\Container;
-    }
-
-    public function teardown()
-    {
-        $this->container->mockery_close();
-    }
-
     /**
      * @test
      *
@@ -43,7 +33,7 @@ class MockingProtectedMethodsTest extends MockeryTestCase
      */
     public function shouldAutomaticallyDeferCallsToProtectedMethodsForPartials()
     {
-        $mock = $this->container->mock("test\Mockery\TestWithProtectedMethods[foo]");
+        $mock = mock("test\Mockery\TestWithProtectedMethods[foo]");
         $this->assertEquals("bar", $mock->bar());
     }
 
@@ -55,21 +45,21 @@ class MockingProtectedMethodsTest extends MockeryTestCase
      */
     public function shouldAutomaticallyDeferCallsToProtectedMethodsForRuntimePartials()
     {
-        $mock = $this->container->mock("test\Mockery\TestWithProtectedMethods")->shouldDeferMissing();
+        $mock = mock("test\Mockery\TestWithProtectedMethods")->shouldDeferMissing();
         $this->assertEquals("bar", $mock->bar());
     }
 
     /** @test */
     public function shouldAutomaticallyIgnoreAbstractProtectedMethods()
     {
-        $mock = $this->container->mock("test\Mockery\TestWithProtectedMethods")->shouldDeferMissing();
+        $mock = mock("test\Mockery\TestWithProtectedMethods")->shouldDeferMissing();
         $this->assertEquals(null, $mock->foo());
     }
 
     /** @test */
     public function shouldAllowMockingProtectedMethods()
     {
-        $mock = $this->container->mock("test\Mockery\TestWithProtectedMethods")
+        $mock = mock("test\Mockery\TestWithProtectedMethods")
             ->shouldDeferMissing()
             ->shouldAllowMockingProtectedMethods();
 
@@ -80,7 +70,7 @@ class MockingProtectedMethodsTest extends MockeryTestCase
     /** @test */
     public function shouldAllowMockingProtectedMethodOnDefinitionTimePartial()
     {
-        $mock = $this->container->mock("test\Mockery\TestWithProtectedMethods[protectedBar]")
+        $mock = mock("test\Mockery\TestWithProtectedMethods[protectedBar]")
             ->shouldAllowMockingProtectedMethods();
 
         $mock->shouldReceive("protectedBar")->andReturn("notbar");
@@ -90,7 +80,7 @@ class MockingProtectedMethodsTest extends MockeryTestCase
     /** @test */
     public function shouldAllowMockingAbstractProtectedMethods()
     {
-        $mock = $this->container->mock("test\Mockery\TestWithProtectedMethods")
+        $mock = mock("test\Mockery\TestWithProtectedMethods")
             ->shouldDeferMissing()
             ->shouldAllowMockingProtectedMethods();
 
@@ -101,7 +91,7 @@ class MockingProtectedMethodsTest extends MockeryTestCase
     /** @test */
     public function shouldAllowMockingIncreasedVisabilityMethods()
     {
-        $mock = $this->container->mock("test\Mockery\TestIncreasedVisibilityChild");
+        $mock = mock("test\Mockery\TestIncreasedVisibilityChild");
         $mock->shouldReceive('foobar')->andReturn("foobar");
         $this->assertEquals('foobar', $mock->foobar());
     }

--- a/tests/Mockery/MockingVariadicArgumentsTest.php
+++ b/tests/Mockery/MockingVariadicArgumentsTest.php
@@ -25,20 +25,10 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 class MockingVariadicArgumentsTest extends MockeryTestCase
 {
-    public function setup()
-    {
-        $this->container = new \Mockery\Container;
-    }
-
-    public function teardown()
-    {
-        $this->container->mockery_close();
-    }
-
     /** @test */
     public function shouldAllowMockingVariadicArguments()
     {
-        $mock = $this->container->mock("test\Mockery\TestWithVariadicArguments");
+        $mock = mock("test\Mockery\TestWithVariadicArguments");
 
         $mock->shouldReceive("foo")->andReturn("notbar");
         $this->assertEquals("notbar", $mock->foo());

--- a/tests/Mockery/MockingVoidMethodsTest.php
+++ b/tests/Mockery/MockingVoidMethodsTest.php
@@ -31,19 +31,13 @@ class MockingVoidMethodsTest extends MockeryTestCase
     protected function setUp()
     {
         require_once __DIR__."/Fixtures/MethodWithVoidReturnType.php";
-
-        $this->container = new \Mockery\Container;
     }
 
-    protected function tearDown()
-    {
-        $this->container->mockery_close();
-    }
 
     /** @test */
     public function itShouldSuccessfullyBuildTheMock()
     {
-        $mock = $this->container->mock("test\Mockery\Fixtures\MethodWithVoidReturnType");
+        $mock = mock("test\Mockery\Fixtures\MethodWithVoidReturnType");
 
         $this->assertTrue($mock instanceof \test\Mockery\Fixtures\MethodWithVoidReturnType);
     }
@@ -51,7 +45,7 @@ class MockingVoidMethodsTest extends MockeryTestCase
     /** @test */
     public function it_can_stub_and_mock_void_methods()
     {
-        $mock = $this->container->mock("test\Mockery\Fixtures\MethodWithVoidReturnType");
+        $mock = mock("test\Mockery\Fixtures\MethodWithVoidReturnType");
 
         $mock->shouldReceive("foo");
         $mock->foo();

--- a/tests/Mockery/SpyTest.php
+++ b/tests/Mockery/SpyTest.php
@@ -23,20 +23,10 @@ namespace test\Mockery;
 
 use Mockery as m;
 use Mockery\Spy;
-use PHPUnit\Framework\TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class SpyTest extends TestCase
+class SpyTest extends MockeryTestCase
 {
-    public function setup()
-    {
-        $this->container = new \Mockery\Container;
-    }
-
-    public function teardown()
-    {
-        $this->container->mockery_close();
-    }
-
     /** @test */
     public function itVerifiesAMethodWasCalled()
     {


### PR DESCRIPTION
Kinda...

This moves nearly all of the tests away from an isolated container. This loses some niceness in the tests, but allows us to use our own PHPUnit integration to achieve assertion counting etc.

The confusing tests are the ones where we want the actual test to throw one of our exceptions, so we have to manually call `Mockery::close()` to force it as part of the test, rather than the PHPUnit integration firing them in the postAssertion hook.

There are a lot of tests that have been added for bugs and special cases, which aren't all that clear. I've left them alone, only adding the odd assertion to make them go green rather than yellow. I'd rather have the odd bit of confusion for an individual test, than newcomers to the project run the suite and see loads of risky tests.