### PR TITLE
Allow overriding count validators

### DIFF
--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -625,7 +625,7 @@ class Expectation implements ExpectationInterface
         if (!is_int($limit)) {
             throw new \InvalidArgumentException('The passed Times limit should be an integer value');
         }
-        $this->_countValidators[] = new $this->_countValidatorClass($this, $limit);
+        $this->_countValidators[$this->_countValidatorClass] = new $this->_countValidatorClass($this, $limit);
         $this->_countValidatorClass = 'Mockery\CountValidator\Exact';
         return $this;
     }

--- a/tests/Mockery/AllowsExpectsSyntaxTest.php
+++ b/tests/Mockery/AllowsExpectsSyntaxTest.php
@@ -96,13 +96,25 @@ class AllowsExpectsSyntaxTest extends TestCase
     }
 
     /** @test */
-    public function callVerificationCountCanBeOverridenAfterExpects()
+    public function callVerificationCountCanBeOverridenAfterExpectsThrowsExceptionWhenIncorrectNumberOfCalls()
     {
         $mock = m::mock();
         $mock->expects()->foo(123)->twice();
 
         $mock->foo(123);
         $this->expectException("Mockery\Exception\InvalidCountException");
+        m::close();
+    }
+
+    /** @test */
+    public function callVerificationCountCanBeOverridenAfterExpects()
+    {
+        $mock = m::mock();
+        $mock->expects()->foo(123)->twice();
+
+        $mock->foo(123);
+        $mock->foo(123);
+
         m::close();
     }
 


### PR DESCRIPTION
Keep track of count validators as an associative array,
so we can easily override existing validator classes with
new validators of the same type.

This allows to modify the number of call expectation, especially
when working with ``expects()``, because it defines ``once()``
by default.

Fixes #745