### PR TITLE
Doc Fix invalid code for closure

### DIFF
--- a/docs/reference/argument_validation.rst
+++ b/docs/reference/argument_validation.rst
@@ -148,7 +148,7 @@ assumed to have matched the expectation.
 
     $mock->shouldReceive('foo')
         ->with(\Mockery::on(function ($argument) {
-            if ($arg % 2 == 0) {
+            if ($argument % 2 == 0) {
                 return true;
             }
             return false;


### PR DESCRIPTION
The condition was checking for `$arg` which is undefined and should have been checking for `argument`