### PR TITLE
Fix: internal class param by reference cannot have default value

### DIFF
--- a/library/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php
@@ -82,6 +82,7 @@ class MethodDefinitionPass implements Pass
 
     private function renderMethodBody($method, $config)
     {
+        /** @var \ReflectionMethod $method */
         $invoke = $method->isStatic() ? 'static::_mockery_handleStaticMethodCall' : '$this->_mockery_handleMethodCall';
         $body = <<<BODY
 {
@@ -102,6 +103,9 @@ BODY;
             for ($i = 0; $i < $paramCount; ++$i) {
                 $param = $params[$i];
                 if (strpos($param, '&') !== false) {
+                    if (($stripDefaultValue = strpos($param, '=')) !== false) {
+                        $param = trim(substr($param, 0, $stripDefaultValue));
+                    }
                     $body .= <<<BODY
 if (\$argc > $i) {
     \$argv[$i] = {$param};
@@ -111,6 +115,7 @@ BODY;
                 }
             }
         } else {
+            /** @var \ReflectionParameter[] $params */
             $params = array_values($method->getParameters());
             $paramCount = count($params);
             for ($i = 0; $i < $paramCount; ++$i) {

--- a/tests/Mockery/MockingInternalModuleClassWithOptionalParameterByReference.php
+++ b/tests/Mockery/MockingInternalModuleClassWithOptionalParameterByReference.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ */
+
+namespace test\Mockery;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+
+class MockingInternalModuleClassWithOptionalParameterByReference extends MockeryTestCase
+{
+    protected function setUp()
+    {
+        if (!extension_loaded('memcache')) {
+            $this->markTestSkipped('The memcache extension needs to be loaded in order to run this test');
+        }
+        parent::setUp();
+    }
+
+    protected function tearDown()
+    {
+        static::closeMockery();
+        parent::tearDown();
+    }
+
+    /**
+     * Regression for {@see https://github.com/mockery/mockery/issues/757 issue#757}
+     *
+     * @test
+     */
+    public function mockingInternalModuleClassWithOptionalParameterByReferenceMayNotBreakCodeGeneration()
+    {
+        \Mockery::getConfiguration()
+            ->setInternalClassMethodParamMap(\Memcache::class, 'get', ['$id', '&$flags = null']);
+
+        $memcache = \Mockery::mock(\Memcache::class);
+        $memcache->shouldReceive('get')
+            ->with(
+                $id = 'foobar',
+                \Mockery::on(
+                    function (&$flags) {
+                        $this->assertNull($flags);
+                        $flags = 255;
+                        return true;
+                    }
+                )
+            )
+            ->once()
+            ->andReturn($expected = time());
+        $paramFlags = null;
+        $this->assertSame($expected, $memcache->get($id, $paramFlags));
+        $this->assertSame(255, $paramFlags);
+    }
+
+}

--- a/tests/Mockery/MockingInternalModuleClassWithOptionalParameterByReferenceTest.php
+++ b/tests/Mockery/MockingInternalModuleClassWithOptionalParameterByReferenceTest.php
@@ -18,12 +18,12 @@ namespace test\Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 
-class MockingInternalModuleClassWithOptionalParameterByReference extends MockeryTestCase
+class MockingInternalModuleClassWithOptionalParameterByReferenceTest extends MockeryTestCase
 {
     protected function setUp()
     {
         if (!extension_loaded('memcache')) {
-            $this->markTestSkipped('The memcache extension needs to be loaded in order to run this test');
+            $this->markTestSkipped('ext/memcache not installed');
         }
         parent::setUp();
     }
@@ -42,15 +42,15 @@ class MockingInternalModuleClassWithOptionalParameterByReference extends Mockery
     public function mockingInternalModuleClassWithOptionalParameterByReferenceMayNotBreakCodeGeneration()
     {
         \Mockery::getConfiguration()
-            ->setInternalClassMethodParamMap(\Memcache::class, 'get', ['$id', '&$flags = null']);
-
-        $memcache = \Mockery::mock(\Memcache::class);
+            ->setInternalClassMethodParamMap('Memcache', 'get', array('$id', '&$flags = null'));
+        $self = $this;
+        $memcache = \Mockery::mock('Memcache');
         $memcache->shouldReceive('get')
             ->with(
                 $id = 'foobar',
                 \Mockery::on(
-                    function (&$flags) {
-                        $this->assertNull($flags);
+                    function (&$flags) use ($self){
+                        $self->assertNull($flags);
                         $flags = 255;
                         return true;
                     }

--- a/tests/Mockery/MockingInternalModuleClassWithOptionalParameterByReferenceTest.php
+++ b/tests/Mockery/MockingInternalModuleClassWithOptionalParameterByReferenceTest.php
@@ -18,7 +18,6 @@ namespace test\Mockery;
 
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-
 class MockingInternalModuleClassWithOptionalParameterByReferenceTest extends MockeryTestCase
 {
     protected function setUp()

--- a/tests/Mockery/MockingInternalModuleClassWithOptionalParameterByReferenceTest.php
+++ b/tests/Mockery/MockingInternalModuleClassWithOptionalParameterByReferenceTest.php
@@ -20,50 +20,50 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 class MockingInternalModuleClassWithOptionalParameterByReferenceTest extends MockeryTestCase
 {
-	protected function setUp()
-	{
-		if (!extension_loaded('memcache')) {
-			$this->markTestSkipped('ext/memcache not installed');
-		}
-		parent::setUp();
-	}
+    protected function setUp()
+    {
+        if (!extension_loaded('memcache')) {
+            $this->markTestSkipped('ext/memcache not installed');
+        }
+        parent::setUp();
+    }
 
-	protected function tearDown()
-	{
-		static::closeMockery();
-		parent::tearDown();
-	}
+    protected function tearDown()
+    {
+        static::closeMockery();
+        parent::tearDown();
+    }
 
-	/**
-	 * Regression for {@see https://github.com/mockery/mockery/issues/757 issue#757}
-	 *
-	 * @test
-	 */
-	public function mockingInternalModuleClassWithOptionalParameterByReferenceMayNotBreakCodeGeneration()
-	{
-		// this works for macOS
-		\Mockery::getConfiguration()
-			->setInternalClassMethodParamMap('Memcache', 'get', array('$id', '&$flags = null'));
-		// strange thing is, the reflected class under linux is MemcachePool not Memcache
-		\Mockery::getConfiguration()
-			->setInternalClassMethodParamMap('MemcachePool', 'get', array('$id', '&$flags = null'));
-		$memcache = \Mockery::mock('Memcache');
-		$memcache->shouldReceive('get')
-			->with(
-				$id = 'foobar',
-				\Mockery::on(
-					function (&$flags) {
-						$valid = null === $flags;
-						$flags = 255;
-						return $valid;
-					}
-				)
-			)
-			->once()
-			->andReturn($expected = time());
-		$paramFlags = null;
-		$this->assertSame($expected, $memcache->get($id, $paramFlags));
-		\Mockery::close();
-		$this->assertSame(255, $paramFlags);
-	}
+    /**
+     * Regression for {@see https://github.com/mockery/mockery/issues/757 issue#757}
+     *
+     * @test
+     */
+    public function mockingInternalModuleClassWithOptionalParameterByReferenceMayNotBreakCodeGeneration()
+    {
+        // this works for macOS
+        \Mockery::getConfiguration()
+            ->setInternalClassMethodParamMap('Memcache', 'get', array('$id', '&$flags = null'));
+        // strange thing is, the reflected class under linux is MemcachePool not Memcache
+        \Mockery::getConfiguration()
+            ->setInternalClassMethodParamMap('MemcachePool', 'get', array('$id', '&$flags = null'));
+        $memcache = \Mockery::mock('Memcache');
+        $memcache->shouldReceive('get')
+            ->with(
+                $id = 'foobar',
+                \Mockery::on(
+                    function (&$flags) {
+                        $valid = null === $flags;
+                        $flags = 255;
+                        return $valid;
+                    }
+                )
+            )
+            ->once()
+            ->andReturn($expected = time());
+        $paramFlags = null;
+        $this->assertSame($expected, $memcache->get($id, $paramFlags));
+        \Mockery::close();
+        $this->assertSame(255, $paramFlags);
+    }
 }

--- a/tests/Mockery/MockingInternalModuleClassWithOptionalParameterByReferenceTest.php
+++ b/tests/Mockery/MockingInternalModuleClassWithOptionalParameterByReferenceTest.php
@@ -15,6 +15,7 @@
  */
 
 namespace test\Mockery;
+
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 
@@ -49,7 +50,7 @@ class MockingInternalModuleClassWithOptionalParameterByReferenceTest extends Moc
             ->with(
                 $id = 'foobar',
                 \Mockery::on(
-                    function (&$flags) use ($self){
+                    function (&$flags) use ($self) {
                         $self->assertNull($flags);
                         $flags = 255;
                         return true;
@@ -62,5 +63,4 @@ class MockingInternalModuleClassWithOptionalParameterByReferenceTest extends Moc
         $this->assertSame($expected, $memcache->get($id, $paramFlags));
         $this->assertSame(255, $paramFlags);
     }
-
 }

--- a/travis/extra.ini
+++ b/travis/extra.ini
@@ -1,2 +1,3 @@
 extension = "mongo.so"
 extension = "redis.so"
+extension = "memcache.so"


### PR DESCRIPTION
This will fix issue: https://github.com/mockery/mockery/issues/757, which describes, that Mockery will actually fail to create proper code, when overriding the parameter map with optional parameters passed by reference, e.g. [Memcache::get()](http://php.net/manual/en/memcache.get.php).