### PR TITLE
support PHPStorm autocompletion

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -4,5 +4,14 @@ namespace PHPSTORM_META {
         \Mockery::mock('') => [
             "" == "@",
         ],
+        \Mockery::spy('') => [
+            "" == "@",
+        ],
+        \mock('') => [
+            "" == "@",
+        ],
+        \spy('') => [
+            "" == "@",
+        ],
     ];
 }

--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -1,0 +1,8 @@
+<?php
+namespace PHPSTORM_META {
+    $STATIC_METHOD_TYPES = [
+        \Mockery::mock('') => [
+            "" == "@",
+        ],
+    ];
+}

--- a/library/helpers.php
+++ b/library/helpers.php
@@ -25,21 +25,21 @@ use Mockery\Matcher\NoArgs;
 if (!function_exists("mock")) {
     function mock(...$args)
     {
-        return call_user_func_array([Mockery::class, "mock"], $args);
+        return Mockery::mock(...$args);
     }
 }
 
 if (!function_exists("spy")) {
     function spy(...$args)
     {
-        return call_user_func_array([Mockery::class, "spy"], $args);
+        return Mockery::spy(...$args);
     }
 }
 
 if (!function_exists("namedMock")) {
     function namedMock(...$args)
     {
-        return call_user_func_array([Mockery::class, "namedMock"], $args);
+        return Mockery::namedMock(...$args);
     }
 }
 


### PR DESCRIPTION
when I use mockery in phpstorm, mockery doesn't work autocompletion perfectly.

so i make `.phpstorm.meta.php`, how about apply this PR? :-)


**before**

<img width="506" alt="2017-06-07 3 52 24" src="https://user-images.githubusercontent.com/4086535/26865826-60d5641a-4b99-11e7-8b6b-e4c30cbf4856.png">

**after**

<img width="507" alt="2017-06-07 3 52 34" src="https://user-images.githubusercontent.com/4086535/26865827-6204adf0-4b99-11e7-964c-3e378a2aec8e.png">
