### PR TITLE
Custom object formatters

### DIFF
--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -662,23 +662,20 @@ class Mockery
             return array('...');
         }
 
+        $defaultFormatter = function ($object, $nesting) {
+            return array('properties' => self::extractInstancePublicProperties($object, $nesting));
+        };
+
         $class = get_class($object);
-        $customFormatterClass = self::getConfiguration()->findObjectFormatter($class);
+
+        $formatter = self::getConfiguration()->getObjectFormatter($class, $defaultFormatter);
 
         $array = array(
           'class' => $class,
           'identity' => '#' . md5(spl_object_hash($object))
         );
 
-        if ($customFormatterClass) {
-            $customFormatter = self::getConfiguration()->getObjectFormatter($customFormatterClass);
-            $array = array_merge($array, $customFormatter($object));
-        } else {
-            $array = array_merge(
-                $array,
-                array('properties' => self::extractInstancePublicProperties($object, $nesting))
-            );
-        }
+        $array = array_merge($array, $formatter($object, $nesting));
 
         return $array;
     }

--- a/library/Mockery/Configuration.php
+++ b/library/Mockery/Configuration.php
@@ -68,6 +68,13 @@ class Configuration
     }
 
     /**
+     * Custom object formatters
+     *
+     * @var array
+     */
+    protected $_objectFormatters = array();
+
+    /**
      * Set boolean to allow/prevent mocking of non-existent methods
      *
      * @param bool $flag
@@ -210,5 +217,31 @@ class Configuration
     public function reflectionCacheEnabled()
     {
         return $this->_reflectionCacheEnabled;
+    }
+
+    public function setObjectFormatter($class, $formatterCallback)
+    {
+        $this->_objectFormatters[$class] = $formatterCallback;
+    }
+
+    public function findObjectFormatter($class)
+    {
+        $parentClass = $class;
+        do {
+            $classes[] = $parentClass;
+            $parentClass = get_parent_class($parentClass);
+        } while ($parentClass);
+        $classesAndInterfaces = array_merge($classes, class_implements($class));
+        foreach ($classesAndInterfaces as $type) {
+            if (isset($this->_objectFormatters[$type])) {
+                return $type;
+            }
+        }
+        return null;
+    }
+
+    public function getObjectFormatter($class)
+    {
+        return $this->_objectFormatters[$class];
     }
 }

--- a/library/Mockery/Configuration.php
+++ b/library/Mockery/Configuration.php
@@ -224,7 +224,7 @@ class Configuration
         $this->_objectFormatters[$class] = $formatterCallback;
     }
 
-    public function findObjectFormatter($class)
+    public function getObjectFormatter($class, $defaultFormatter)
     {
         $parentClass = $class;
         do {
@@ -234,14 +234,9 @@ class Configuration
         $classesAndInterfaces = array_merge($classes, class_implements($class));
         foreach ($classesAndInterfaces as $type) {
             if (isset($this->_objectFormatters[$type])) {
-                return $type;
+                return $this->_objectFormatters[$type];
             }
         }
-        return null;
-    }
-
-    public function getObjectFormatter($class)
-    {
-        return $this->_objectFormatters[$class];
+        return $defaultFormatter;
     }
 }

--- a/tests/Mockery/WithCustomFormatterExpectationTest.php
+++ b/tests/Mockery/WithCustomFormatterExpectationTest.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ *
+ * @category     Mockery
+ * @package        Mockery
+ * @subpackage UnitTests
+ * @copyright    Copyright (c) 2010 Pádraic Brady (http://blog.astrumfutura.com)
+ * @license        http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class WithCustomFormatterExpectationTest extends TestCase
+{
+    public function setUp(): void
+    {
+        \Mockery::getConfiguration()->setObjectFormatter(
+            'ClassWithCustomFormatter',
+            function ($object) {
+                return array(
+                    "properties" => array(
+                        "stringProperty" => $object->stringProperty
+                    ),
+                    "getters" => array(
+                        "gettedProperty" => $object->getArrayProperty()
+                    )
+                );
+            }
+        );
+        \Mockery::getConfiguration()->setObjectFormatter(
+            'InterfaceWithCustomFormatter',
+            function ($object) {
+                return array(
+                    "properties" => array(
+                        "stringProperty" => $object->stringProperty
+                    ),
+                    "getters" => array(
+                        "gettedProperty" => $object->getArrayProperty()
+                    )
+                );
+            }
+        );
+    }
+
+    /**
+     * @dataProvider findObjectFormatterDataProvider
+     */
+    public function testFindObjectFormatter($object, $expected)
+    {
+        $this->assertEquals(
+            $expected,
+            \Mockery::getConfiguration()->findObjectFormatter(get_class($object))
+        );
+    }
+
+    public function findObjectFormatterDataProvider()
+    {
+        return array(
+            array(
+                new \StdClass(),
+                null
+            ),
+            array(
+                new ClassWithoutCustomFormatter(),
+                null
+            ),
+            array(
+                new ClassWithCustomFormatter(),
+                'ClassWithCustomFormatter'
+            ),
+            array(
+                new ClasschildOfWithCustomFormatter(),
+                'ClassWithCustomFormatter'
+            ),
+            array(
+                new ClassImplementsWithCustomFormatter(),
+                'InterfaceWithCustomFormatter'
+            )
+        );
+    }
+
+    /**
+     * @dataProvider formatObjectsDataProvider
+     */
+    public function testFormatObjects($obj, $shouldContains, $shouldNotContains)
+    {
+        $string = Mockery::formatObjects(array($obj));
+        foreach ($shouldContains as $containString) {
+            $this->assertStringContainsString($containString, $string);
+        }
+        foreach ($shouldNotContains as $containString) {
+            $this->assertStringNotContainsString($containString, $string);
+        }
+    }
+
+    public function formatObjectsDataProvider()
+    {
+        return array(
+            array(
+                new ClassWithoutCustomFormatter(),
+                array(
+                    'stringProperty',
+                    'numberProperty',
+                    'arrayProperty'
+                ),
+                array(
+                    'privateProperty'
+                )
+            ),
+            array(
+                new ClassWithCustomFormatter(),
+                array(
+                    'stringProperty',
+                    'gettedProperty'
+                ),
+                array(
+                    'numberProperty',
+                    'privateProperty'
+                )
+            ),
+            array(
+                new ClassImplementsWithCustomFormatter(),
+                array(
+                    'stringProperty',
+                    'gettedProperty'
+                ),
+                array(
+                    'numberProperty',
+                    'privateProperty'
+                )
+            ),
+        );
+    }
+}
+
+class ClassWithoutCustomFormatter
+{
+    public $stringProperty = "a string";
+    public $numberProperty = 123;
+    public $arrayProperty = array('a', 'nother', 'array');
+    private $privateProperty = "private";
+}
+
+class ClassWithCustomFormatter
+{
+    public $stringProperty = "a string";
+    public $numberProperty = 123;
+    private $arrayProperty = array('a', 'nother', 'array');
+    private $privateProperty = "private";
+
+    public function getArrayProperty()
+    {
+        return $this->arrayProperty;
+    }
+}
+
+class ClassChildOfWithCustomFormatter extends ClassWithCustomFormatter
+{
+}
+
+interface InterfaceWithCustomFormatter
+{
+}
+
+class ClassImplementsWithCustomFormatter implements InterfaceWithCustomFormatter
+{
+    public $stringProperty = "a string";
+    public $numberProperty = 123;
+    private $privateProperty = "private";
+    private $arrayProperty = array('a', 'nother', 'array');
+
+    public function getArrayProperty()
+    {
+        return $this->arrayProperty;
+    }
+}

--- a/tests/Mockery/WithCustomFormatterExpectationTest.php
+++ b/tests/Mockery/WithCustomFormatterExpectationTest.php
@@ -27,8 +27,9 @@ class WithCustomFormatterExpectationTest extends TestCase
     {
         \Mockery::getConfiguration()->setObjectFormatter(
             'ClassWithCustomFormatter',
-            function ($object) {
+            function ($object, $nesting) {
                 return array(
+                    "formatter" => 'ClassWithCustomFormatter',
                     "properties" => array(
                         "stringProperty" => $object->stringProperty
                     ),
@@ -40,8 +41,9 @@ class WithCustomFormatterExpectationTest extends TestCase
         );
         \Mockery::getConfiguration()->setObjectFormatter(
             'InterfaceWithCustomFormatter',
-            function ($object) {
+            function ($object, $nesting) {
                 return array(
+                    "formatter" => 'InterfaceWithCustomFormatter',
                     "properties" => array(
                         "stringProperty" => $object->stringProperty
                     ),
@@ -54,17 +56,24 @@ class WithCustomFormatterExpectationTest extends TestCase
     }
 
     /**
-     * @dataProvider findObjectFormatterDataProvider
+     * @dataProvider getObjectFormatterDataProvider
      */
-    public function testFindObjectFormatter($object, $expected)
+    public function testGetObjectFormatter($object, $expected)
     {
+        $defaultFormatter = function ($class, $nesting) {
+            return null;
+        };
+
+        $formatter = \Mockery::getConfiguration()->getObjectFormatter(get_class($object), $defaultFormatter);
+        $formatted = $formatter($object, 1);
+
         $this->assertEquals(
             $expected,
-            \Mockery::getConfiguration()->findObjectFormatter(get_class($object))
+            $formatted ? $formatted['formatter'] : null
         );
     }
 
-    public function findObjectFormatterDataProvider()
+    public function getObjectFormatterDataProvider()
     {
         return array(
             array(


### PR DESCRIPTION
Possibility to set custom objet formatters for specific classes or interfaces. If formatter is set it's used instead of default formatter outputing public properties.

```
        \Mockery::getConfiguration()->setObjectFormatter(
            'ClassWithCustomFormatter',
            function($object) {
                return array(
                    "properties" => array(
                        "stringProperty" => $object->stringProperty
                    ),
                    "getters" => array(
                        "gettedProperty" => $object->getArrayProperty()
                    )
                );
            }
        );
```