### PR TITLE
Fix risky tests

### DIFF
--- a/library/Mockery/Adapter/Phpunit/TestListener.php
+++ b/library/Mockery/Adapter/Phpunit/TestListener.php
@@ -69,4 +69,11 @@ class TestListener extends BaseTestListener
         $result = $test->getTestResultObject();
         $result->addFailure($test, $e, $time);
     }
+
+    public function startTestSuite(\PHPUnit\Framework\TestSuite $suite)
+    {
+        \PHPUnit\Util\Blacklist::$blacklistedClassNames[\Mockery\Mockery::class] = 1;
+
+        parent::startTestSuite($suite);
+    }
 }

--- a/tests/Mockery/Adapter/Phpunit/TestListenerTest.php
+++ b/tests/Mockery/Adapter/Phpunit/TestListenerTest.php
@@ -83,6 +83,15 @@ class Mockery_Adapter_Phpunit_TestListenerTest extends TestCase
         $mock->bar();
         \Mockery::close();
     }
+
+    public function testMockeryIsAddedToBlacklist()
+    {
+        $suite = \Mockery::mock(\PHPUnit\Framework\TestSuite::class);
+
+        $this->assertArrayNotHasKey(\Mockery\Mock::class, \PHPUnit\Util\Blacklist::$blacklistedClassNames);
+        $this->listener->startTestSuite($suite);
+        $this->assertSame(1, \PHPUnit\Util\Blacklist::$blacklistedClassNames[\Mockery\Mockery::class]);
+    }
 }
 
 class EmptyTestCase extends TestCase


### PR DESCRIPTION
Using mockery 1.0-dev we get a lot of warnings and [risky tests](https://github.com/mockery/mockery/issues/742) this PR fixes the issue.

In Mockery.php on line 163 there's an `@unlink` which phpunit warns about if xdebug is enabled.

```
unlink() used in /Users/marijn/my-project/vendor/mockery/mockery/library/Mockery.php:163
```

To fix this you can add Mockery to the Blacklist in phpunit so it's ignored and tests are no longer marked risky because of this `@unlink`.

--

Maybe there is a better way/place to put this, as I read that the Listener is kind of deprecated in version 6.  But I couldn't find a better place. As the Listener allows you to do it `onSuiteStart` which is better than always doing it `onTestStart`.

The Listener also makes the user aware in case you don't call `Mockery::close`, which is nice, as we've already had some places where we didn't call it (because we forgot to use the Trait), and the tests where green, while in fact the expectations were not met.

So I actually like to use the Listener for this sake. Although the downside is that you need every test to use the trait, even when you don't use expectations. But I guess that's a trade-off unless that can be fixed.

Let me know if there is a better place and it should be moved to somewhere else.

/edit: I noticed the tests are failing with old phpunit version still, unfortunately. But let's discuss the solution we want to go for first, then i'll fix it properly. (either another/new listener, or a listener-less way)