### PR TITLE
Cast expectedArgs to array (fix php7.2)

### DIFF
--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -324,7 +324,7 @@ class Expectation implements ExpectationInterface
             return $this->_matchArg($this->_expectedArgs[0], $args);
         }
         $argCount = count($args);
-        if ($argCount !== count($this->_expectedArgs)) {
+        if ($argCount !== count((array) $this->_expectedArgs)) {
             return false;
         }
         for ($i=0; $i<$argCount; $i++) {


### PR DESCRIPTION
On PHP 7.2 count throws a warning when passing something that isn't an array or a implementation of Countable to the count function.

``` _expectedArgs ``` may be null sometimes, this causes [tests to fail](https://travis-ci.org/laravel/framework/jobs/257748808) on 7.2.