### PR TITLE
Set the InvalidCountException message using because($message);

### DIFF
--- a/library/Mockery/CountValidator/Exact.php
+++ b/library/Mockery/CountValidator/Exact.php
@@ -33,12 +33,15 @@ class Exact extends CountValidatorAbstract
     public function validate($n)
     {
         if ($this->_limit !== $n) {
+            $because = $this->_expectation->getExceptionMessage();
+
             $exception = new Mockery\Exception\InvalidCountException(
                 'Method ' . (string) $this->_expectation
                 . ' from ' . $this->_expectation->getMock()->mockery_getName()
                 . ' should be called' . PHP_EOL
                 . ' exactly ' . $this->_limit . ' times but called ' . $n
                 . ' times.'
+                . ($because ? ' Because ' . $this->_expectation->getExceptionMessage() : '')
             );
             $exception->setMock($this->_expectation->getMock())
                 ->setMethodName((string) $this->_expectation)

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -43,6 +43,13 @@ class Expectation implements ExpectationInterface
     protected $_name = null;
 
     /**
+     * Exception message
+     *
+     * @var null
+     */
+    protected $_because = null;
+
+    /**
      * Arguments expected by this expectation
      *
      * @var array
@@ -693,6 +700,19 @@ class Expectation implements ExpectationInterface
         return $this->atLeast()->times($minimum)->atMost()->times($maximum);
     }
 
+
+    /**
+     * Set the exception message
+     *
+     * @param string $message
+     * @return $this
+     */
+    public function because($message)
+    {
+        $this->_because = $message;
+        return $this;
+    }
+
     /**
      * Indicates that this expectation must be called in a specific given order
      *
@@ -811,5 +831,10 @@ class Expectation implements ExpectationInterface
     public function getName()
     {
         return $this->_name;
+    }
+
+    public function getExceptionMessage()
+    {
+        return $this->_because;
     }
 }

--- a/library/Mockery/ExpectationInterface.php
+++ b/library/Mockery/ExpectationInterface.php
@@ -30,6 +30,7 @@ namespace Mockery;
  * @method Expectation atLeast()
  * @method Expectation atMost()
  * @method Expectation between()
+ * @method Expectation because(string $message)
  */
 interface ExpectationInterface
 {

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -2090,6 +2090,18 @@ class ExpectationTest extends MockeryTestCase
         \Mockery::close();
     }
 
+    public function testCountWithBecauseExceptionMessage()
+    {
+        $this->expectException(InvalidCountException::class);
+        $this->expectExceptionMessage(
+            'Method foo(<Any Arguments>) from Mockery_0 should be called' . PHP_EOL . ' ' .
+            'exactly 1 times but called 0 times. Because We like foo'
+        );
+
+        $this->mock->shouldReceive('foo')->once()->because('We like foo');
+        Mockery::close();
+    }
+
     /** @test */
     public function it_uses_a_matchers_to_string_method_in_the_exception_output()
     {


### PR DESCRIPTION
Adds functionality for #264 

```php
// Add a message which will be displayed in the exception message
$mock->shouldReceive('foo')->once()->because('We like foo');
```