### PR TITLE
- Backported Pull request 781 to Mockery 0.9: Added possibility to ad…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * This will be the *last version to support PHP 5.3*
 * Added `Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration` trait
 * Added `makePartial` to `Mockery\MockInterface` as it was missing
+* Backported from master: Added possibility to add Constructor-Expectations on hard dependancies, read: Mockery::mock('overload:...')
 
 ## 0.9.3 (2014-12-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * This will be the *last version to support PHP 5.3*
 * Added `Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration` trait
 * Added `makePartial` to `Mockery\MockInterface` as it was missing
-* Backported from master: Added possibility to add Constructor-Expectations on hard dependancies, read: Mockery::mock('overload:...')
+* Backported from master: Added possibility to add Constructor-Expectations on hard dependencies, read: Mockery::mock('overload:...')
 
 ## 0.9.3 (2014-12-22)
 

--- a/library/Mockery/Generator/StringManipulation/Pass/InstanceMockPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/InstanceMockPass.php
@@ -36,6 +36,8 @@ class InstanceMockPass
             }
         }
         \Mockery::getContainer()->rememberMock(\$this);
+        
+        \$this->_mockery_constructorCalled(func_get_args());
     }
 MOCK;
 

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -675,8 +675,7 @@ class Mock implements MockInterface
             return call_user_func_array("parent::$method", $args);
         }
 
-        if (isset($this->_mockery_expectations[$method])
-        && !$this->_mockery_disableExpectationMatching) {
+        if (isset($this->_mockery_expectations[$method]) && !$this->_mockery_disableExpectationMatching) {
             $handler = $this->_mockery_expectations[$method];
 
             try {
@@ -754,5 +753,19 @@ class Mock implements MockInterface
                 return !$method->isPublic();
             })
         );
+    }
+
+    /**
+     * Called when an instance Mock was created and its constructor is getting called
+     *
+     * @see \Mockery\Generator\StringManipulation\Pass\InstanceMockPass
+     * @param array $args
+     */
+    protected function _mockery_constructorCalled(array $args)
+    {
+        if (!isset($this->_mockery_expectations['__construct']) /* _mockery_handleMethodCall runs the other checks */) {
+            return;
+        }
+        $this->_mockery_handleMethodCall('__construct', $args);
     }
 }

--- a/tests/Mockery/ContainerTest.php
+++ b/tests/Mockery/ContainerTest.php
@@ -728,6 +728,45 @@ class ContainerTest extends MockeryTestCase
         Mockery::resetContainer();
     }
 
+    public function testInstantiationOfInstanceMockWithConstructorParameterValidation()
+    {
+        $m = Mockery::mock('overload:MyNamespace\MyClass14');
+        $params = array(
+            'value1' => uniqid('test_')
+        );
+        $m->shouldReceive('__construct')->with($params);
+
+        new MyNamespace\MyClass14($params);
+    }
+
+    /**
+     * @expectedException \Mockery\Exception\NoMatchingExpectationException
+     */
+    public function testInstantiationOfInstanceMockWithConstructorParameterValidationNegative()
+    {
+        $m = Mockery::mock('overload:MyNamespace\MyClass15');
+        $params = array(
+            'value1' => uniqid('test_')
+        );
+        $m->shouldReceive('__construct')->with($params);
+
+        new MyNamespace\MyClass15(array());
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessageRegExp /^instanceMock \d{3}$/
+     */
+    public function testInstantiationOfInstanceMockWithConstructorParameterValidationException()
+    {
+        $m = Mockery::mock('overload:MyNamespace\MyClass16');
+        $m->shouldReceive('__construct')
+            ->andThrow(new \Exception('instanceMock '.rand(100, 999)));
+
+        new MyNamespace\MyClass16();
+    }
+
+
     public function testMethodParamsPassedByReferenceHaveReferencePreserved()
     {
         $m = $this->container->mock('MockeryTestRef1');

--- a/tests/Mockery/Generator/StringManipulation/Pass/InstanceMockPassTest.php
+++ b/tests/Mockery/Generator/StringManipulation/Pass/InstanceMockPassTest.php
@@ -20,5 +20,6 @@ class InstanceMockPassTest extends \PHPUnit_Framework_TestCase
         $code = $pass->apply('class Dave { }', $config);
         $this->assertContains('public function __construct', $code);
         $this->assertContains('protected $_mockery_ignoreVerification', $code);
+        $this->assertContains('this->_mockery_constructorCalled(func_get_args());', $code);
     }
 }


### PR DESCRIPTION
Backported Pull request 781 https://github.com/mockery/mockery/pull/781 to Mockery 0.9

When i ran the unittests this test failed, which i didnt fix:

test\Mockery\MockingInternalModuleClassWithOptionalParameterByReferenceTest::mockingInternalModuleClassWithOptionalParameterByReferenceMayNotBreakCodeGeneration
Declaration of Mockery_365_Memcache::get($id, &$flags = NULL) should be compatible with MemcachePool::get($param0, &$param1, &$param2)