### PR TITLE
Allows use of string method names in allows and expects

### DIFF
--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -234,15 +234,20 @@ class Mock implements MockInterface
 
     // start method allows
     /**
-     * @return self
+     * @param mixed $something  String method name or map of method => return
+     * @return self|\Mockery\ExpectationInterface|\Mockery\HigherOrderMessage
      */
-    public function allows(array $stubs = [])
+    public function allows($something = [])
     {
-        if (empty($stubs)) {
+        if (is_string($something)) {
+            return $this->shouldReceive($something);
+        }
+
+        if (empty($something)) {
             return $this->shouldReceive();
         }
 
-        foreach ($stubs as $method => $returnValue) {
+        foreach ($something as $method => $returnValue) {
             $this->shouldReceive($method)->andReturn($returnValue);
         }
 
@@ -252,10 +257,16 @@ class Mock implements MockInterface
 
     // start method expects
     /**
+     * @param mixed $something  String method name (optional)
      * @return ExpectsHigherOrderMessage
+     * @return \Mockery\ExpectationInterface|ExpectsHigherOrderMessage
      */
-    public function expects()
+    public function expects($something = null)
     {
+        if (is_string($something)) {
+            return $this->shouldReceive($something)->atLeast()->once();
+        }
+
         return new ExpectsHigherOrderMessage($this);
     }
     // end method expects

--- a/tests/Mockery/AllowsExpectsSyntaxTest.php
+++ b/tests/Mockery/AllowsExpectsSyntaxTest.php
@@ -67,10 +67,27 @@ class AllowsExpectsSyntaxTest extends TestCase
     }
 
     /** @test */
+    public function allowsCanTakeAString()
+    {
+        $stub = m::mock();
+        $stub->allows("foo")->andReturns("bar");
+        $this->assertEquals("bar", $stub->foo());
+    }
+
+    /** @test */
     public function expects_can_optionally_match_on_any_arguments()
     {
         $mock = m::mock();
         $mock->allows()->foo()->withAnyArgs()->andReturns(123);
+
+        $this->assertEquals(123, $mock->foo(456, 789));
+    }
+
+    /** @test */
+    public function expects_can_take_a_string()
+    {
+        $mock = m::mock();
+        $mock->allows("foo")->andReturns(123);
 
         $this->assertEquals(123, $mock->foo(456, 789));
     }

--- a/tests/Mockery/AllowsExpectsSyntaxTest.php
+++ b/tests/Mockery/AllowsExpectsSyntaxTest.php
@@ -87,7 +87,7 @@ class AllowsExpectsSyntaxTest extends TestCase
     public function expects_can_take_a_string()
     {
         $mock = m::mock();
-        $mock->allows("foo")->andReturns(123);
+        $mock->expects("foo")->andReturns(123);
 
         $this->assertEquals(123, $mock->foo(456, 789));
     }


### PR DESCRIPTION
What do we think?

I personally prefer to avoid the string names, but this makes the API more like the old API, at the slight cost of confusing return types for the `allows` and `expects` methods, although the `allows` already has mixed return thanks to the array of stubs functionality.