### PR TITLE
Issue 72

### DIFF
--- a/tests/Mockery/DemeterChainTest.php
+++ b/tests/Mockery/DemeterChainTest.php
@@ -28,7 +28,7 @@ class DemeterChainTest extends MockeryTestCase
 
     public function setUp()
     {
-        $this->mock = $this->mock = Mockery::mock('object')->shouldIgnoreMissing();
+        $this->mock = $this->mock = Mockery::mock('stdClass')->shouldIgnoreMissing();
     }
 
     public function tearDown()

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -1238,7 +1238,7 @@ class ExpectationTest extends MockeryTestCase
 
     public function testObjectConstraintMatchesArgument()
     {
-        $this->mock->shouldReceive('foo')->with(Mockery::type('object'))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::type('stdClass'))->once();
         $this->mock->foo(new stdClass);
         $this->container->mockery_verify();
     }
@@ -1246,7 +1246,7 @@ class ExpectationTest extends MockeryTestCase
     public function testObjectConstraintNonMatchingCase()
     {
         $this->mock->shouldReceive('foo')->times(3);
-        $this->mock->shouldReceive('foo')->with(1, Mockery::type('object`'))->never();
+        $this->mock->shouldReceive('foo')->with(1, Mockery::type('stdClass`'))->never();
         $this->mock->foo();
         $this->mock->foo(1);
         $this->mock->foo(1, 2, 3);
@@ -1258,7 +1258,7 @@ class ExpectationTest extends MockeryTestCase
      */
     public function testObjectConstraintThrowsExceptionWhenConstraintUnmatched()
     {
-        $this->mock->shouldReceive('foo')->with(Mockery::type('object'))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::type('stdClass'))->once();
         $this->mock->foo('f');
         $this->container->mockery_verify();
     }

--- a/tests/Mockery/NamedMockTest.php
+++ b/tests/Mockery/NamedMockTest.php
@@ -33,11 +33,11 @@ class NamedMockTest extends MockeryTestCase
     /** @test */
     public function itCreatesPassesFurtherArgumentsJustLikeMock()
     {
-        $mock = Mockery::namedMock("Mockery\Dave456", "DateTime", array(
+        $mock = Mockery::namedMock("Mockery\Dave456", "DateTimeZone", array(
             "getDave" => "dave"
         ));
 
-        $this->assertInstanceOf("DateTime", $mock);
+        $this->assertInstanceOf("DateTimeZone", $mock);
         $this->assertEquals("dave", $mock->getDave());
     }
 


### PR DESCRIPTION
Probably not perfect... but, without
```
PHPUnit 4.8.36 by Sebastian Bergmann and contributors.

Runtime:	PHP 7.2.0RC3
Configuration:	/work/GIT/mockery/phpunit.xml.dist

.................................................S.............  63 / 453 ( 13%)
.................S............................................. 126 / 453 ( 27%)
...PHP Fatal error:  Cannot use 'object' as class name as it is reserved in /tmp/Mockery5W5oj8 on line 1

```
With:

```
PHPUnit 4.8.36 by Sebastian Bergmann and contributors.

Runtime:	PHP 7.2.0RC3
Configuration:	/work/GIT/mockery/phpunit.xml.dist

.................................................S.............  63 / 453 ( 13%)
.................S............................................. 126 / 453 ( 27%)
............................................................... 189 / 453 ( 41%)
............................................................... 252 / 453 ( 55%)
............................................................... 315 / 453 ( 69%)
............................................................... 378 / 453 ( 83%)
.......S.................................................S..... 441 / 453 ( 97%)
............

Time: 479 ms, Memory: 62.00MB

There were 4 skipped tests:

```