### PR TITLE
Fix Spelling in Documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * Adds ability to create objects using traits
 * `Mockery\Matcher\MustBe` was deprecated
 * Marked `Mockery\MockInterface` as internal
-* Subset matcher matches recusively
+* Subset matcher matches recursively
 * BC BREAK - Spies return `null` by default from ignored (non-mocked) methods with nullable return type
 * Removed extracting getter methods of object instances
 * BC BREAK - Remove implicit regex matching when trying to match string arguments, introduce `\Mockery::pattern()` when regex matching is needed
@@ -47,7 +47,7 @@
 
 ## 0.9.2 (2014-09-03)
 
-* Some workarounds for the serilisation problems created by changes to PHP in 5.5.13, 5.4.29,
+* Some workarounds for the serialisation problems created by changes to PHP in 5.5.13, 5.4.29,
   5.6.
 * Demeter chains attempt to reuse doubles as they see fit, so for foo->bar and
   foo->baz, we'll attempt to use the same foo

--- a/docs/cookbook/class_constants.rst
+++ b/docs/cookbook/class_constants.rst
@@ -5,12 +5,12 @@ Class Constants
 ===============
 
 When creating a test double for a class, Mockery does not create stubs out of
-any class contants defined in the class we are mocking. Sometimes though, the
+any class constants defined in the class we are mocking. Sometimes though, the
 non-existence of these class constants, setup of the test, and the application
 code itself, it can lead to undesired behavior, and even a PHP error:
 ``PHP Fatal error:  Uncaught Error: Undefined class constant 'FOO' in ...```
 
-While supporting class contants in Mockery would be possible, it does require
+While supporting class constants in Mockery would be possible, it does require
 an awful lot of work, for a small number of use cases.
 
 We can, however, deal with these constants in a way supported by Mockery - by

--- a/docs/getting_started/upgrading.rst
+++ b/docs/getting_started/upgrading.rst
@@ -23,7 +23,7 @@ Since the release of 0.8.0 the following behaviours were altered:
 1. The ``shouldIgnoreMissing()`` behaviour optionally applied to mock objects
    returned an instance of ``\Mockery\Undefined`` when methods called did not
    match a known expectation. Since 0.8.0, this behaviour was switched to
-   returning ``null`` instead. You can restore the 0.7.2 behavour by using the
+   returning ``null`` instead. You can restore the 0.7.2 behaviour by using the
    following:
 
    .. code-block:: php

--- a/docs/reference/spies.rst
+++ b/docs/reference/spies.rst
@@ -150,5 +150,5 @@ We can set expectation on number of calls as well:
         ->foo('bar')
         ->twice();
 
-Unfortunatelly, due to limitations we can't support the same syntax for the
+Unfortunately, due to limitations we can't support the same syntax for the
 ``shouldNotHaveReceived()`` method.


### PR DESCRIPTION
Hi

Here are some minor improvements to the spelling in the documentation