### PR TITLE
Fix namespace in TestListener

### DIFF
--- a/library/Mockery/Adapter/Phpunit/TestListener.php
+++ b/library/Mockery/Adapter/Phpunit/TestListener.php
@@ -72,7 +72,7 @@ class TestListener extends BaseTestListener
 
     public function startTestSuite(\PHPUnit\Framework\TestSuite $suite)
     {
-        \PHPUnit\Util\Blacklist::$blacklistedClassNames[\Mockery\Mockery::class] = 1;
+        \PHPUnit\Util\Blacklist::$blacklistedClassNames[\Mockery::class] = 1;
 
         parent::startTestSuite($suite);
     }

--- a/tests/Mockery/Adapter/Phpunit/TestListenerTest.php
+++ b/tests/Mockery/Adapter/Phpunit/TestListenerTest.php
@@ -88,9 +88,9 @@ class Mockery_Adapter_Phpunit_TestListenerTest extends TestCase
     {
         $suite = \Mockery::mock(\PHPUnit\Framework\TestSuite::class);
 
-        $this->assertArrayNotHasKey(\Mockery\Mock::class, \PHPUnit\Util\Blacklist::$blacklistedClassNames);
+        $this->assertArrayNotHasKey(\Mockery::class, \PHPUnit\Util\Blacklist::$blacklistedClassNames);
         $this->listener->startTestSuite($suite);
-        $this->assertSame(1, \PHPUnit\Util\Blacklist::$blacklistedClassNames[\Mockery\Mockery::class]);
+        $this->assertSame(1, \PHPUnit\Util\Blacklist::$blacklistedClassNames[\Mockery::class]);
     }
 }
 


### PR DESCRIPTION
Apologies, I'm not sure where it went wrong, but the [previous PR](https://github.com/mockery/mockery/pull/769) had the wrong namespace. 

This fixes the namespace and test to use the correct one.