### PR TITLE
Bump PHPUnit 6 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "hamcrest/hamcrest-php": "~2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7|~6.1"
+        "phpunit/phpunit": "~5.7|~6.5"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
I've bumped `PHPUnit 6` version. This will help us test `PHP 7.2` in #814 