### PR TITLE
Clean elses

### DIFF
--- a/library/Mockery/Matcher/MustBe.php
+++ b/library/Mockery/Matcher/MustBe.php
@@ -35,9 +35,9 @@ class MustBe extends MatcherAbstract
     {
         if (!is_object($actual)) {
             return $this->_expected === $actual;
-        } else {
-            return $this->_expected == $actual;
         }
+
+        return $this->_expected == $actual;
     }
 
     /**

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -629,7 +629,7 @@ class Mock implements MockInterface
     public function mockery_isAnonymous()
     {
         $rfc = new \ReflectionClass($this);
-        
+
         // HHVM has a Stringish interface
         $interfaces = array_filter($rfc->getInterfaces(), function ($i) {
             return $i->getName() !== "Stringish";
@@ -846,9 +846,9 @@ class Mock implements MockInterface
                     return call_user_func_array(array($this->_mockery_defaultReturnValue, $method), $args);
                 } elseif (null === $this->_mockery_defaultReturnValue) {
                     return $this->mockery_returnValueForMethod($method);
-                } else {
-                    return $this->_mockery_defaultReturnValue;
                 }
+
+                return $this->_mockery_defaultReturnValue;
             }
         }
 


### PR DESCRIPTION
I've removed the `else`s when we have already returned something :put_litter_in_its_place: