### PR TITLE
Fix PHPdoc

### DIFF
--- a/library/Mockery/ExpectationInterface.php
+++ b/library/Mockery/ExpectationInterface.php
@@ -21,17 +21,6 @@
 
 namespace Mockery;
 
-/**
- * @method Expectation once()
- * @method Expectation zeroOrMoreTimes()
- * @method Expectation twice()
- * @method Expectation times(int $limit)
- * @method Expectation never()
- * @method Expectation atLeast()
- * @method Expectation atMost()
- * @method Expectation between()
- * @method Expectation because(string $message)
- */
 interface ExpectationInterface
 {
     /**

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -187,7 +187,7 @@ class Mock implements MockInterface
      *
      * @param array $methodNames,... one or many methods that are expected to be called in this mock
      *
-     * @return \Mockery\ExpectationInterface|\Mockery\HigherOrderMessage
+     * @return \Mockery\ExpectationInterface|\Mockery\Expectation|\Mockery\HigherOrderMessage
      */
     public function shouldReceive(...$methodNames)
     {
@@ -234,7 +234,7 @@ class Mock implements MockInterface
 
     /**
      * @param mixed $something  String method name or map of method => return
-     * @return self|\Mockery\ExpectationInterface|\Mockery\HigherOrderMessage
+     * @return self|\Mockery\ExpectationInterface|\Mockery\Expectation|\Mockery\HigherOrderMessage
      */
     public function allows($something = [])
     {
@@ -255,7 +255,7 @@ class Mock implements MockInterface
 
     /**
      * @param mixed $something  String method name (optional)
-     * @return \Mockery\ExpectationInterface|ExpectsHigherOrderMessage
+     * @return \Mockery\ExpectationInterface|\Mockery\Expectation|ExpectsHigherOrderMessage
      */
     public function expects($something = null)
     {
@@ -270,7 +270,7 @@ class Mock implements MockInterface
      * Shortcut method for setting an expectation that a method should not be called.
      *
      * @param array $methodNames one or many methods that are expected not to be called in this mock
-     * @return \Mockery\Expectation|\Mockery\HigherOrderMessage
+     * @return \\Mockery\ExpectationInterface|\Mockery\Expectation|\Mockery\HigherOrderMessage
      */
     public function shouldNotReceive(...$methodNames)
     {

--- a/library/Mockery/MockInterface.php
+++ b/library/Mockery/MockInterface.php
@@ -24,13 +24,13 @@ interface MockInterface
 {
     /**
      * @param mixed $something  String method name or map of method => return
-     * @return self|\Mockery\ExpectationInterface|\Mockery\HigherOrderMessage
+     * @return self|\Mockery\ExpectationInterface|\Mockery\Expectation|\Mockery\HigherOrderMessage
      */
     public function allows($something = []);
 
     /**
      * @param mixed $something  String method name (optional)
-     * @return \Mockery\ExpectationInterface|\Mockery\ExpectsHigherOrderMessage
+     * @return \Mockery\ExpectationInterface|\Mockery\Expectation|\Mockery\ExpectsHigherOrderMessage
      */
     public function expects($something = null);
 
@@ -48,7 +48,7 @@ interface MockInterface
      *
      * @param array ...$methodNames one or many methods that are expected to be called in this mock
      *
-     * @return \Mockery\ExpectationInterface|\Mockery\HigherOrderMessage
+     * @return \Mockery\ExpectationInterface|\Mockery\Expectation|\Mockery\HigherOrderMessage
      */
     public function shouldReceive(...$methodNames);
 
@@ -56,7 +56,7 @@ interface MockInterface
      * Shortcut method for setting an expectation that a method should not be called.
      *
      * @param array $methodNames one or many methods that are expected not to be called in this mock
-     * @return \Mockery\Expectation|\Mockery\HigherOrderMessage
+     * @return \Mockery\ExpectationInterface|\Mockery\Expectation|\Mockery\HigherOrderMessage
      */
     public function shouldNotReceive(...$methodNames);
 
@@ -84,7 +84,7 @@ interface MockInterface
      * @return Mock
      */
     public function shouldDeferMissing();
-    
+
     /**
      * Set mock to defer unexpected methods to its parent if possible
      *


### PR DESCRIPTION
Some methods contain phpdoc with return type of `ExpectationInterface`, but this interface contains only a very limited set of methods compared to the actual implementation in `Expectation`. This cases various problems with autocompletion in IDEs.
A previous attempt to solve this used `@method` annotations on `ExpectationInterface`, but this approach did not cover all the necessary methods, and furthermore is simply wrong - either every implementor supports all the methods and they should be defined in PHP code of the interface, or they don't in which case additional `@method` annotations are wrong.