### PR TITLE
Updated protected method mocking exception message

### DIFF
--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -215,7 +215,7 @@ class Mock implements MockInterface
                         throw new \InvalidArgumentException("$method() cannot be mocked as it is a private method");
                     }
                     if (!$allowMockingProtectedMethods && $rm->isProtected()) {
-                        throw new \InvalidArgumentException("$method() cannot be mocked as it is a protected method and mocking protected methods is not enabled for the currently used mock object.");
+                        throw new \InvalidArgumentException("$method() cannot be mocked as it is a protected method and mocking protected methods is not enabled for the currently used mock object. Use shouldAllowMockingProtectedMethods() to enable mocking of protected methods.");
                     }
                 }
 


### PR DESCRIPTION
Sorry for the unsolicited PR.

I just had a test error from trying to mock a protected method. I thought it might be useful if the message explained how to enable mocking protected methods on the mock object. It seems like if a developer is getting the error message then there's a good chance they want to mock the protected method.