### PR TITLE
Fixes from PHPStan

### DIFF
--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -34,7 +34,7 @@ class Mockery
     /**
      * Global container to hold all mocks for the current unit test running.
      *
-     * @var \Mockery\Container
+     * @var \Mockery\Container|null
      */
     protected static $_container = null;
 
@@ -485,7 +485,7 @@ class Mockery
      * @param mixed $argument
      * @param int $depth
      *
-     * @return string
+     * @return mixed
      */
     private static function formatArgument($argument, $depth = 0)
     {

--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -73,7 +73,7 @@ class Mockery
     /**
      * Static shortcut to \Mockery\Container::mock().
      *
-     * @param array $args
+     * @param array ...$args
      *
      * @return \Mockery\MockInterface
      */
@@ -86,7 +86,7 @@ class Mockery
      * Static and semantic shortcut for getting a mock from the container
      * and applying the spy's expected behavior into it.
      *
-     * @param array $args
+     * @param array ...$args
      *
      * @return \Mockery\MockInterface
      */
@@ -98,7 +98,7 @@ class Mockery
     /**
      * Static and Semantic shortcut to \Mockery\Container::mock().
      *
-     * @param array $args
+     * @param array ...$args
      *
      * @return \Mockery\MockInterface
      */
@@ -110,7 +110,7 @@ class Mockery
     /**
      * Static shortcut to \Mockery\Container::mock(), first argument names the mock.
      *
-     * @param array $args
+     * @param array ...$args
      *
      * @return \Mockery\MockInterface
      */
@@ -169,7 +169,7 @@ class Mockery
     /**
      * Static fetching of a mock associated with a name or explicit class poser.
      *
-     * @param $name
+     * @param string $name
      *
      * @return \Mockery\Mock
      */
@@ -299,7 +299,7 @@ class Mockery
     /**
      * Return instance of TYPE matcher.
      *
-     * @param $expected
+     * @param mixed $expected
      *
      * @return \Mockery\Matcher\Type
      */
@@ -311,7 +311,7 @@ class Mockery
     /**
      * Return instance of DUCKTYPE matcher.
      *
-     * @param array $args
+     * @param array ...$args
      *
      * @return \Mockery\Matcher\Ducktype
      */
@@ -336,7 +336,7 @@ class Mockery
     /**
      * Return instance of CONTAINS matcher.
      *
-     * @param array $args
+     * @param array ...$args
      *
      * @return \Mockery\Matcher\Contains
      */
@@ -348,7 +348,7 @@ class Mockery
     /**
      * Return instance of HASKEY matcher.
      *
-     * @param $key
+     * @param mixed $key
      *
      * @return \Mockery\Matcher\HasKey
      */
@@ -360,7 +360,7 @@ class Mockery
     /**
      * Return instance of HASVALUE matcher.
      *
-     * @param $val
+     * @param mixed $val
      *
      * @return \Mockery\Matcher\HasValue
      */
@@ -372,7 +372,7 @@ class Mockery
     /**
      * Return instance of CLOSURE matcher.
      *
-     * @param $closure
+     * @param mixed $closure
      *
      * @return \Mockery\Matcher\Closure
      */
@@ -384,7 +384,7 @@ class Mockery
     /**
      * Return instance of MUSTBE matcher.
      *
-     * @param $expected
+     * @param mixed $expected
      *
      * @return \Mockery\Matcher\MustBe
      */
@@ -396,7 +396,7 @@ class Mockery
     /**
      * Return instance of NOT matcher.
      *
-     * @param $expected
+     * @param mixed $expected
      *
      * @return \Mockery\Matcher\Not
      */
@@ -408,7 +408,7 @@ class Mockery
     /**
      * Return instance of ANYOF matcher.
      *
-     * @param array $args
+     * @param array ...$args
      *
      * @return \Mockery\Matcher\AnyOf
      */
@@ -420,7 +420,7 @@ class Mockery
     /**
      * Return instance of NOTANYOF matcher.
      *
-     * @param array $args
+     * @param array ...$args
      *
      * @return \Mockery\Matcher\NotAnyOf
      */
@@ -432,7 +432,7 @@ class Mockery
     /**
      * Return instance of PATTERN matcher.
      *
-     * @param $expected
+     * @param mixed $expected
      *
      * @return \Mockery\Matcher\Pattern
      */
@@ -482,8 +482,8 @@ class Mockery
      * Gets the string representation
      * of any passed argument.
      *
-     * @param $argument
-     * @param $depth
+     * @param mixed $argument
+     * @param int $depth
      *
      * @return string
      */
@@ -572,7 +572,7 @@ class Mockery
     /**
      * Utility function to turn public properties and public get* and is* method values into an array.
      *
-     * @param     $object
+     * @param object $object
      * @param int $nesting
      *
      * @return array
@@ -592,8 +592,8 @@ class Mockery
     /**
      * Returns all public instance properties.
      *
-     * @param $object
-     * @param $nesting
+     * @param mixed $object
+     * @param int $nesting
      *
      * @return array
      */
@@ -617,8 +617,8 @@ class Mockery
      * Utility method used for recursively generating
      * an object or array representation.
      *
-     * @param $argument
-     * @param $nesting
+     * @param mixed $argument
+     * @param int $nesting
      *
      * @return mixed
      */
@@ -670,7 +670,7 @@ class Mockery
      * expectations from such as needed.
      *
      * @param Mockery\MockInterface $mock
-     * @param array $args
+     * @param array ...$args
      * @param callable $add
      * @return \Mockery\CompositeExpectation
      */

--- a/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegration.php
+++ b/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegration.php
@@ -56,7 +56,7 @@ trait MockeryPHPUnitIntegration
 
         foreach (Mockery::getContainer()->mockery_thrownExceptions() as $e) {
             if (!$e->dismissed()) {
-                $this->markAsRisky('Mockery found an exception that appears to have been swallowed: '.$e->getMessage());
+                $this->markAsRisky();
             }
         }
     }

--- a/library/Mockery/CompositeExpectation.php
+++ b/library/Mockery/CompositeExpectation.php
@@ -41,7 +41,7 @@ class CompositeExpectation implements ExpectationInterface
     }
 
     /**
-     * @param mixed ...
+     * @param mixed ...$args
      */
     public function andReturn(...$args)
     {
@@ -51,7 +51,7 @@ class CompositeExpectation implements ExpectationInterface
     /**
      * Set a return value, or sequential queue of return values
      *
-     * @param mixed ...
+     * @param mixed ...$args
      * @return self
      */
     public function andReturns(...$args)
@@ -112,7 +112,7 @@ class CompositeExpectation implements ExpectationInterface
      * Starts a new expectation addition on the first mock which is the primary
      * target outside of a demeter chain
      *
-     * @param mixed ...
+     * @param mixed ...$args
      * @return \Mockery\Expectation
      */
     public function shouldReceive(...$args)

--- a/library/Mockery/Configuration.php
+++ b/library/Mockery/Configuration.php
@@ -50,7 +50,7 @@ class Configuration
     /**
      * Set boolean to allow/prevent mocking of non-existent methods
      *
-     * @param bool
+     * @param bool $flag
      */
     public function allowMockingNonExistentMethods($flag = true)
     {
@@ -72,7 +72,7 @@ class Configuration
      *
      * Set boolean to allow/prevent unnecessary mocking of methods
      *
-     * @param bool
+     * @param bool $flag
      */
     public function allowMockingMethodsUnnecessarily($flag = true)
     {

--- a/library/Mockery/Container.php
+++ b/library/Mockery/Container.php
@@ -85,7 +85,7 @@ class Container
      * names or partials - just so long as it's something that can be mocked.
      * I'll refactor it one day so it's easier to follow.
      *
-     * @param array $args
+     * @param array ...$args
      *
      * @return Mock
      * @throws Exception\RuntimeException
@@ -427,7 +427,7 @@ class Container
     /**
      * Store a mock and set its container reference
      *
-     * @param \Mockery\Mock
+     * @param \Mockery\Mock $mock
      * @return \Mockery\MockInterface
      */
     public function rememberMock(\Mockery\MockInterface $mock)

--- a/library/Mockery/Container.php
+++ b/library/Mockery/Container.php
@@ -96,6 +96,7 @@ class Container
         $quickdefs = array();
         $constructorArgs = null;
         $blocks = array();
+        $class = null;
 
         if (count($args) > 1) {
             $finalArg = end($args);
@@ -191,7 +192,6 @@ class Container
         $builder->addBlackListedMethods($blocks);
 
         if (defined('HHVM_VERSION')
-            && isset($class)
             && ($class === 'Exception' || is_subclass_of($class, 'Exception'))) {
             $builder->addBlackListedMethod("setTraceOptions");
             $builder->addBlackListedMethod("getTraceOptions");

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -31,7 +31,7 @@ class Expectation implements ExpectationInterface
     /**
      * Mock object to which this expectation belongs
      *
-     * @var object
+     * @var \Mockery\MockInterface
      */
     protected $_mock = null;
 
@@ -45,7 +45,7 @@ class Expectation implements ExpectationInterface
     /**
      * Exception message
      *
-     * @var null
+     * @var string|null
      */
     protected $_because = null;
 

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -348,7 +348,7 @@ class Expectation implements ExpectationInterface
      * Check if passed argument matches an argument expectation
      *
      * @param mixed $expected
-     * @param mixed &$actual
+     * @param mixed $actual
      * @return bool
      */
     protected function _matchArg($expected, &$actual)
@@ -377,7 +377,7 @@ class Expectation implements ExpectationInterface
     /**
      * Expected argument setter for the expectation
      *
-     * @param mixed[] ...
+     * @param mixed[] ...$args
      * @return self
      */
     public function with(...$args)
@@ -457,7 +457,7 @@ class Expectation implements ExpectationInterface
     /**
      * Set a return value, or sequential queue of return values
      *
-     * @param mixed[] ...
+     * @param mixed[] ...$args
      * @return self
      */
     public function andReturn(...$args)
@@ -469,7 +469,7 @@ class Expectation implements ExpectationInterface
     /**
      * Set a return value, or sequential queue of return values
      *
-     * @param mixed[] ...
+     * @param mixed[] ...$args
      * @return self
      */
     public function andReturns(...$args)
@@ -504,7 +504,7 @@ class Expectation implements ExpectationInterface
      * values. The arguments passed to the expected method are passed to the
      * closures as parameters.
      *
-     * @param callable[] $args
+     * @param callable[] ...$args
      * @return self
      */
     public function andReturnUsing(...$args)
@@ -590,7 +590,7 @@ class Expectation implements ExpectationInterface
      * Register values to be set to a public property each time this expectation occurs
      *
      * @param string $name
-     * @param array $values
+     * @param array ...$values
      * @return self
      */
     public function andSet($name, ...$values)

--- a/library/Mockery/ExpectationDirector.php
+++ b/library/Mockery/ExpectationDirector.php
@@ -150,7 +150,7 @@ class ExpectationDirector
      * Make the given expectation a default for all others assuming it was
      * correctly created last
      *
-     * @param \Mockery\Expectation
+     * @param \Mockery\Expectation $expectation
      */
     public function makeExpectationDefault(\Mockery\Expectation $expectation)
     {

--- a/library/Mockery/ExpectationInterface.php
+++ b/library/Mockery/ExpectationInterface.php
@@ -45,7 +45,7 @@ interface ExpectationInterface
     public function getMock();
 
     /**
-     * @param array $args
+     * @param array ...$args
      * @return self
      */
     public function andReturn(...$args);

--- a/library/Mockery/ExpectsHigherOrderMessage.php
+++ b/library/Mockery/ExpectsHigherOrderMessage.php
@@ -24,7 +24,7 @@ class ExpectsHigherOrderMessage extends HigherOrderMessage
 {
     public function __construct(MockInterface $mock)
     {
-        return parent::__construct($mock, "shouldReceive");
+        parent::__construct($mock, "shouldReceive");
     }
     /**
      * @return \Mockery\Expectation

--- a/library/Mockery/Generator/StringManipulation/Pass/MagicMethodTypeHintsPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/MagicMethodTypeHintsPass.php
@@ -50,7 +50,7 @@ class MagicMethodTypeHintsPass implements Pass
     /**
      * Apply implementation.
      *
-     * @param int $code
+     * @param string $code
      * @param MockConfiguration $config
      * @return string
      */

--- a/library/Mockery/Generator/StringManipulation/Pass/MagicMethodTypeHintsPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/MagicMethodTypeHintsPass.php
@@ -50,7 +50,7 @@ class MagicMethodTypeHintsPass implements Pass
     /**
      * Apply implementation.
      *
-     * @param $code
+     * @param int $code
      * @param MockConfiguration $config
      * @return string
      */
@@ -90,7 +90,7 @@ class MagicMethodTypeHintsPass implements Pass
      * Applies type hints of magic methods from
      * class to the passed code.
      *
-     * @param $code
+     * @param int $code
      * @param Method $method
      * @return string
      */
@@ -113,7 +113,7 @@ class MagicMethodTypeHintsPass implements Pass
     /**
      * Checks if the method is declared withing code.
      *
-     * @param $code
+     * @param int $code
      * @param Method $method
      * @return boolean
      */
@@ -129,7 +129,7 @@ class MagicMethodTypeHintsPass implements Pass
      * Returns the method original parameters, as they're
      * described in the $code string.
      *
-     * @param $code
+     * @param int $code
      * @param Method $method
      * @return array
      */

--- a/library/Mockery/Generator/TargetClassInterface.php
+++ b/library/Mockery/Generator/TargetClassInterface.php
@@ -27,7 +27,7 @@ interface TargetClassInterface
      * TargetClassInterface's
      * implementation.
      *
-     * @param $name
+     * @param string $name
      * @return TargetClassInterface
      */
     public static function factory($name);
@@ -92,7 +92,7 @@ interface TargetClassInterface
      * Returns whether the targetClass is in
      * the passed interface.
      *
-     * @param $interface
+     * @param mixed $interface
      * @return boolean
      */
     public function implementsInterface($interface);

--- a/library/Mockery/Matcher/PHPUnitConstraint.php
+++ b/library/Mockery/Matcher/PHPUnitConstraint.php
@@ -28,7 +28,7 @@ class PHPUnitConstraint extends MatcherAbstract
     protected $rethrow;
 
     /**
-     * @param \PHPUnit\Framework\Constraint $constraint
+     * @param \PHPUnit\Framework\Constraint|\PHPUnit_Framework_Constraint $constraint
      * @param bool $rethrow
      */
     public function __construct($constraint, $rethrow = false)

--- a/library/Mockery/Matcher/PHPUnitConstraint.php
+++ b/library/Mockery/Matcher/PHPUnitConstraint.php
@@ -28,7 +28,7 @@ class PHPUnitConstraint extends MatcherAbstract
     protected $rethrow;
 
     /**
-     * @param \PHPUnit\Framework\Constraint|\PHPUnit_Framework_Constraint $constraint
+     * @param mixed $constraint
      * @param bool $rethrow
      */
     public function __construct($constraint, $rethrow = false)

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -201,14 +201,11 @@ class Mock implements MockInterface
             }
         }
 
-        /** @var array $nonPublicMethods */
-        $nonPublicMethods = $this->getNonPublicMethods();
-
         $self = $this;
         $allowMockingProtectedMethods = $this->_mockery_allowMockingProtectedMethods;
 
         $lastExpectation = \Mockery::parseShouldReturnArgs(
-            $this, $methodNames, function ($method) use ($self, $nonPublicMethods, $allowMockingProtectedMethods) {
+            $this, $methodNames, function ($method) use ($self, $allowMockingProtectedMethods) {
                 $rm = $self->mockery_getMethod($method);
                 if ($rm) {
                     if ($rm->isPrivate()) {

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -185,7 +185,7 @@ class Mock implements MockInterface
     /**
      * Set expected method calls
      *
-     * @param array $methodNames,... one or many methods that are expected to be called in this mock
+     * @param array ...$methodNames one or many methods that are expected to be called in this mock
      *
      * @return \Mockery\ExpectationInterface|\Mockery\HigherOrderMessage
      */
@@ -266,7 +266,7 @@ class Mock implements MockInterface
     /**
      * Shortcut method for setting an expectation that a method should not be called.
      *
-     * @param array $methodNames one or many methods that are expected not to be called in this mock
+     * @param array ...$methodNames one or many methods that are expected not to be called in this mock
      * @return \Mockery\Expectation|\Mockery\HigherOrderMessage
      */
     public function shouldNotReceive(...$methodNames)

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -759,8 +759,8 @@ class Mock implements MockInterface
 
     protected static function _mockery_handleStaticMethodCall($method, array $args)
     {
+        $associatedRealObject = \Mockery::fetchMock(__CLASS__);
         try {
-            $associatedRealObject = \Mockery::fetchMock(__CLASS__);
             return $associatedRealObject->__call($method, $args);
         } catch (BadMethodCallException $e) {
             throw new BadMethodCallException(

--- a/library/Mockery/MockInterface.php
+++ b/library/Mockery/MockInterface.php
@@ -55,7 +55,7 @@ interface MockInterface
     /**
      * Shortcut method for setting an expectation that a method should not be called.
      *
-     * @param array $methodNames one or many methods that are expected not to be called in this mock
+     * @param array ...$methodNames one or many methods that are expected not to be called in this mock
      * @return \Mockery\Expectation|\Mockery\HigherOrderMessage
      */
     public function shouldNotReceive(...$methodNames);
@@ -84,7 +84,7 @@ interface MockInterface
      * @return Mock
      */
     public function shouldDeferMissing();
-    
+
     /**
      * Set mock to defer unexpected methods to its parent if possible
      *

--- a/tests/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationTest.php
+++ b/tests/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationTest.php
@@ -39,7 +39,7 @@ class MockeryPHPUnitIntegrationTest extends MockeryTestCase
         $test = spy(BaseClassStub::class)->makePartial();
         $test->finish();
 
-        $test->shouldHaveReceived()->markAsRisky(m::type("string"));
+        $test->shouldHaveReceived()->markAsRisky();
     }
 
     /**
@@ -58,6 +58,6 @@ class MockeryPHPUnitIntegrationTest extends MockeryTestCase
         $test = spy(BaseClassStub::class)->makePartial();
         $test->finish();
 
-        $test->shouldNotHaveReceived()->markAsRisky(m::any());
+        $test->shouldNotHaveReceived()->markAsRisky();
     }
 }


### PR DESCRIPTION
Some fixes found with [`PHPStan`](https://github.com/phpstan/phpstan). Noticeable changes:
- `__construct` does not return anything;
- Fix [documentation of variadic parameters](https://github.com/phpstan/phpstan/issues/683#issuecomment-350254607);
- PHPUnit's `markAsRisky` [does not take any argument](https://github.com/sebastianbergmann/phpunit/blob/master/src/Framework/TestCase.php#L693).