### PR TITLE
Adds withVariadicArgs for optional argument matching

### DIFF
--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -433,6 +433,39 @@ class Expectation implements ExpectationInterface
     }
 
     /**
+     * Expect a variable number of arguments
+     *
+     * Useful when we want to set up an expectation only for a subset of arguments:
+     *
+     * ``` php
+     * class Foo
+     * {
+     *   public function bar($x, $y) {}
+     * }
+     *
+     * $m = \Mockery::mock(Foo::class);
+     * $m->shouldReceive('bar')
+     *   ->withVariadicArgs(1); // we car only about $x, not about $y
+     * $m->bar(1, 2);
+     * ```
+     *
+     * @param ...mixed
+     * @return self
+     */
+    public function withVariadicArgs(...$args)
+    {
+        return $this->withArgsMatchedByClosure(function (...$innerArgs) use ($args) {
+            $match = true;
+            foreach ($args as $k => $a) {
+                if ($innerArgs[$k] !== $a) {
+                    $match = false;
+                }
+            }
+            return $match;
+        });
+    }
+
+    /**
      * Set with() as no arguments expected
      *
      * @return self

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -476,6 +476,21 @@ class ExpectationTest extends MockeryTestCase
         Mockery::close();
     }
 
+    public function testExpectsVariadicArguments()
+    {
+        $this->mock->shouldReceive('foo')->withVariadicArgs(1);
+        $this->mock->foo(1, 4, 2);
+    }
+
+    /**
+     * @expectedException \Mockery\Exception
+     */
+    public function testExpectsVariadicArgumentsThrowsException()
+    {
+        $this->mock->shouldReceive('foo')->withVariadicArgs(2);
+        $this->mock->foo(1, 4, 2);
+    }
+
     public function testExpectsAnyArguments()
     {
         $this->mock->shouldReceive('foo')->withAnyArgs();


### PR DESCRIPTION
I realised that #531 and #301 can be done with `withArgs` and a closure, so adding `withVariadicArgs` as a shortcut for that.

Thoughts?