### PR TITLE
Vendor should be updated if composer.json changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-vendor/composer/installed.json:
+vendor/composer/installed.json: composer.json
 	composer install
 
 .PHONY: deps


### PR DESCRIPTION
Makes `composer.json` a pre requisite of vendor, this is way `vendor` will be updated when `composer.json` is updated (useful if you run it locally)