### PR TITLE
Adds support for late static binding

### DIFF
--- a/library/Mockery/Container.php
+++ b/library/Mockery/Container.php
@@ -141,6 +141,13 @@ class Container
                 $builder->addTarget('stdClass');
                 $builder->setName($name);
                 continue;
+            } elseif (is_string($arg) && substr($arg, 0, 4) == 'lsb:') {
+                $name = str_replace('lsb:', '', $arg);
+                $builder->setInstanceMock(true);
+                $builder->addTarget($name);
+                array_shift($args);
+
+                continue;
             } elseif (is_string($arg) && substr($arg, strlen($arg)-1, 1) == ']') {
                 $parts = explode('[', $arg);
                 if (!class_exists($parts[0], true) && !interface_exists($parts[0], true)) {

--- a/tests/Mockery/ContainerTest.php
+++ b/tests/Mockery/ContainerTest.php
@@ -1331,6 +1331,19 @@ class ContainerTest extends MockeryTestCase
             array(true,  '\\Foo\\Bar'),
         );
     }
+
+    /**
+     * @test
+     */
+    public function objectCreatedWithLateStaticBindingInheritsExpectations()
+    {
+        $mock = mock("lsb:MockeryTest_ClassThatHasLateStaticBinding")->makePartial();
+        $mock->shouldReceive("foo")->andReturn(2);
+
+        $result = $mock->createLSBObject();
+
+        $this->assertSame(2, $result);
+    }
 }
 
 class MockeryTest_CallStatic
@@ -1798,5 +1811,20 @@ class MockeryTest_ClassThatImplementsSerializable implements Serializable
 
     public function unserialize($serialized)
     {
+    }
+}
+
+class MockeryTest_ClassThatHasLateStaticBinding
+{
+    public function createLSBObject()
+    {
+        $object = new static();
+
+        return $object->foo();
+    }
+
+    public function foo()
+    {
+        return 1;
     }
 }


### PR DESCRIPTION
Objects that are mocked and then "recreated" with
late static binding would not inherit the expectations set
on the original mock object.

By telling Mockery to consider those mock objects as instance
mocks as well, they will inherit the expectations as expected.

Went with a new prefix of `lsb:` instead of trying to bolt it
on top of existing functionality because I'm too scared of the
things that might break otherwise.