### PR TITLE
Publish API Documentation to GH Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ phpunit.xml
 *.DS_store
 .idea/*
 .php_cs.cache
+apidocs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,3 +86,14 @@ notifications:
     - dave@atstsolutions.co.uk
 
   irc: irc.freenode.org#mockery
+deploy:
+  overwrite: true
+  provider: pages
+  file_glob: true
+  file: apidocs/*
+  local_dir: apidocs
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN
+  on:
+    branch: master
+    php: '7.1'

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,8 +91,8 @@ deploy:
   overwrite: true
   provider: pages
   file_glob: true
-  file: apidocs/*
-  local_dir: apidocs
+  file: docs/api/*
+  local_dir: docs/api
   skip_cleanup: true
   github_token: $GITHUB_TOKEN
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,7 @@ after_success:
   - vendor/bin/coveralls -v
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover "$clover"
+  - composer run-script docs
 
 notifications:
   email:

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,9 @@
 {
     "name": "mockery/mockery",
     "description": "Mockery is a simple yet flexible PHP mock object framework",
+    "scripts": {
+        "docs": "phpdoc -d library -t apidocs"
+    },
     "keywords": [
         "bdd",
         "library",
@@ -33,7 +36,8 @@
         "hamcrest/hamcrest-php": "~2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7.10|~6.5"
+        "phpunit/phpunit": "~5.7.10|~6.5",
+        "phpdocumentor/phpdocumentor": "^2.9"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "mockery/mockery",
     "description": "Mockery is a simple yet flexible PHP mock object framework",
     "scripts": {
-        "docs": "phpdoc -d library -t apidocs"
+        "docs": "phpdoc -d library -t docs/api"
     },
     "keywords": [
         "bdd",


### PR DESCRIPTION
Automatically publish php docs to gh-pages. For this to work you will need to able gh-pages and configure it for the `gh-pages` branch.

You will also need to add an environment var to travis called `GITHUB_TOKEN` with your GitHub token (see https://docs.travis-ci.com/user/deployment/pages/). 

Finally, this does not provide a fully comprehensive overview of the API(there are docblocks missing, and phpdocumentor will yell about this in the "Errors" report with ~500 notices). But over time I'm sure that could be PR'd back in separately.