### PR TITLE
Adds andAnyOther argument matcher

### DIFF
--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -297,13 +297,26 @@ class Mockery
     }
 
     /**
-     * Return instance of AndAnyOther matcher.
+     * Return instance of AndAnyOtherArgs matcher.
      *
-     * @return \Mockery\Matcher\AndAnyOther
+     * An alternative name to `andAnyOtherArgs` so
+     * the API stays closer to `any` as well.
+     *
+     * @return \Mockery\Matcher\AndAnyOtherArgs
      */
-    public static function andAnyOther()
+    public static function andAnyOthers()
     {
-        return new \Mockery\Matcher\AndAnyOther();
+        return new \Mockery\Matcher\AndAnyOtherArgs();
+    }
+
+    /**
+     * Return instance of AndAnyOtherArgs matcher.
+     *
+     * @return \Mockery\Matcher\AndAnyOtherArgs
+     */
+    public static function andAnyOtherArgs()
+    {
+        return new \Mockery\Matcher\AndAnyOtherArgs();
     }
 
     /**

--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -297,6 +297,16 @@ class Mockery
     }
 
     /**
+     * Return instance of AndAnyOther matcher.
+     *
+     * @return \Mockery\Matcher\AndAnyOther
+     */
+    public static function andAnyOther()
+    {
+        return new \Mockery\Matcher\AndAnyOther();
+    }
+
+    /**
      * Return instance of TYPE matcher.
      *
      * @param mixed $expected

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -23,7 +23,7 @@ namespace Mockery;
 use Closure;
 use Mockery\Matcher\NoArgs;
 use Mockery\Matcher\AnyArgs;
-use Mockery\Matcher\AndAnyOther;
+use Mockery\Matcher\AndAnyOtherArgs;
 use Mockery\Matcher\ArgumentListMatcher;
 use Mockery\Matcher\MultiArgumentClosure;
 
@@ -320,9 +320,9 @@ class Expectation implements ExpectationInterface
         return (count($this->_expectedArgs) === 1 && ($this->_expectedArgs[0] instanceof ArgumentListMatcher));
     }
 
-    private function isAndAnyOtherArgumentMatcher($expectedArg)
+    private function isAndAnyOtherArgumentsMatcher($expectedArg)
     {
-        return $expectedArg instanceof AndAnyOther;
+        return $expectedArg instanceof AndAnyOtherArgs;
     }
 
     /**
@@ -341,7 +341,7 @@ class Expectation implements ExpectationInterface
             $lastExpectedArgument = end($this->_expectedArgs);
             reset($this->_expectedArgs);
 
-            if ($this->isAndAnyOtherArgumentMatcher($lastExpectedArgument)) {
+            if ($this->isAndAnyOtherArgumentsMatcher($lastExpectedArgument)) {
                 $argCountToSkipMatching = $argCount - count($this->_expectedArgs);
                 $args = array_slice($args, 0, $argCountToSkipMatching);
                 return $this->_matchArgs($args);

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -21,10 +21,11 @@
 namespace Mockery;
 
 use Closure;
-use Mockery\Matcher\MultiArgumentClosure;
-use Mockery\Matcher\ArgumentListMatcher;
-use Mockery\Matcher\AnyArgs;
 use Mockery\Matcher\NoArgs;
+use Mockery\Matcher\AnyArgs;
+use Mockery\Matcher\AndAnyOther;
+use Mockery\Matcher\ArgumentListMatcher;
+use Mockery\Matcher\MultiArgumentClosure;
 
 class Expectation implements ExpectationInterface
 {
@@ -319,6 +320,11 @@ class Expectation implements ExpectationInterface
         return (count($this->_expectedArgs) === 1 && ($this->_expectedArgs[0] instanceof ArgumentListMatcher));
     }
 
+    private function isAndAnyOtherArgumentMatcher($expectedArg)
+    {
+        return $expectedArg instanceof AndAnyOther;
+    }
+
     /**
      * Check if passed arguments match an argument expectation
      *
@@ -332,15 +338,36 @@ class Expectation implements ExpectationInterface
         }
         $argCount = count($args);
         if ($argCount !== count((array) $this->_expectedArgs)) {
+            $lastExpectedArgument = end($this->_expectedArgs);
+            reset($this->_expectedArgs);
+
+            if ($this->isAndAnyOtherArgumentMatcher($lastExpectedArgument)) {
+                $argCountToSkipMatching = $argCount - count($this->_expectedArgs);
+                $args = array_slice($args, 0, $argCountToSkipMatching);
+                return $this->_matchArgs($args);
+            }
+
             return false;
         }
+
+        return $this->_matchArgs($args);
+    }
+
+    /**
+     * Check if the passed arguments match the expectations, one by one.
+     *
+     * @param array $args
+     * @return bool
+     */
+    protected function _matchArgs($args)
+    {
+        $argCount = count($args);
         for ($i=0; $i<$argCount; $i++) {
             $param =& $args[$i];
             if (!$this->_matchArg($this->_expectedArgs[$i], $param)) {
                 return false;
             }
         }
-
         return true;
     }
 

--- a/library/Mockery/Matcher/AndAnyOther.php
+++ b/library/Mockery/Matcher/AndAnyOther.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/blob/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ *
+ * @category   Mockery
+ * @package    Mockery
+ * @copyright  Copyright (c) 2010 Pádraic Brady (http://blog.astrumfutura.com)
+ * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
+ */
+
+namespace Mockery\Matcher;
+
+class AndAnyOther extends MatcherAbstract
+{
+    /**
+     * Check if the actual value matches the expected.
+     *
+     * @param mixed $actual
+     * @return bool
+     */
+    public function match(&$actual)
+    {
+        return true;
+    }
+
+    /**
+     * Return a string representation of this Matcher
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return '<AndAnyOther>';
+    }
+}

--- a/library/Mockery/Matcher/AndAnyOtherArgs.php
+++ b/library/Mockery/Matcher/AndAnyOtherArgs.php
@@ -20,7 +20,7 @@
 
 namespace Mockery\Matcher;
 
-class AndAnyOther extends MatcherAbstract
+class AndAnyOtherArgs extends MatcherAbstract
 {
     /**
      * Check if the actual value matches the expected.
@@ -40,6 +40,6 @@ class AndAnyOther extends MatcherAbstract
      */
     public function __toString()
     {
-        return '<AndAnyOther>';
+        return '<AndAnyOthers>';
     }
 }

--- a/library/helpers.php
+++ b/library/helpers.php
@@ -1,5 +1,6 @@
 <?php
 
+use Mockery\Matcher\AndAnyOtherArgs;
 use Mockery\Matcher\AnyArgs;
 use Mockery\Matcher\NoArgs;
 
@@ -47,5 +48,19 @@ if (!function_exists("anyArgs")) {
     function anyArgs()
     {
         return new AnyArgs();
+    }
+}
+
+if (!function_exists("andAnyOtherArgs")) {
+    function andAnyOtherArgs()
+    {
+        return new AndAnyOtherArgs();
+    }
+}
+
+if (!function_exists("andAnyOthers")) {
+    function andAnyOthers()
+    {
+        return new AndAnyOtherArgs();
     }
 }

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -1082,7 +1082,7 @@ class ExpectationTest extends MockeryTestCase
 
     public function testAndAnyOtherConstraintMatchesTheRestOfTheArguments()
     {
-        $this->mock->shouldReceive('foo')->with(1, 2, Mockery::andAnyOther())->twice();
+        $this->mock->shouldReceive('foo')->with(1, 2, Mockery::andAnyOthers())->twice();
         $this->mock->foo(1, 2, 3, 4, 5);
         $this->mock->foo(1, 'str', 3, 4);
     }
@@ -1092,7 +1092,7 @@ class ExpectationTest extends MockeryTestCase
      */
     public function testAndAnyOtherConstraintDoesNotPreventMatchingOfRegularArguments()
     {
-        $this->mock->shouldReceive('foo')->with(1, 2, Mockery::andAnyOther());
+        $this->mock->shouldReceive('foo')->with(1, 2, Mockery::andAnyOthers());
         $this->mock->foo(10, 2, 3, 4, 5);
         Mockery::close();
     }

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -1080,6 +1080,23 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, 2, 3);
     }
 
+    public function testAndAnyOtherConstraintMatchesTheRestOfTheArguments()
+    {
+        $this->mock->shouldReceive('foo')->with(1, 2, Mockery::andAnyOther())->twice();
+        $this->mock->foo(1, 2, 3, 4, 5);
+        $this->mock->foo(1, 'str', 3, 4);
+    }
+
+    /**
+     * @expectedException \Mockery\Exception
+     */
+    public function testAndAnyOtherConstraintDoesNotPreventMatchingOfRegularArguments()
+    {
+        $this->mock->shouldReceive('foo')->with(1, 2, Mockery::andAnyOther());
+        $this->mock->foo(10, 2, 3, 4, 5);
+        Mockery::close();
+    }
+
     public function testArrayConstraintMatchesArgument()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::type('array'))->once();


### PR DESCRIPTION
The name is on purpose "andAnyOther" so that it
is visible from the name itself that it should
never be the first matcher in a list of matchers,
and hopefuly the "other" part says enough that
it will match more than one argument.