### PR TITLE
Move OldStyleConstructor test to a separate file

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,10 +15,12 @@
     <testsuites>
         <testsuite name="Mockery Test Suite">
             <directory suffix="Test.php">./tests</directory>
+            <exclude>./tests/Mockery/MockingOldStyleConstructorTest.php</exclude>
             <exclude>./tests/Mockery/MockingVariadicArgumentsTest.php</exclude>
             <exclude>./tests/Mockery/MockingParameterAndReturnTypesTest.php</exclude>
             <exclude>./tests/Mockery/Generator/StringManipulation/Pass/MagicMethodTypeHintsPassTest.php</exclude>
             <exclude>./tests/Mockery/Php72LanguageFeaturesTest.php</exclude>
+            <file phpVersion="7.0.0-dev" phpVersionOperator="&lt;">./tests/Mockery/MockingOldStyleConstructorTest.php</file>
             <file phpVersion="7.0.0-dev" phpVersionOperator=">=">./tests/Mockery/MockingParameterAndReturnTypesTest.php</file>
             <file phpVersion="7.0.0-dev" phpVersionOperator=">=">./tests/Mockery/Generator/StringManipulation/Pass/MagicMethodTypeHintsPassTest.php</file>
             <file phpVersion="7.2.0-dev" phpVersionOperator=">=">./tests/Mockery/Php72LanguageFeaturesTest.php</file>

--- a/tests/Mockery/ContainerTest.php
+++ b/tests/Mockery/ContainerTest.php
@@ -1082,14 +1082,6 @@ class ContainerTest extends MockeryTestCase
         $this->assertInstanceOf(MockInterface::class, mock('MockeryTest_CallStatic'));
     }
 
-    /**
-     * @issue issue/139
-     */
-    public function testCanMockClassWithOldStyleConstructorAndArguments()
-    {
-        $this->assertInstanceOf(MockInterface::class, mock('MockeryTest_OldStyleConstructor'));
-    }
-
     /** @group issue/144 */
     public function testMockeryShouldInterpretEmptyArrayAsConstructorArgs()
     {
@@ -1719,13 +1711,6 @@ class MockeryTest_ImplementsIterator implements Iterator
     }
 
     public function valid()
-    {
-    }
-}
-
-class MockeryTest_OldStyleConstructor
-{
-    public function MockeryTest_OldStyleConstructor($arg)
     {
     }
 }

--- a/tests/Mockery/MockingOldStyleConstructorTest.php
+++ b/tests/Mockery/MockingOldStyleConstructorTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ *
+ * @category   Mockery
+ * @package    Mockery
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2010 Pádraic Brady (http://blog.astrumfutura.com)
+ * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
+ */
+
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Mockery\MockInterface;
+
+class MockingOldStyleConstructorTest extends MockeryTestCase
+{
+
+    /**
+     * @issue issue/139
+     */
+    public function testCanMockClassWithOldStyleConstructorAndArguments()
+    {
+        $this->assertInstanceOf(MockInterface::class, mock('MockeryTest_OldStyleConstructor'));
+    }
+}
+
+class MockeryTest_OldStyleConstructor
+{
+    public function MockeryTest_OldStyleConstructor($arg)
+    {
+    }
+}


### PR DESCRIPTION
So we run it only against PHP 5.6 as it is deprecated
as of PHP 7.