### PR TITLE
Fix iterable return type

### DIFF
--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -699,7 +699,10 @@ class Mock implements MockInterface
             case 'int':    return 0;
             case 'float':  return 0.0;
             case 'bool':   return false;
-            case 'array':  return [];
+
+            case 'array':
+            case 'iterable':
+                return [];
 
             case 'callable':
             case 'Closure':

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,10 +19,12 @@
             <exclude>./tests/Mockery/MockingVariadicArgumentsTest.php</exclude>
             <exclude>./tests/Mockery/MockingParameterAndReturnTypesTest.php</exclude>
             <exclude>./tests/Mockery/Generator/StringManipulation/Pass/MagicMethodTypeHintsPassTest.php</exclude>
+            <exclude>./tests/Mockery/Php71LanguageFeaturesTest.php</exclude>
             <exclude>./tests/Mockery/Php72LanguageFeaturesTest.php</exclude>
             <file phpVersion="7.0.0-dev" phpVersionOperator="&lt;">./tests/Mockery/MockingOldStyleConstructorTest.php</file>
             <file phpVersion="7.0.0-dev" phpVersionOperator=">=">./tests/Mockery/MockingParameterAndReturnTypesTest.php</file>
             <file phpVersion="7.0.0-dev" phpVersionOperator=">=">./tests/Mockery/Generator/StringManipulation/Pass/MagicMethodTypeHintsPassTest.php</file>
+            <file phpVersion="7.1.0-dev" phpVersionOperator=">=">./tests/Mockery/Php71LanguageFeaturesTest.php</file>
             <file phpVersion="7.2.0-dev" phpVersionOperator=">=">./tests/Mockery/Php72LanguageFeaturesTest.php</file>
         </testsuite>
     </testsuites>

--- a/tests/Mockery/Php71LanguageFeaturesTest.php
+++ b/tests/Mockery/Php71LanguageFeaturesTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace test\Mockery;
+
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+/**
+ * @requires PHP 7.1.0-dev
+ */
+class Php71LanguageFeaturesTest extends MockeryTestCase
+{
+    public function testMockingIterableReturnType()
+    {
+        $mock = mock("test\Mockery\ReturnTypeIterableTypeHint");
+
+        $mock->shouldReceive("returnIterable");
+        $this->assertSame([], $mock->returnIterable());
+    }
+}
+
+abstract class ReturnTypeIterableTypeHint
+{
+    public function returnIterable(): iterable
+    {
+    }
+}


### PR DESCRIPTION
Hi,

Since php 7.1 iterable can be used as return type. (http://php.net/manual/en/language.types.iterable.php) 

In 1.0, Mockery tries to create a class name iterable. This fixes this behavior and returns an array instead. 