### PR TITLE
Fixed Travis dependency caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
 
 cache:
   directories:
-    - .composer/cache
+    - vendor
 
 before_install:
   - alias composer=composer\ -n && composer self-update


### PR DESCRIPTION
Actually cache dependencies instead of just pretending, to speed up builds.