### PR TITLE
Fix typo on the return annotation of shouldNotReceive

### DIFF
--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -267,7 +267,7 @@ class Mock implements MockInterface
      * Shortcut method for setting an expectation that a method should not be called.
      *
      * @param array ...$methodNames one or many methods that are expected not to be called in this mock
-     * @return \\Mockery\ExpectationInterface|\Mockery\Expectation|\Mockery\HigherOrderMessage
+     * @return \Mockery\ExpectationInterface|\Mockery\Expectation|\Mockery\HigherOrderMessage
      */
     public function shouldNotReceive(...$methodNames)
     {


### PR DESCRIPTION
There's an extra backslash :)