### PR TITLE
Fix mocking with classes that use HHVM memoization

### DIFF
--- a/library/Mockery/Generator/MockConfiguration.php
+++ b/library/Mockery/Generator/MockConfiguration.php
@@ -521,6 +521,34 @@ class MockConfiguration
             return true;
         });
 
+        // In HHVM, class methods can be annotated with the built-in
+        // <<__Memoize>> attribute (similar to a Python decorator),
+        // which builds an LRU cache of method arguments and their
+        // return values.
+        // https://docs.hhvm.com/hack/attributes/special#__memoize
+        //
+        // HHVM implements this behavior by inserting a private helper
+        // method into the class at runtime which is named as the
+        // method to be memoized, suffixed by `$memoize_impl`.
+        // https://github.com/facebook/hhvm/blob/6aa46f1e8c2351b97d65e67b73e26f274a7c3f2e/hphp/runtime/vm/func.cpp#L364
+        //
+        // Ordinarily, PHP does not all allow the `$` token in method
+        // names, but since the memoization helper is inserted at
+        // runtime (and not in userland), HHVM allows it.
+        //
+        // We use code generation and eval() for some types of mocks,
+        // so to avoid syntax errors from these memoization helpers,
+        // we must filter them from our list of class methods.
+        //
+        // This effectively disables the memoization behavior in HHVM,
+        // but that's preferable to failing catastrophically when
+        // attempting to mock a class using the attribute.
+        if (defined('HHVM_VERSION')) {
+            $methods = array_filter($methods, function ($method) {
+                return strpos($method->getName(), '$memoize_impl') === false;
+            });
+        }
+
         return $this->allMethods = $methods;
     }
 


### PR DESCRIPTION
HHVM has a [built-in decorator](https://docs.hhvm.com/hack/attributes/special#__memoize) that memoizes class methods. However, its implementation is incompatible with the code generation/evaluation strategy that Mockery uses.

This PR fixes Mockery to allow mocking of classes that use the decorator, though with the caveat that the decorator will no longer function as advertised. This is regrettable, but memoization (as implemented by HHVM) is solely a means of improving performance, and so disabling it in tests should not greatly affect behavior.