### PR TITLE
Add PhpStorm Advanced Metadata for autocompletion

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PHPSTORM_META;
+
+override(\Mockery::mock(0), type(0));
+override(\Mockery::spy(0), type(0));
+override(\Mockery::namedMock(0), type(0));
+override(\Mockery::instanceMock(0), type(0));
+override(\mock(0), type(0));
+override(\spy(0), type(0));
+override(\namedMock(0), type(0));

--- a/library/helpers.php
+++ b/library/helpers.php
@@ -26,21 +26,21 @@ use Mockery\Matcher\NoArgs;
 if (!function_exists("mock")) {
     function mock(...$args)
     {
-        return call_user_func_array([Mockery::class, "mock"], $args);
+        return Mockery::mock(...$args);
     }
 }
 
 if (!function_exists("spy")) {
     function spy(...$args)
     {
-        return call_user_func_array([Mockery::class, "spy"], $args);
+        return Mockery::spy(...$args);
     }
 }
 
 if (!function_exists("namedMock")) {
     function namedMock(...$args)
     {
-        return call_user_func_array([Mockery::class, "namedMock"], $args);
+        return Mockery::namedMock(...$args);
     }
 }
 


### PR DESCRIPTION
I saw a previous attempt at this was made in #759, but it looks like @wan2land hasn't got around to creating a new PR based on the new format for PhpStorm metadata.

This PR is basically the same thing as #759, but using the new format.


For reference, [here is the documentation about this feature in PhpStorm](https://confluence.jetbrains.com/display/PhpStorm/PhpStorm+Advanced+Metadata)