### PR TITLE
Update Method.php to remove returnType for HHVM

### DIFF
--- a/library/Mockery/Generator/Method.php
+++ b/library/Mockery/Generator/Method.php
@@ -43,6 +43,11 @@ class Method
 
     public function getReturnType()
     {
+        if (defined('HHVM_VERSION') && method_exists($this->method, 'getReturnTypeText')) {
+            // Remove return type for HHVM
+            return '';
+        }
+        
         if (version_compare(PHP_VERSION, '7.0.0-dev') >= 0 && $this->method->hasReturnType()) {
             $returnType = (string) $this->method->getReturnType();
 


### PR DESCRIPTION
HHVM with php >7.0 dependency would fail to evaluate. Striping all return type for HHVM solve this issue.

Return type associated to the error include but no limited to: HH/string, HH/this, HH/int, HH/mixed, HH/bool, tuple, array<HH/string> and more.