### PR TITLE
Upgrading to HHVM 3.25 causes errors due to return type

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -2,5 +2,6 @@ preset: psr2
 
 finder:
   not-name:
+    - MethodWithHHVMReturnType.php
     - MockingParameterAndReturnTypesTest.php
     - SemiReservedWordsAsMethods.php

--- a/library/Mockery/Generator/Method.php
+++ b/library/Mockery/Generator/Method.php
@@ -48,17 +48,8 @@ class Method
             $returnType = $this->method->getReturnTypeText();
 
             // Remove tuple, ImmVector<>, ImmSet<>, ImmMap<>, array<>, anything with <>, void, mixed which cause eval() errors
-            if (preg_match('/(\w+<.*>)|(\(.+\))|(HH\\\\(void|mixed))/', $returnType)) {
+            if (preg_match('/(\w+<.*>)|(\(.+\))|(HH\\\\(void|mixed|this))/', $returnType)) {
                 return '';
-            }
-
-            // Convert HH\this to declaring class
-            if (preg_match('/HH\\\\this/', $returnType)) {
-                $returnType = $this->method->getDeclaringClass()->name;
-
-                if ($this->method->getReturnType()->allowsNull()) {
-                    $returnType = '?'.$returnType;
-                }
             }
 
             // return directly without going through php logic.

--- a/library/Mockery/Generator/Method.php
+++ b/library/Mockery/Generator/Method.php
@@ -43,6 +43,24 @@ class Method
 
     public function getReturnType()
     {
+    	if (defined('HHVM_VERSION') && method_exists($this->method, 'getReturnTypeText') && $this->method->hasReturnType()) {
+    		// Available in HHVM
+    		$returnType = $this->method->getReturnTypeText();
+
+    		// Remove tuple, anything with <*>
+    		if (preg_match('/(<.*>)|(\(.+\))/', $returnType)) {
+    			return '';
+    		}
+
+    		// Remove ImmVector, ImmSet, ImmMap, void, and this which cause eval() errors
+    		if (preg_match('/HH\\\\(ImmVector|ImmMap|ImmSet|void|this)/', $returnType)) {
+    			return '';
+    		}
+
+    		// return directly without going through php logic.
+    		return $returnType;
+    	}
+
         if (version_compare(PHP_VERSION, '7.0.0-dev') >= 0 && $this->method->hasReturnType()) {
             $returnType = (string) $this->method->getReturnType();
 

--- a/library/Mockery/Generator/Method.php
+++ b/library/Mockery/Generator/Method.php
@@ -57,10 +57,8 @@ class Method
                 $returnType = $this->method->getDeclaringClass()->name;
 
                 if ($this->method->getReturnType()->allowsNull()) {
-                    return '?'.$returnType;
+                    $returnType = '?'.$returnType;
                 }
-
-                return $returnType;
             }
 
             // return directly without going through php logic.

--- a/library/Mockery/Generator/Method.php
+++ b/library/Mockery/Generator/Method.php
@@ -53,7 +53,7 @@ class Method
             }
 
             // Remove ImmVector, ImmSet, ImmMap, void, and this which cause eval() errors
-            if (preg_match('/HH\\\\(ImmVector|ImmMap|ImmSet|void|this)/', $returnType)) {
+            if (preg_match('/HH\\\\(ImmVector|ImmMap|ImmSet|void|this|mixed)/', $returnType)) {
                 return '';
             }
 

--- a/library/Mockery/Generator/Method.php
+++ b/library/Mockery/Generator/Method.php
@@ -43,23 +43,23 @@ class Method
 
     public function getReturnType()
     {
-    	if (defined('HHVM_VERSION') && method_exists($this->method, 'getReturnTypeText') && $this->method->hasReturnType()) {
-    		// Available in HHVM
-    		$returnType = $this->method->getReturnTypeText();
+        if (defined('HHVM_VERSION') && method_exists($this->method, 'getReturnTypeText') && $this->method->hasReturnType()) {
+            // Available in HHVM
+            $returnType = $this->method->getReturnTypeText();
 
-    		// Remove tuple, anything with <*>
-    		if (preg_match('/(<.*>)|(\(.+\))/', $returnType)) {
-    			return '';
-    		}
+            // Remove tuple, anything with <*>
+            if (preg_match('/(<.*>)|(\(.+\))/', $returnType)) {
+                return '';
+            }
 
-    		// Remove ImmVector, ImmSet, ImmMap, void, and this which cause eval() errors
-    		if (preg_match('/HH\\\\(ImmVector|ImmMap|ImmSet|void|this)/', $returnType)) {
-    			return '';
-    		}
+            // Remove ImmVector, ImmSet, ImmMap, void, and this which cause eval() errors
+            if (preg_match('/HH\\\\(ImmVector|ImmMap|ImmSet|void|this)/', $returnType)) {
+                return '';
+            }
 
-    		// return directly without going through php logic.
-    		return $returnType;
-    	}
+            // return directly without going through php logic.
+            return $returnType;
+        }
 
         if (version_compare(PHP_VERSION, '7.0.0-dev') >= 0 && $this->method->hasReturnType()) {
             $returnType = (string) $this->method->getReturnType();

--- a/tests/Mockery/Fixtures/MethodWithHHVMReturnType.php
+++ b/tests/Mockery/Fixtures/MethodWithHHVMReturnType.php
@@ -1,0 +1,57 @@
+<?hh
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ *
+ * @category   Mockery
+ * @package    Mockery
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2010 Pádraic Brady (http://blog.astrumfutura.com)
+ * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
+ */
+
+namespace test\Mockery\Fixtures;
+
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+class MethodWithHHVMReturnType extends MockeryTestCase
+{
+    public function nullableHHVMArray() : ?array<string, bool>
+    {
+        return array('key' => true);
+    }
+
+    public function HHVMVoid() : ?void
+    {
+        return null;
+    }
+
+    public function HHVMMixed() : mixed
+    {
+        return null;
+    }
+
+    public function HHVMThis() : this
+    {
+        return $this;
+    }
+
+    public function HHVMString() : string
+    {
+        return 'a string';
+    }
+
+    public function HHVMImmVector() : ImmVector<int>
+    {
+        return new ImmVector([1, 2, 3]);
+    }
+}

--- a/tests/Mockery/MockingHHVMMethodsTest.php
+++ b/tests/Mockery/MockingHHVMMethodsTest.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ *
+ * @category   Mockery
+ * @package    Mockery
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2010 Pádraic Brady (http://blog.astrumfutura.com)
+ * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
+ */
+
+namespace test\Mockery;
+
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Mockery\Generator\Method;
+use test\Mockery\Fixtures\MethodWithHHVMReturnType;
+
+class MockingHHVMMethodsTest extends MockeryTestCase
+{
+    /**
+     * @var \Mockery\Container
+     */
+    private $container;
+
+    protected function setUp()
+    {
+        if (!$this->isHHVM()) {
+            $this->markTestSkipped('For HHVM test only');
+        }
+
+        parent::setUp();
+
+        require_once __DIR__."/Fixtures/MethodWithHHVMReturnType.php";
+    }
+
+    /** @test */
+    public function it_strip_hhvm_array_return_types()
+    {
+        $mock = mock('test\Mockery\Fixtures\MethodWithHHVMReturnType');
+
+        $this->assertEquals($mock->nullableHHVMArray(), array('key' => true));
+    }
+
+    /** @test */
+    public function it_strip_hhvm_void_return_types()
+    {
+        $mock = mock(MethodWithHHVMReturnType::class);
+
+        $this->assertNull($mock->HHVMVoid());
+    }
+
+    /** @test */
+    public function it_strip_hhvm_mixed_return_types()
+    {
+        $mock = mock(MethodWithHHVMReturnType::class);
+
+        $this->assertNull($mock->HHVMMixed());
+    }
+
+    /** @test */
+    public function it_strip_hhvm_this_return_types()
+    {
+        $mock = mock(MethodWithHHVMReturnType::class);
+
+        $this->assertEquals($mock->HHVMThis(), MethodWithHHVMReturnType::class);
+    }
+
+    /** @test */
+    public function it_allow_hhvm_string_return_types()
+    {
+        $mock = mock(MethodWithHHVMReturnType::class);
+
+        $this->assertEquals($mock->HHVMString(), 'a string');
+    }
+
+    /** @test */
+    public function it_allow_hhvm_imm_vector_return_types()
+    {
+        $mock = mock(MethodWithHHVMReturnType::class);
+
+        $this->assertEquals($mock->HHVMImmVector(), new ImmVector([1, 2, 3]));
+    }
+
+    /**
+     * Returns true when it is HHVM.
+     */
+    private function isHHVM()
+    {
+        return \defined('HHVM_VERSION');
+    }
+}

--- a/tests/Mockery/MockingHHVMMethodsTest.php
+++ b/tests/Mockery/MockingHHVMMethodsTest.php
@@ -48,47 +48,53 @@ class MockingHHVMMethodsTest extends MockeryTestCase
     {
         $mock = mock('test\Mockery\Fixtures\MethodWithHHVMReturnType');
 
-        $this->assertEquals($mock->nullableHHVMArray(), array('key' => true));
+        $mock->shouldReceive('nullableHHVMArray')->andReturn(array('key' => true));
+        $mock->nullableHHVMArray();
     }
 
     /** @test */
     public function it_strip_hhvm_void_return_types()
     {
-        $mock = mock(MethodWithHHVMReturnType::class);
+        $mock = mock('test\Mockery\Fixtures\MethodWithHHVMReturnType');
 
-        $this->assertNull($mock->HHVMVoid());
+        $mock->shouldReceive('HHVMVoid')->andReturnNull();
+        $mock->HHVMVoid();
     }
 
     /** @test */
     public function it_strip_hhvm_mixed_return_types()
     {
-        $mock = mock(MethodWithHHVMReturnType::class);
+        $mock = mock('test\Mockery\Fixtures\MethodWithHHVMReturnType');
 
-        $this->assertNull($mock->HHVMMixed());
+        $mock->shouldReceive('HHVMMixed')->andReturnNull();
+        $mock->HHVMMixed();
     }
 
     /** @test */
     public function it_strip_hhvm_this_return_types()
     {
-        $mock = mock(MethodWithHHVMReturnType::class);
+        $mock = mock('test\Mockery\Fixtures\MethodWithHHVMReturnType');
 
-        $this->assertEquals($mock->HHVMThis(), MethodWithHHVMReturnType::class);
+        $mock->shouldReceive('HHVMThis')->andReturn(new MethodWithHHVMReturnType());
+        $mock->HHVMThis();
     }
 
     /** @test */
     public function it_allow_hhvm_string_return_types()
     {
-        $mock = mock(MethodWithHHVMReturnType::class);
+        $mock = mock('test\Mockery\Fixtures\MethodWithHHVMReturnType');
 
-        $this->assertEquals($mock->HHVMString(), 'a string');
+        $mock->shouldReceive('HHVMString')->andReturn('a string');
+        $mock->HHVMString();
     }
 
     /** @test */
     public function it_allow_hhvm_imm_vector_return_types()
     {
-        $mock = mock(MethodWithHHVMReturnType::class);
+        $mock = mock('test\Mockery\Fixtures\MethodWithHHVMReturnType');
 
-        $this->assertEquals($mock->HHVMImmVector(), new ImmVector([1, 2, 3]));
+        $mock->shouldReceive('HHVMImmVector')->andReturn(new \HH\ImmVector([1, 2, 3]));
+        $mock->HHVMImmVector();
     }
 
     /**


### PR DESCRIPTION
Return type cannot be properly evaluated by PHP `eval()` function. Stripping out the following return type: `tuple`, `array<*>` or anything with `<*>` in it, `HH\void`, `HH\this`, `HH\ImmVector`, `HH\ImmMap`, `HH\ImmSet`.

The hope is HHVM have a replacement for `eval`. If not, this seems to be the best course forward

- [x] Add smoke test