### PR TITLE
Switches to an alpha version of phpDocumentor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ phpunit.xml
 .idea/*
 .php_cs.cache
 docs/api
+phpDocumentor.phar*

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,13 @@ test: deps
 .PHONY: apidocs
 apidocs: docs/api/index.html
 
+phpDocumentor.phar: 
+	wget https://github.com/phpDocumentor/phpDocumentor2/releases/download/v3.0.0-alpha.2-nightly-gdff5545/phpDocumentor.phar
+	wget https://github.com/phpDocumentor/phpDocumentor2/releases/download/v3.0.0-alpha.2-nightly-gdff5545/phpDocumentor.phar.pubkey
+
 library_files=$(shell find library -name '*.php')
-docs/api/index.html: vendor/composer/installed.json $(library_files) 
-	vendor/bin/phpdoc -d library -t docs/api
+docs/api/index.html: vendor/composer/installed.json $(library_files) phpDocumentor.phar
+	php phpDocumentor.phar run -d library -t docs/api
 
 .PHONY: test-all
 test-all: test-72 test-71 test-70 test-56

--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,7 @@
         "hamcrest/hamcrest-php": "~2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7.10|~6.5|~7.0",
-        "phpdocumentor/phpdocumentor": "^2.9"
+        "phpunit/phpunit": "~5.7.10|~6.5|~7.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
See https://github.com/phpDocumentor/phpDocumentor2/issues/1914

Using the phar to avoid having to depend of dev versions of
phpDocumentor and it's dependencies in composer json