### PR TITLE
Stub array interfaces from an existing array.

### DIFF
--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -135,6 +135,17 @@ class Mockery
     }
 
     /**
+     * @param string $class
+     * @param array $items
+     * @return \Mockery\MockInterface
+     * @throws \Mockery\Exception\RuntimeException
+     */
+    public static function stubTraversable($class, array $items)
+    {
+        return self::getContainer()->stubTraversable($class, $items);
+    }
+
+    /**
      * Static and Semantic shortcut to \Mockery\Container::mock().
      *
      * @param array ...$args

--- a/library/Mockery/Container.php
+++ b/library/Mockery/Container.php
@@ -20,6 +20,7 @@
 
 namespace Mockery;
 
+use Mockery\Exception\InvalidArgumentException;
 use Mockery\Generator\Generator;
 use Mockery\Generator\MockConfigurationBuilder;
 use Mockery\Loader\Loader as LoaderInterface;
@@ -234,6 +235,29 @@ class Container
         }
         $this->rememberMock($mock);
         return $mock;
+    }
+
+    /**
+     * @param string $class
+     * @param array $items
+     * @return Mock
+     * @throws Exception\RuntimeException
+     */
+    public function stubTraversable($class, array $items)
+    {
+        $expectedInterfaces = [\Traversable::class, \ArrayAccess::class, \Countable::class];
+
+        if (!count(array_intersect(class_implements($class), $expectedInterfaces)) && !in_array($class, $expectedInterfaces)) {
+            throw new InvalidArgumentException(
+                'Supplied class does not implement any relevant interfaces to stub.'
+            );
+        }
+
+        $mockIterator = $this->mock($class);
+
+        $this->stubTraversableMethods($mockIterator, $items);
+
+        return $mockIterator;
     }
 
     public function instanceMock()
@@ -535,5 +559,85 @@ class Container
             return !preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $name);
         });
         return empty($invalidNames);
+    }
+
+    protected function stubTraversableMethods(MockInterface $mockIterator, array $items) {
+        $arrayIterator = new \ArrayIterator($items);
+
+        if ($mockIterator instanceof \IteratorAggregate) {
+            $this->stubIteratorAggregateMethods($mockIterator, $arrayIterator);
+        }
+
+        if ($mockIterator instanceof \Iterator) {
+            $this->stubIteratorMethods($mockIterator, $arrayIterator);
+        }
+
+        if ($mockIterator instanceof \ArrayAccess) {
+            $this->stubArrayAccessMethods($mockIterator, $arrayIterator);
+        }
+
+        if ($mockIterator instanceof \Countable) {
+            $this->stubCountableMethods($mockIterator, $arrayIterator);
+        }
+    }
+
+    /**
+     * @param \IteratorAggregate|MockInterface $mockIteratorAggregate
+     * @param \ArrayIterator $arrayIterator
+     */
+    protected function stubIteratorAggregateMethods(MockInterface $mockIteratorAggregate, \ArrayIterator $arrayIterator)
+    {
+        $mockIteratorAggregate->shouldReceive('getIterator')
+            ->andReturnUsing(function () use ($arrayIterator) {
+                return $arrayIterator;
+            })->byDefault();
+    }
+
+    /**
+     * @param MockInterface|\Iterator $mockIterator
+     * @param \ArrayIterator $arrayIterator
+     */
+    protected function stubIteratorMethods(MockInterface $mockIterator, \ArrayIterator $arrayIterator)
+    {
+        $mockIterator->shouldReceive('rewind')
+            ->andReturnUsing(function () use ($arrayIterator) {
+                $arrayIterator->rewind();
+            })->byDefault();
+        $mockIterator->shouldReceive('current')
+            ->andReturnUsing(function () use ($arrayIterator) {
+                return $arrayIterator->current();
+            })->byDefault();
+        $mockIterator->shouldReceive('key')
+            ->andReturnUsing(function () use ($arrayIterator) {
+                return $arrayIterator->key();
+            })->byDefault();
+        $mockIterator->shouldReceive('next')
+            ->andReturnUsing(function () use ($arrayIterator) {
+                $arrayIterator->next();
+            })->byDefault();
+        $mockIterator->shouldReceive('valid')
+            ->andReturnUsing(function () use ($arrayIterator) {
+                return $arrayIterator->valid();
+            })->byDefault();
+    }
+
+    protected function stubArrayAccessMethods(MockInterface $mockArrayAccess, \ArrayIterator $arrayIterator)
+    {
+        $mockArrayAccess->shouldReceive('offsetExists')
+            ->andReturnUsing(function ($offset) use ($arrayIterator) {
+                return $arrayIterator->offsetExists($offset);
+            })->byDefault();
+        $mockArrayAccess->shouldReceive('offsetGet')
+            ->andReturnUsing(function ($offset) use ($arrayIterator) {
+                return $arrayIterator->offsetGet($offset);
+            })->byDefault();
+    }
+
+    protected function stubCountableMethods(MockInterface $mockCountable, \ArrayIterator $arrayIterator)
+    {
+        $mockCountable->shouldReceive('count')
+            ->andReturnUsing(function () use ($arrayIterator) {
+                return $arrayIterator->count();
+            })->byDefault();
     }
 }

--- a/library/helpers.php
+++ b/library/helpers.php
@@ -44,6 +44,13 @@ if (!function_exists("namedMock")) {
     }
 }
 
+if (!function_exists("stubTraversable")) {
+    function stubTraversable($class, array $items)
+    {
+        return Mockery::stubTraversable($class, $items);
+    }
+}
+
 if (!function_exists("anyArgs")) {
     function anyArgs()
     {

--- a/tests/Mockery/ContainerTest.php
+++ b/tests/Mockery/ContainerTest.php
@@ -1313,6 +1313,99 @@ class ContainerTest extends MockeryTestCase
     }
 
     /**
+     * @dataProvider getIteratorTestData
+     * @param string $traversableInterface
+     */
+    public function testStubTraversableWithIterator($traversableInterface)
+    {
+        $arrayItems = [
+            'alpha' => 'apple',
+            'beta' => 'banana',
+            'kappa' => 'cherry'
+        ];
+
+        $mockIterator = stubTraversable($traversableInterface, $arrayItems);
+
+        $count = 0;
+        foreach ($mockIterator as $key => $item) {
+            $this->assertSame($arrayItems[$key], $item);
+            $count++;
+        }
+
+        $this->assertSame(count($arrayItems), $count);
+    }
+
+    /**
+     * @see testStubTraversableWithIterator
+     * @return array
+     */
+    public function getIteratorTestData()
+    {
+        return [
+            [\Iterator::class],
+            [\IteratorAggregate::class],
+            [\ArrayIterator::class],
+        ];
+    }
+
+    /**
+     * @dataProvider getCountableTestData
+     * @param $countableInterface
+     */
+    public function testStubTraversableWithCountable($countableInterface)
+    {
+        $arrayItems = ['apple', 'banana', 'cherry'];
+
+        $mockIterator = stubTraversable($countableInterface, $arrayItems);
+
+        $this->assertCount(count($arrayItems), $mockIterator);
+    }
+
+    /**
+     * @see testStubTraversableWithCountable
+     * @return array
+     */
+    public function getCountableTestData()
+    {
+        return [
+            [\Countable::class],
+            [\ArrayIterator::class]
+        ];
+    }
+
+    /**
+     * @dataProvider getArrayAccessTestData
+     * @param $arrayAccessInterface
+     */
+    public function testStubTraversableWithArrayAccessGetters($arrayAccessInterface)
+    {
+        $arrayItems = [
+            'alpha' => 'apple',
+            'beta' => 'banana',
+            'kappa' => 'cherry'
+        ];
+
+        $mockArrayAccess = stubTraversable($arrayAccessInterface, $arrayItems);
+
+        foreach ($arrayItems as $key => $item) {
+            $this->assertTrue(isset($mockArrayAccess[$key]));
+            $this->assertSame($item, $mockArrayAccess[$key]);
+        }
+    }
+
+    /**
+     * @see testStubTraversableWithArrayAccess
+     * @return array
+     */
+    public function getArrayAccessTestData()
+    {
+        return [
+            [\ArrayAccess::class],
+            [\ArrayIterator::class],
+        ];
+    }
+
+    /**
      * @test
      * @group issue/339
      */


### PR DESCRIPTION
This PR is for #905 

It provides a convenient way to stub all the methods associated with a class that implements `\Iterator`, `\ArrayAccess` or `\Countable`, by supplying an array as the source for the method values.

```php
$arrOfViolations = [
    \Mockery::mock(\Symfony\Component\Validator\ConstraintViolationInterface::class),
    \Mockery::mock(\Symfony\Component\Validator\ConstraintViolationInterface::class),
];

$mockViolationList = \Mockery::stubTraversable(
    \Symfony\Component\Validator\ConstraintViolationListInterface::class,
    $arrOfViolations
);

echo count($mockViolationList); // 2

foreach ($mockViolationList as $violation) {
    // ...
}
```

A con with this current implementation is that the array items can't be updated.  I.e. it does not stub `ArrayAccess::offsetSet()` and `ArrayAccess::offsetUnset()`