### PR TITLE
Strip HHVM return type and prevent HH object creation

### DIFF
--- a/library/Mockery/Generator/Method.php
+++ b/library/Mockery/Generator/Method.php
@@ -44,9 +44,9 @@ class Method
     public function getReturnType()
     {
         if (defined('HHVM_VERSION') && method_exists($this->method, 'getReturnTypeText') && $this->method->hasReturnType()) {
-        	// Strip all return type for hhvm.
-            // eval() errors on hhvm return type include but not limited to 
-            // tuple, ImmVector<>, ImmSet<>, ImmMap<>, array<>, 
+            // Strip all return type for hhvm.
+            // eval() errors on hhvm return type include but not limited to
+            // tuple, ImmVector<>, ImmSet<>, ImmMap<>, array<>,
             // anything with <>, void, mixed, this, and type-constant.
             // For type-constant Can see https://docs.hhvm.com/hack/type-constants/introduction
             // for more details.

--- a/library/Mockery/Generator/Method.php
+++ b/library/Mockery/Generator/Method.php
@@ -44,16 +44,13 @@ class Method
     public function getReturnType()
     {
         if (defined('HHVM_VERSION') && method_exists($this->method, 'getReturnTypeText') && $this->method->hasReturnType()) {
-            // Available in HHVM
-            $returnType = $this->method->getReturnTypeText();
-
-            // Remove tuple, ImmVector<>, ImmSet<>, ImmMap<>, array<>, anything with <>, void, mixed which cause eval() errors
-            if (preg_match('/(\w+<.*>)|(\(.+\))|(HH\\\\(void|mixed|this))/', $returnType)) {
-                return '';
-            }
-
-            // return directly without going through php logic.
-            return $returnType;
+        	// Strip all return type for hhvm.
+            // eval() errors on hhvm return type include but not limited to 
+            // tuple, ImmVector<>, ImmSet<>, ImmMap<>, array<>, 
+            // anything with <>, void, mixed, this, and type-constant.
+            // For type-constant Can see https://docs.hhvm.com/hack/type-constants/introduction
+            // for more details.
+            return '';
         }
 
         if (version_compare(PHP_VERSION, '7.0.0-dev') >= 0 && $this->method->hasReturnType()) {

--- a/library/Mockery/Generator/StringManipulation/Pass/ClassPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/ClassPass.php
@@ -36,13 +36,13 @@ class ClassPass implements Pass
             return $code;
         }
 
+        $className = ltrim($target->getName(), "\\");
         if (defined('HHVM_VERSION') && preg_match('/^HH\\\\/', $className)) {
             // HH\ namespace is reserved for HHVM class and doesnt require
             // class declaration and extension.
             return $code;
         }
 
-        $className = ltrim($target->getName(), "\\");
         if (!class_exists($className)) {
             \Mockery::declareClass($className);
         }

--- a/library/Mockery/Generator/StringManipulation/Pass/ClassPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/ClassPass.php
@@ -36,6 +36,12 @@ class ClassPass implements Pass
             return $code;
         }
 
+        if (defined('HHVM_VERSION') && preg_match('/^HH\\\\/', $className)) {
+            // HH\ namespace is reserved for HHVM class and doesnt require 
+            // class declaration and extension.
+            return $code;
+        }
+
         $className = ltrim($target->getName(), "\\");
         if (!class_exists($className)) {
             \Mockery::declareClass($className);

--- a/library/Mockery/Generator/StringManipulation/Pass/ClassPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/ClassPass.php
@@ -37,7 +37,7 @@ class ClassPass implements Pass
         }
 
         if (defined('HHVM_VERSION') && preg_match('/^HH\\\\/', $className)) {
-            // HH\ namespace is reserved for HHVM class and doesnt require 
+            // HH\ namespace is reserved for HHVM class and doesnt require
             // class declaration and extension.
             return $code;
         }

--- a/tests/Mockery/Fixtures/MethodWithHHVMReturnType.php
+++ b/tests/Mockery/Fixtures/MethodWithHHVMReturnType.php
@@ -30,7 +30,7 @@ class MethodWithHHVMReturnType extends MockeryTestCase
         return array('key' => true);
     }
 
-    public function HHVMVoid() : ?void
+    public function HHVMVoid() : void
     {
         return null;
     }

--- a/tests/Mockery/Generator/StringManipulation/Pass/ClassPassTest.php
+++ b/tests/Mockery/Generator/StringManipulation/Pass/ClassPassTest.php
@@ -51,7 +51,6 @@ class ClassPassTest extends TestCase
     {
         $config = new MockConfiguration(array("\HH\\this"), array(), array(), "Dave\Dave");
         $code = $this->pass->apply(static::CODE, $config);
-        var_dump($code);
         if (\defined('HHVM_VERSION')) {
             $this->assertNotContains('extends \HH\this', $code);
         } else {

--- a/tests/Mockery/Generator/StringManipulation/Pass/ClassPassTest.php
+++ b/tests/Mockery/Generator/StringManipulation/Pass/ClassPassTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ *
+ * @category   Mockery
+ * @package    Mockery
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2010 Pádraic Brady (http://blog.astrumfutura.com)
+ * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
+ */
+
+namespace Mockery\Generator\StringManipulation\Pass;
+
+use Mockery\Generator\MockConfiguration;
+use Mockery\Generator\StringManipulation\Pass\ClassPass;
+use PHPUnit\Framework\TestCase;
+
+class ClassPassTest extends TestCase
+{
+    const CODE = "class Mock implements MockInterface {}";
+
+    public function setup()
+    {
+        $this->pass = new ClassPass();
+    }
+
+    /**
+     * @test
+     */
+    public function shouldDeclareUnknownClass()
+    {
+        $config = new MockConfiguration(array("Testing\TestClass"), array(), array(), "Dave\Dave");
+        $code = $this->pass->apply(static::CODE, $config);
+        $this->assertContains('class Mock extends \Testing\TestClass implements MockInterface', $code);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotExtendHHVMClass()
+    {
+        $config = new MockConfiguration(array("\HH\\this"), array(), array(), "Dave\Dave");
+        $code = $this->pass->apply(static::CODE, $config);
+        var_dump($code);
+        if (\defined('HHVM_VERSION')) {
+            $this->assertNotContains('extends \HH\this', $code);
+        } else {
+            $this->assertSame('class Mock extends \HH\this implements MockInterface {}', $code);
+        }
+    }
+}


### PR DESCRIPTION
HHVM has type-constant `const type Example = ExampleClass` which allows custom return type  As a result, return type can be anything specified by the developer. Therefore, we strip all return type for HHVM.

Prevent Mockery from creating HH\this and other HH namespace class which already exists for HHVM.

- [x] Need to add test.