### PR TITLE
[0.9] The `Mockery:: globalHelpers()` added for the backwards compatibility

### DIFF
--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -68,6 +68,16 @@ class Mockery
     private static $_filesToCleanUp = array();
 
     /**
+     * Defines the global helper functions
+     *
+     * @return void
+     */
+    public static function globalHelpers()
+    {
+        require_once __DIR__.'/helpers.php';
+    }
+
+    /**
      * Static shortcut to \Mockery\Container::mock().
      *
      * @return \Mockery\MockInterface

--- a/library/helpers.php
+++ b/library/helpers.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/blob/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ *
+ * @category   Mockery
+ * @package    Mockery
+ * @copyright  Copyright (c) 2016 Dave Marshall
+ * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
+ */
+
+if (!function_exists("mock")) {
+    function mock()
+    {
+        return Mockery::mock(func_get_args());
+    }
+}
+
+if (!function_exists("spy")) {
+    function spy()
+    {
+        return Mockery::spy(func_get_args());
+    }
+}
+
+if (!function_exists("namedMock")) {
+    function namedMock()
+    {
+        return Mockery::namedMock(func_get_args());
+    }
+}

--- a/library/helpers.php
+++ b/library/helpers.php
@@ -22,20 +22,20 @@
 if (!function_exists("mock")) {
     function mock()
     {
-        return Mockery::mock(func_get_args());
+        return call_user_func_array(array('Mockery', 'mock'), func_get_args());
     }
 }
 
 if (!function_exists("spy")) {
     function spy()
     {
-        return Mockery::spy(func_get_args());
+        return call_user_func_array(array('Mockery', 'spy'), func_get_args());
     }
 }
 
 if (!function_exists("namedMock")) {
     function namedMock()
     {
-        return Mockery::namedMock(func_get_args());
+        return call_user_func_array(array('Mockery', 'namedMock'), func_get_args());
     }
 }

--- a/tests/Mockery/GlobalHelpersTest.php
+++ b/tests/Mockery/GlobalHelpersTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/blob/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ *
+ * @category   Mockery
+ * @package    Mockery
+ * @copyright  Copyright (c) 2016 Dave Marshall
+ * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class GlobalHelpersTest extends TestCase
+{
+    public function setup()
+    {
+        \Mockery::globalHelpers();
+    }
+
+    public function tearDown()
+    {
+        \Mockery::close();
+    }
+
+    /** @test */
+    public function mock_creates_a_mock()
+    {
+        $double = mock();
+
+        $this->assertInstanceOf('Mockery\MockInterface', $double);
+        $this->expectException('Exception');
+        $double->foo();
+    }
+
+    /** @test */
+    public function spy_creates_a_spy()
+    {
+        $double = spy();
+
+        $this->assertInstanceOf('Mockery\MockInterface', $double);
+        $double->foo();
+    }
+
+    /** @test */
+    public function named_mock_creates_a_named_mock()
+    {
+        $className = "Class".uniqid();
+        $double = namedMock($className);
+
+        $this->assertInstanceOf('Mockery\MockInterface', $double);
+        $this->assertInstanceOf($className, $double);
+    }
+}

--- a/tests/Mockery/GlobalHelpersTest.php
+++ b/tests/Mockery/GlobalHelpersTest.php
@@ -38,7 +38,7 @@ class GlobalHelpersTest extends TestCase
         $double = mock();
 
         $this->assertInstanceOf('Mockery\MockInterface', $double);
-        $this->expectException('Exception');
+        $this->setExpectedException('Exception');
         $double->foo();
     }
 


### PR DESCRIPTION
The legacy projects, or the packages, which are supporting an older PHP versions would be able to use the same code. The same static method `Mockery::globalHelpers()` and the same global helpers, for example `mock()`, for creating the mocks.