### PR TITLE
Fix in documentation of test doubles

### DIFF
--- a/docs/reference/creating_test_doubles.rst
+++ b/docs/reference/creating_test_doubles.rst
@@ -16,7 +16,7 @@ allow us to inspect these calls after the fact.
 
 When creating a test double object, we can pass in an identifier as a name for
 our test double. If we pass it no identifier, the test double name will be
-unknown. Furthermore, the identifier doest not have to be a class name. It is a
+unknown. Furthermore, the identifier does not have to be a class name. It is a
 good practice, and our recommendation, to always name the test doubles with the
 same name as the underlying class we are creating test doubles for.
 

--- a/docs/reference/creating_test_doubles.rst
+++ b/docs/reference/creating_test_doubles.rst
@@ -16,7 +16,7 @@ allow us to inspect these calls after the fact.
 
 When creating a test double object, we can pass in an identifier as a name for
 our test double. If we pass it no identifier, the test double name will be
-unknown. Furthermore, the identifier must not be a class name. It is a
+unknown. Furthermore, the identifier doest not have to be a class name. It is a
 good practice, and our recommendation, to always name the test doubles with the
 same name as the underlying class we are creating test doubles for.
 


### PR DESCRIPTION
Maybe I am confused, but the identifier can be a class name, right? 🤔 
I mean, that's how you make it inherit that class - or am I misreading something and identifier is not the thing you pass to `\Mockery::mock`?