### PR TITLE
Update expectations.rst

### DIFF
--- a/docs/reference/expectations.rst
+++ b/docs/reference/expectations.rst
@@ -270,7 +270,7 @@ use when throwing an ``Exception`` from the mocked method:
 
     $mock = \Mockery::mock('MyClass');
     $mock->shouldReceive('name_of_method')
-        ->andThrow(exception_name, message);
+        ->andThrow('exception_name', 'message');
 
 .. _expectations-setting-public-properties:
 


### PR DESCRIPTION
Makes it clearer that exception name and message should be strings, keeps consistent with `'name_of_method'` usages.