### PR TITLE
Fix allowing mocking of protected methods when configured to not allow non existent methods

### DIFF
--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -315,6 +315,14 @@ class Mock implements MockInterface
      */
     public function shouldAllowMockingProtectedMethods()
     {
+        if (!\Mockery::getConfiguration()->mockingNonExistentMethodsAllowed()) {
+            foreach ($this->mockery_getMethods() as $method) {
+                if ($method->isProtected() && !$method->isStatic()) {
+                    $this->_mockery_mockableMethods[] = $method->getName();
+                }
+            }
+        }
+
         $this->_mockery_allowMockingProtectedMethods = true;
         return $this;
     }

--- a/tests/Mockery/MockTest.php
+++ b/tests/Mockery/MockTest.php
@@ -43,6 +43,16 @@ class Mockery_MockTest extends MockeryTestCase
         \Mockery::getConfiguration()->allowMockingNonExistentMethods(true);
     }
 
+    public function testProtectedMethodMockWithNotAllowingMockingOfNonExistentMethodsWhenShouldAllowMockingProtectedMethodsIsCalled()
+    {
+        \Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
+        $m = mock('ClassWithProtectedMethod');
+        $m->shouldAllowMockingProtectedMethods();
+        $m->shouldReceive('foo')->andReturn(true);
+        assertThat($m->foo(), equalTo(true));
+        \Mockery::getConfiguration()->allowMockingNonExistentMethods(true);
+    }
+
     public function testShouldAllowMockingMethodReturnsMockInstance()
     {
         $m = Mockery::mock('someClass');
@@ -215,5 +225,13 @@ class ClassWithMethods
     public function bar()
     {
         return 'bar';
+    }
+}
+
+class ClassWithProtectedMethod
+{
+    protected function foo()
+    {
+        return 'foo';
     }
 }


### PR DESCRIPTION
Fix #934 Allowing mocking of protected methods when `allowMockingNonExistentMethods` is set to `false` and `shouldAllowMockingProtectedMethods` is called.