### PR TITLE
Add support for PHPUnit 8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ phpunit.xml
 .php_cs.cache
 docs/api
 phpDocumentor.phar*
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "hamcrest/hamcrest-php": "~2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7.10|~6.5|~7.0"
+        "phpunit/phpunit": "~5.7.10|~6.5|~7.0|~8.0"
     },
     "autoload": {
         "psr-0": {

--- a/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegration.php
+++ b/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegration.php
@@ -22,19 +22,27 @@ namespace Mockery\Adapter\Phpunit;
 
 use Mockery;
 
+if (class_exists('PHPUnit_Framework_TestCase') || version_compare(\PHPUnit\Runner\Version::id(), '8.0.0', '<')) {
+    class_alias(MockeryPHPUnitIntegrationAssertPostConditionsForV7AndPrevious::class, MockeryPHPUnitIntegrationAssertPostConditions::class);
+} else {
+    class_alias(MockeryPHPUnitIntegrationAssertPostConditionsForV8::class, MockeryPHPUnitIntegrationAssertPostConditions::class);
+}
+
 /**
  * Integrates Mockery into PHPUnit. Ensures Mockery expectations are verified
  * for each test and are included by the assertion counter.
  */
 trait MockeryPHPUnitIntegration
 {
+    use MockeryPHPUnitIntegrationAssertPostConditions;
+
     protected $mockeryOpen;
 
     /**
      * Performs assertions shared by all tests of a test case. This method is
      * called before execution of a test ends and before the tearDown method.
      */
-    protected function assertPostConditions()
+    protected function mockeryAssertPostConditions()
     {
         $this->addMockeryExpectationsToAssertionCount();
         $this->checkMockeryExceptions();

--- a/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationAssertPostConditionsForV7AndPrevious.php
+++ b/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationAssertPostConditionsForV7AndPrevious.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/blob/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ *
+ * @category   Mockery
+ * @package    Mockery
+ * @copyright  Copyright (c) 2019 Enalean
+ * @license    https://github.com/mockery/mockery/blob/master/LICENSE New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Mockery\Adapter\Phpunit;
+
+trait MockeryPHPUnitIntegrationAssertPostConditionsForV7AndPrevious
+{
+    protected function assertPostConditions()
+    {
+        $this->mockeryAssertPostConditions();
+    }
+}

--- a/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationAssertPostConditionsForV8.php
+++ b/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationAssertPostConditionsForV8.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/blob/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ *
+ * @category   Mockery
+ * @package    Mockery
+ * @copyright  Copyright (c) 2019 Enalean
+ * @license    https://github.com/mockery/mockery/blob/master/LICENSE New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Mockery\Adapter\Phpunit;
+
+trait MockeryPHPUnitIntegrationAssertPostConditionsForV8
+{
+    protected function assertPostConditions() : void
+    {
+        $this->mockeryAssertPostConditions();
+    }
+}

--- a/library/Mockery/Adapter/Phpunit/MockeryTestCase.php
+++ b/library/Mockery/Adapter/Phpunit/MockeryTestCase.php
@@ -20,7 +20,20 @@
 
 namespace Mockery\Adapter\Phpunit;
 
+if (class_exists('PHPUnit_Framework_TestCase') || version_compare(\PHPUnit\Runner\Version::id(), '8.0.0', '<')) {
+    class_alias(MockeryTestCaseSetUpForV7AndPrevious::class, MockeryTestCaseSetUp::class);
+} else {
+    class_alias(MockeryTestCaseSetUpForV8::class, MockeryTestCaseSetUp::class);
+}
 abstract class MockeryTestCase extends \PHPUnit\Framework\TestCase
 {
-    use MockeryPHPUnitIntegration;
+    use MockeryPHPUnitIntegration, MockeryTestCaseSetUp;
+
+    protected function mockeryTestSetUp()
+    {
+    }
+
+    protected function mockeryTestTearDown()
+    {
+    }
 }

--- a/library/Mockery/Adapter/Phpunit/MockeryTestCaseSetUpForV7AndPrevious.php
+++ b/library/Mockery/Adapter/Phpunit/MockeryTestCaseSetUpForV7AndPrevious.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/blob/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ *
+ * @category   Mockery
+ * @package    Mockery
+ * @copyright  Copyright (c) 2019 Enalean
+ * @license    https://github.com/mockery/mockery/blob/master/LICENSE New BSD License
+ */
+
+namespace Mockery\Adapter\Phpunit;
+
+trait MockeryTestCaseSetUpForV7AndPrevious
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->mockeryTestSetUp();
+    }
+
+    protected function tearDown()
+    {
+        $this->mockeryTestTearDown();
+        parent::tearDown();
+    }
+}

--- a/library/Mockery/Adapter/Phpunit/MockeryTestCaseSetUpForV8.php
+++ b/library/Mockery/Adapter/Phpunit/MockeryTestCaseSetUpForV8.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/blob/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ *
+ * @category   Mockery
+ * @package    Mockery
+ * @copyright  Copyright (c) 2019 Enalean
+ * @license    https://github.com/mockery/mockery/blob/master/LICENSE New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Mockery\Adapter\Phpunit;
+
+trait MockeryTestCaseSetUpForV8
+{
+    protected function setUp() : void
+    {
+        parent::setUp();
+        $this->mockeryTestSetUp();
+    }
+
+    protected function tearDown() : void
+    {
+        $this->mockeryTestTearDown();
+        parent::tearDown();
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -29,6 +29,8 @@
             <exclude>
                 <directory>./library/Mockery/Adapter/Phpunit/Legacy</directory>
                 <file>./library/Mockery/Adapter/Phpunit/TestListener.php</file>
+                <file>./library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationAssertPostConditionsForV8.php</file>
+                <file>./library/Mockery/Adapter/Phpunit/MockeryTestCaseSetUpForV8.php</file>
             </exclude>
         </whitelist>
     </filter>

--- a/tests/Mockery/Adapter/Phpunit/TestListenerTest.php
+++ b/tests/Mockery/Adapter/Phpunit/TestListenerTest.php
@@ -21,7 +21,7 @@
 
 namespace tests\Mockery\Adapter\Phpunit;
 
-use PHPUnit\Framework\TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PHPUnit\Framework\TestResult;
 use Mockery\Adapter\Phpunit\TestListener;
 
@@ -33,9 +33,9 @@ if (class_exists('PHPUnit_Runner_Version') && version_compare(\PHPUnit_Runner_Ve
     class_alias('test\Mockery\Fixtures\EmptyTestCaseV7', 'tests\Mockery\Adapter\Phpunit\EmptyTestCase');
 }
 
-class TestListenerTest extends TestCase
+class TestListenerTest extends MockeryTestCase
 {
-    protected function setUp()
+    protected function mockeryTestSetUp()
     {
         /**
          * Skip all tests here if PHPUnit is less than 6.0.0

--- a/tests/Mockery/AdhocTest.php
+++ b/tests/Mockery/AdhocTest.php
@@ -26,12 +26,12 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
  */
 class Mockery_AdhocTest extends MockeryTestCase
 {
-    public function setup()
+    public function mockeryTestSetUp()
     {
         $this->container = new \Mockery\Container(\Mockery::getDefaultGenerator(), \Mockery::getDefaultLoader());
     }
 
-    public function teardown()
+    public function mockeryTestTearDown()
     {
         $this->container->mockery_close();
     }

--- a/tests/Mockery/ContainerTest.php
+++ b/tests/Mockery/ContainerTest.php
@@ -172,13 +172,11 @@ class ContainerTest extends MockeryTestCase
         $this->assertEquals(123, $m->bar());
     }
 
-    /**
-     * @expectedException BadMethodCallException
-     */
     public function testNamedMockWithMakePartialThrowsIfNotAvailable()
     {
         $m = mock("MockeryTest_ClassConstructor2", array($param1 = new stdClass()));
         $m->makePartial();
+        $this->expectException(\BadMethodCallException::class);
         $m->foorbar123();
         $m->mockery_verify();
     }
@@ -243,11 +241,9 @@ class ContainerTest extends MockeryTestCase
         $this->assertEquals('bar', $m->foo());
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testMockingAKnownConcreteFinalClassThrowsErrors_OnlyPartialMocksCanMockFinalElements()
     {
+        $this->expectException(\Mockery\Exception::class);
         $m = mock('MockeryFoo3');
     }
 
@@ -323,7 +319,7 @@ class ContainerTest extends MockeryTestCase
         $this->assertEquals('foo', $file->getFilename());
         $this->assertEquals('path/to/foo', $file->getPathname());
         $this->assertEquals('css', $file->getExtension());
-        $this->assertInternalType('int', $file->getMTime());
+        $this->assertTrue(is_int($file->getMTime()));
     }
 
     public function testCanMockInterface()
@@ -423,7 +419,6 @@ class ContainerTest extends MockeryTestCase
     }
 
     /**
-     * @expectedException \Mockery\Exception
      * @group partial
      */
     public function testThrowsExceptionIfSettingExpectationForNonMockedMethodOfPartialMock()
@@ -431,15 +426,16 @@ class ContainerTest extends MockeryTestCase
         $this->markTestSkipped('For now...');
         $m = mock('MockeryTest_PartialNormalClass[foo]');
         $this->assertInstanceOf(MockeryTest_PartialNormalClass::class, $m);
+        $this->expectException(\Mockery\Exception::class);
         $m->shouldReceive('bar')->andReturn('cba');
     }
 
     /**
-     * @expectedException \Mockery\Exception
      * @group partial
      */
     public function testThrowsExceptionIfClassOrInterfaceForPartialMockDoesNotExist()
     {
+        $this->expectException(\Mockery\Exception::class);
         $m = mock('MockeryTest_PartialNormalClassXYZ[foo]');
     }
 
@@ -564,12 +560,12 @@ class ContainerTest extends MockeryTestCase
 
     /**
      * @group issue/7
-     * @expectedException \Mockery\CountValidator\Exception
      */
     public function testMockedStaticMethodsObeyMethodCounting()
     {
         $m = mock('alias:MyNamespace\MyClass3');
         $m->shouldReceive('staticFoo')->once()->andReturn('bar');
+        $this->expectException(\Mockery\CountValidator\Exception::class);
         Mockery::close();
     }
 
@@ -680,14 +676,12 @@ class ContainerTest extends MockeryTestCase
         $m->shouldReceive('foo')->once()->andReturn('bar');
     }
 
-    /**
-     * @expectedException \Mockery\CountValidator\Exception
-     */
     public function testInstantiationOfInstanceMocksAddsThemToContainerForVerification()
     {
         $m = mock('overload:MyNamespace\MyClass8');
         $m->shouldReceive('foo')->once();
         $instance = new MyNamespace\MyClass8;
+        $this->expectException(\Mockery\CountValidator\Exception::class);
         Mockery::close();
     }
 
@@ -701,9 +695,6 @@ class ContainerTest extends MockeryTestCase
         $instance2->foo();
     }
 
-    /**
-     * @expectedException \Mockery\CountValidator\Exception
-     */
     public function testInstantiationOfInstanceMocksDoesNotHaveCountValidatorCrossover2()
     {
         $m = mock('overload:MyNamespace\MyClass10');
@@ -711,6 +702,7 @@ class ContainerTest extends MockeryTestCase
         $instance1 = new MyNamespace\MyClass10;
         $instance2 = new MyNamespace\MyClass10;
         $instance1->foo();
+        $this->expectException(\Mockery\CountValidator\Exception::class);
         Mockery::close();
     }
 
@@ -753,9 +745,6 @@ class ContainerTest extends MockeryTestCase
         new MyNamespace\MyClass14($params);
     }
 
-    /**
-     * @expectedException \Mockery\Exception\NoMatchingExpectationException
-     */
     public function testInstantiationOfInstanceMockWithConstructorParameterValidationNegative()
     {
         $m = mock('overload:MyNamespace\MyClass15');
@@ -764,19 +753,18 @@ class ContainerTest extends MockeryTestCase
         ];
         $m->shouldReceive('__construct')->with($params);
 
+        $this->expectException(\Mockery\Exception\NoMatchingExpectationException::class);
         new MyNamespace\MyClass15([]);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessageRegExp /^instanceMock \d{3}$/
-     */
     public function testInstantiationOfInstanceMockWithConstructorParameterValidationException()
     {
         $m = mock('overload:MyNamespace\MyClass16');
         $m->shouldReceive('__construct')
             ->andThrow(new \Exception('instanceMock '.rand(100, 999)));
 
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageRegExp('/^instanceMock \d{3}$/');
         new MyNamespace\MyClass16();
     }
 
@@ -1159,23 +1147,24 @@ class ContainerTest extends MockeryTestCase
 
     /**
      * @group issue/154
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage protectedMethod() cannot be mocked as it is a protected method and mocking protected methods is not enabled for the currently used mock object.
      */
     public function testShouldThrowIfAttemptingToStubProtectedMethod()
     {
         $mock = mock('MockeryTest_WithProtectedAndPrivate');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('protectedMethod() cannot be mocked as it is a protected method and mocking protected methods is not enabled for the currently used mock object.');
         $mock->shouldReceive("protectedMethod");
     }
 
     /**
      * @group issue/154
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage privateMethod() cannot be mocked as it is a private method
      */
     public function testShouldThrowIfAttemptingToStubPrivateMethod()
     {
         $mock = mock('MockeryTest_WithProtectedAndPrivate');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('privateMethod() cannot be mocked as it is a private method');
         $mock->shouldReceive("privateMethod");
     }
 
@@ -1197,32 +1186,26 @@ class ContainerTest extends MockeryTestCase
     /**
      * @test
      * @group issue/294
-     * @expectedException Mockery\Exception\RuntimeException
-     * @expectedExceptionMessage Could not load mock DateTime, class already exists
      */
     public function testThrowsWhenNamedMockClassExistsAndIsNotMockery()
     {
         $builder = new MockConfigurationBuilder();
         $builder->setName("DateTime");
+        $this->expectException(\Mockery\Exception\RuntimeException::class);
+        $this->expectExceptionMessage('Could not load mock DateTime, class already exists');
         $mock = mock($builder);
     }
 
-    /**
-     * @expectedException Mockery\Exception\NoMatchingExpectationException
-     * @expectedExceptionMessage MyTestClass::foo(resource(...))
-     */
     public function testHandlesMethodWithArgumentExpectationWhenCalledWithResource()
     {
         $mock = mock('MyTestClass');
         $mock->shouldReceive('foo')->with(array('yourself' => 21));
 
+        $this->expectException(\Mockery\Exception\NoMatchingExpectationException::class);
+        $this->expectExceptionMessage('MyTestClass::foo(resource(...))');
         $mock->foo(fopen('php://memory', 'r'));
     }
 
-    /**
-     * @expectedException Mockery\Exception\NoMatchingExpectationException
-     * @expectedExceptionMessage MyTestClass::foo(['myself' => [...]])
-     */
     public function testHandlesMethodWithArgumentExpectationWhenCalledWithCircularArray()
     {
         $testArray = array();
@@ -1231,13 +1214,11 @@ class ContainerTest extends MockeryTestCase
         $mock = mock('MyTestClass');
         $mock->shouldReceive('foo')->with(array('yourself' => 21));
 
+        $this->expectException(\Mockery\Exception\NoMatchingExpectationException::class);
+        $this->expectExceptionMessage("MyTestClass::foo(['myself' => [...]])");
         $mock->foo($testArray);
     }
 
-    /**
-     * @expectedException Mockery\Exception\NoMatchingExpectationException
-     * @expectedExceptionMessage MyTestClass::foo(['a_scalar' => 2, 'an_array' => [...]])
-     */
     public function testHandlesMethodWithArgumentExpectationWhenCalledWithNestedArray()
     {
         $testArray = array();
@@ -1247,13 +1228,11 @@ class ContainerTest extends MockeryTestCase
         $mock = mock('MyTestClass');
         $mock->shouldReceive('foo')->with(array('yourself' => 21));
 
+        $this->expectException(\Mockery\Exception\NoMatchingExpectationException::class);
+        $this->expectExceptionMessage("MyTestClass::foo(['a_scalar' => 2, 'an_array' => [...]])");
         $mock->foo($testArray);
     }
 
-    /**
-     * @expectedException Mockery\Exception\NoMatchingExpectationException
-     * @expectedExceptionMessage MyTestClass::foo(['a_scalar' => 2, 'an_object' => object(stdClass)])
-     */
     public function testHandlesMethodWithArgumentExpectationWhenCalledWithNestedObject()
     {
         $testArray = array();
@@ -1263,13 +1242,11 @@ class ContainerTest extends MockeryTestCase
         $mock = mock('MyTestClass');
         $mock->shouldReceive('foo')->with(array('yourself' => 21));
 
+        $this->expectException(\Mockery\Exception\NoMatchingExpectationException::class);
+        $this->expectExceptionMessage("MyTestClass::foo(['a_scalar' => 2, 'an_object' => object(stdClass)])");
         $mock->foo($testArray);
     }
 
-    /**
-     * @expectedException Mockery\Exception\NoMatchingExpectationException
-     * @expectedExceptionMessage MyTestClass::foo(['a_scalar' => 2, 'a_closure' => object(Closure
-     */
     public function testHandlesMethodWithArgumentExpectationWhenCalledWithNestedClosure()
     {
         $testArray = array();
@@ -1280,13 +1257,11 @@ class ContainerTest extends MockeryTestCase
         $mock = mock('MyTestClass');
         $mock->shouldReceive('foo')->with(array('yourself' => 21));
 
+        $this->expectException(\Mockery\Exception\NoMatchingExpectationException::class);
+        $this->expectExceptionMessage("MyTestClass::foo(['a_scalar' => 2, 'a_closure' => object(Closure");
         $mock->foo($testArray);
     }
 
-    /**
-     * @expectedException Mockery\Exception\NoMatchingExpectationException
-     * @expectedExceptionMessage MyTestClass::foo(['a_scalar' => 2, 'a_resource' => resource(...)])
-     */
     public function testHandlesMethodWithArgumentExpectationWhenCalledWithNestedResource()
     {
         $testArray = array();
@@ -1296,6 +1271,8 @@ class ContainerTest extends MockeryTestCase
         $mock = mock('MyTestClass');
         $mock->shouldReceive('foo')->with(array('yourself' => 21));
 
+        $this->expectException(\Mockery\Exception\NoMatchingExpectationException::class);
+        $this->expectExceptionMessage("MyTestClass::foo(['a_scalar' => 2, 'a_resource' => resource(...)])");
         $mock->foo($testArray);
     }
 

--- a/tests/Mockery/DemeterChainTest.php
+++ b/tests/Mockery/DemeterChainTest.php
@@ -30,12 +30,12 @@ class DemeterChainTest extends MockeryTestCase
     /** @var  Mockery\Mock $this->mock */
     private $mock;
 
-    public function setUp()
+    public function mockeryTestSetUp()
     {
         $this->mock = $this->mock = Mockery::mock()->shouldIgnoreMissing();
     }
 
-    public function tearDown()
+    public function mockeryTestTearDown()
     {
         $this->mock->mockery_getContainer()->mockery_close();
     }

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -25,15 +25,15 @@ use Mockery\MockInterface;
 
 class ExpectationTest extends MockeryTestCase
 {
-    public function setup()
+    public function mockeryTestSetUp()
     {
-        parent::setUp();
+        parent::mockeryTestSetUp();
         $this->mock = mock();
     }
 
-    public function teardown()
+    public function mockeryTestTearDown()
     {
-        parent::tearDown();
+        parent::mockeryTestTearDown();
         \Mockery::getConfiguration()->allowMockingNonExistentMethods(true);
     }
 
@@ -116,7 +116,7 @@ class ExpectationTest extends MockeryTestCase
     {
         $this->mock->bar = null;
         $this->mock->shouldReceive('foo')->set('bar', 'baz', 'bazz', 'bazzz');
-        $this->assertAttributeEmpty('bar', $this->mock);
+        $this->assertTrue(empty($this->mock->bar));
         $this->mock->foo();
         $this->assertEquals('baz', $this->mock->bar);
         $this->mock->foo();
@@ -232,12 +232,10 @@ class ExpectationTest extends MockeryTestCase
         $this->assertEquals(3, $this->mock->foo());
     }
 
-    /**
-     * @expectedException OutOfBoundsException
-     */
     public function testThrowsException()
     {
         $this->mock->shouldReceive('foo')->andThrow(new OutOfBoundsException);
+        $this->expectException(OutOfBoundsException::class);
         $this->mock->foo();
         Mockery::close();
     }
@@ -262,12 +260,10 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
     }
 
-    /**
-     * @expectedException OutOfBoundsException
-     */
     public function testThrowsExceptionBasedOnArgs()
     {
         $this->mock->shouldReceive('foo')->andThrow('OutOfBoundsException');
+        $this->expectException(OutOfBoundsException::class);
         $this->mock->foo();
         Mockery::close();
     }
@@ -282,9 +278,6 @@ class ExpectationTest extends MockeryTestCase
         }
     }
 
-    /**
-     * @expectedException OutOfBoundsException
-     */
     public function testThrowsExceptionSequentially()
     {
         $this->mock->shouldReceive('foo')->andThrow(new Exception)->andThrow(new OutOfBoundsException);
@@ -292,6 +285,7 @@ class ExpectationTest extends MockeryTestCase
             $this->mock->foo();
         } catch (Exception $e) {
         }
+        $this->expectException(OutOfBoundsException::class);
         $this->mock->foo();
         Mockery::close();
     }
@@ -318,12 +312,10 @@ class ExpectationTest extends MockeryTestCase
         }
     }
 
-    /**
-     * @expectedException Mockery\Exception
-     * @expectedExceptionMessage You must pass an array of exception objects to andThrowExceptions
-     */
     public function testAndThrowExceptionsCatchNonExceptionArgument()
     {
+        $this->expectException(\Mockery\Exception::class);
+        $this->expectExceptionMessage('You must pass an array of exception objects to andThrowExceptions');
         $this->mock
             ->shouldReceive('foo')
             ->andThrowExceptions(array('NotAnException'));
@@ -344,12 +336,10 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testExpectsNoArgumentsThrowsExceptionIfAnyPassed()
     {
         $this->mock->shouldReceive('foo')->withNoArgs();
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo(1);
         Mockery::close();
     }
@@ -360,53 +350,43 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, 2);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testExpectsArgumentsArrayThrowsExceptionIfPassedEmptyArray()
     {
         $this->mock->shouldReceive('foo')->withArgs(array());
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo(1, 2);
         Mockery::close();
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testExpectsArgumentsArrayThrowsExceptionIfNoArgumentsPassed()
     {
         $this->mock->shouldReceive('foo')->with();
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo(1);
         Mockery::close();
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testExpectsArgumentsArrayThrowsExceptionIfPassedWrongArguments()
     {
         $this->mock->shouldReceive('foo')->withArgs(array(1, 2));
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo(3, 4);
         Mockery::close();
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     * @expectedExceptionMessageRegExp /foo\(NULL\)/
-     */
     public function testExpectsStringArgumentExceptionMessageDifferentiatesBetweenNullAndEmptyString()
     {
         $this->mock->shouldReceive('foo')->withArgs(array('a string'));
+        $this->expectException(\Mockery\Exception::class);
+        $this->expectExceptionMessageRegExp('/foo\(NULL\)/');
         $this->mock->foo(null);
         Mockery::close();
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /invalid argument (.+), only array and closure are allowed/
-     */
     public function testExpectsArgumentsArrayThrowsExceptionIfPassedWrongArgumentType()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageRegExp('/invalid argument (.+), only array and closure are allowed/');
         $this->mock->shouldReceive('foo')->withArgs(5);
         Mockery::close();
     }
@@ -420,15 +400,13 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, 2);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testExpectsArgumentsArrayThrowsExceptionWhenClosureEvaluatesToFalse()
     {
         $closure = function ($odd, $even) {
             return ($odd % 2 != 0) && ($even % 2 == 0);
         };
         $this->mock->shouldReceive('foo')->withArgs($closure);
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo(4, 2);
         Mockery::close();
     }
@@ -459,9 +437,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, 4, 5);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testExpectsArgumentsArrayClosureThrowsExceptionIfOptionalArgumentsDontMatchTheExpectation()
     {
         $closure = function ($odd, $even, $sum = null) {
@@ -472,6 +447,7 @@ class ExpectationTest extends MockeryTestCase
             return $result;
         };
         $this->mock->shouldReceive('foo')->withArgs($closure);
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo(1, 4, 2);
         Mockery::close();
     }
@@ -490,12 +466,10 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(new stdClass);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testThrowsExceptionOnNoArgumentMatch()
     {
         $this->mock->shouldReceive('foo')->with(1);
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo(2);
         Mockery::close();
     }
@@ -510,32 +484,26 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->shouldNotReceive('foo');
     }
 
-    /**
-     * @expectedException \Mockery\Exception\InvalidCountException
-     */
     public function testShouldNotReceiveThrowsExceptionIfMethodCalled()
     {
         $this->mock->shouldNotReceive('foo');
+        $this->expectException(\Mockery\Exception\InvalidCountException::class);
         $this->mock->foo();
         Mockery::close();
     }
 
-    /**
-     * @expectedException \Mockery\Exception\InvalidCountException
-     */
     public function testShouldNotReceiveWithArgumentThrowsExceptionIfMethodCalled()
     {
         $this->mock->shouldNotReceive('foo')->with(2);
+        $this->expectException(\Mockery\Exception\InvalidCountException::class);
         $this->mock->foo(2);
         Mockery::close();
     }
 
-    /**
-     * @expectedException \Mockery\CountValidator\Exception
-     */
     public function testNeverCalledThrowsExceptionOnCall()
     {
         $this->mock->shouldReceive('foo')->never();
+        $this->expectException(\Mockery\CountValidator\Exception::class);
         $this->mock->foo();
         Mockery::close();
     }
@@ -546,22 +514,18 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
     }
 
-    /**
-     * @expectedException \Mockery\CountValidator\Exception
-     */
     public function testCalledOnceThrowsExceptionIfNotCalled()
     {
+        $this->expectException(\Mockery\CountValidator\Exception::class);
         $this->mock->shouldReceive('foo')->once();
         Mockery::close();
     }
 
-    /**
-     * @expectedException \Mockery\CountValidator\Exception
-     */
     public function testCalledOnceThrowsExceptionIfCalledTwice()
     {
         $this->mock->shouldReceive('foo')->once();
         $this->mock->foo();
+        $this->expectException(\Mockery\CountValidator\Exception::class);
         $this->mock->foo();
         Mockery::close();
     }
@@ -573,23 +537,19 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
     }
 
-    /**
-     * @expectedException \Mockery\CountValidator\Exception
-     */
     public function testCalledTwiceThrowsExceptionIfNotCalled()
     {
         $this->mock->shouldReceive('foo')->twice();
+        $this->expectException(\Mockery\CountValidator\Exception::class);
         Mockery::close();
     }
 
-    /**
-     * @expectedException \Mockery\CountValidator\Exception
-     */
     public function testCalledOnceThrowsExceptionIfCalledThreeTimes()
     {
         $this->mock->shouldReceive('foo')->twice();
         $this->mock->foo();
         $this->mock->foo();
+        $this->expectException(\Mockery\CountValidator\Exception::class);
         $this->mock->foo();
         Mockery::close();
     }
@@ -616,24 +576,20 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
     }
 
-    /**
-     * @expectedException \Mockery\CountValidator\Exception
-     */
     public function testTimesCountCallThrowsExceptionOnTooFewCalls()
     {
         $this->mock->shouldReceive('foo')->times(2);
         $this->mock->foo();
+        $this->expectException(\Mockery\CountValidator\Exception::class);
         Mockery::close();
     }
 
-    /**
-     * @expectedException \Mockery\CountValidator\Exception
-     */
     public function testTimesCountCallThrowsExceptionOnTooManyCalls()
     {
         $this->mock->shouldReceive('foo')->times(2);
         $this->mock->foo();
         $this->mock->foo();
+        $this->expectException(\Mockery\CountValidator\Exception::class);
         $this->mock->foo();
         Mockery::close();
     }
@@ -652,13 +608,11 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
     }
 
-    /**
-     * @expectedException \Mockery\CountValidator\Exception
-     */
     public function testCalledAtLeastThrowsExceptionOnTooFewCalls()
     {
         $this->mock->shouldReceive('foo')->atLeast()->twice();
         $this->mock->foo();
+        $this->expectException(\Mockery\CountValidator\Exception::class);
         Mockery::close();
     }
 
@@ -676,25 +630,21 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
     }
 
-    /**
-     * @expectedException \Mockery\CountValidator\Exception
-     */
     public function testCalledAtLeastThrowsExceptionOnTooManyCalls()
     {
         $this->mock->shouldReceive('foo')->atMost()->twice();
         $this->mock->foo();
         $this->mock->foo();
+        $this->expectException(\Mockery\CountValidator\Exception::class);
         $this->mock->foo();
         Mockery::close();
     }
 
-    /**
-     * @expectedException \Mockery\CountValidator\Exception
-     */
     public function testExactCountersOverrideAnyPriorSetNonExactCounters()
     {
         $this->mock->shouldReceive('foo')->atLeast()->once()->once();
         $this->mock->foo();
+        $this->expectException(\Mockery\CountValidator\Exception::class);
         $this->mock->foo();
         Mockery::close();
     }
@@ -712,22 +662,18 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
     }
 
-    /**
-     * @expectedException \Mockery\CountValidator\Exception
-     */
     public function testComboOfLeastAndMostCallsThrowsExceptionAtTooFewCalls()
     {
         $this->mock->shouldReceive('foo')->atleast()->once()->atMost()->twice();
+        $this->expectException(\Mockery\CountValidator\Exception::class);
         Mockery::close();
     }
 
-    /**
-     * @expectedException \Mockery\CountValidator\Exception
-     */
     public function testComboOfLeastAndMostCallsThrowsExceptionAtTooManyCalls()
     {
         $this->mock->shouldReceive('foo')->atleast()->once()->atMost()->twice();
         $this->mock->foo();
+        $this->expectException(\Mockery\CountValidator\Exception::class);
         $this->mock->foo();
         $this->mock->foo();
         Mockery::close();
@@ -744,9 +690,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(3);
     }
 
-    /**
-     * @expectedException \Mockery\CountValidator\Exception
-     */
     public function testCallCountingThrowsExceptionOnAnyMismatch()
     {
         $this->mock->shouldReceive('foo')->with(1)->once();
@@ -757,12 +700,10 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(2);
         $this->mock->foo(3);
         $this->mock->bar();
+        $this->expectException(\Mockery\CountValidator\Exception::class);
         Mockery::close();
     }
 
-    /**
-     * @expectedException \Mockery\Exception\InvalidCountException
-     */
     public function testCallCountingThrowsExceptionFirst()
     {
         $number_of_calls = 0;
@@ -775,6 +716,7 @@ class ExpectationTest extends MockeryTestCase
 
         $this->mock->foo(1);
         $this->mock->foo(1);
+        $this->expectException(\Mockery\CountValidator\Exception::class);
         $this->mock->foo(1);
         Mockery::close();
     }
@@ -787,13 +729,11 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->bar();
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testOrderedCallsWithOutOfOrderError()
     {
         $this->mock->shouldReceive('foo')->ordered();
         $this->mock->shouldReceive('bar')->ordered();
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->bar();
         $this->mock->foo();
         Mockery::close();
@@ -807,13 +747,11 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(2);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testDifferentArgumentsAndOrderingsThrowExceptionWhenInWrongOrder()
     {
         $this->mock->shouldReceive('foo')->with(1)->ordered();
         $this->mock->shouldReceive('foo')->with(2)->ordered();
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo(2);
         $this->mock->foo(1);
         Mockery::close();
@@ -839,13 +777,11 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->bar();
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testOrderingOfDefaultGroupingThrowsExceptionOnWrongOrder()
     {
         $this->mock->shouldReceive('foo')->ordered();
         $this->mock->shouldReceive('bar')->ordered();
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->bar();
         $this->mock->foo();
         Mockery::close();
@@ -889,13 +825,11 @@ class ExpectationTest extends MockeryTestCase
         $this->assertLessThan($e->getOrderNumber(), $m->getOrderNumber());
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testGroupedOrderingThrowsExceptionWhenCallsDisordered()
     {
         $this->mock->shouldReceive('foo')->ordered('first');
         $this->mock->shouldReceive('bar')->ordered('second');
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->bar();
         $this->mock->foo();
         Mockery::close();
@@ -930,14 +864,12 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testEnsuresOrderingIsCrossMockWhenGloballyFlagSet()
     {
         $this->mock->shouldReceive('foo')->globally()->ordered();
         $mock2 = mock('bar');
         $mock2->shouldReceive('bar')->globally()->ordered();
+        $this->expectException(\Mockery\Exception::class);
         $mock2->bar();
         $this->mock->foo();
         Mockery::close();
@@ -1004,13 +936,11 @@ class ExpectationTest extends MockeryTestCase
         $this->assertEquals('bar', $this->mock->foo(1));
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testDefaultExpectationsCanBeOrdered()
     {
         $this->mock->shouldReceive('foo')->ordered()->byDefault();
         $this->mock->shouldReceive('bar')->ordered()->byDefault();
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->bar();
         $this->mock->foo();
         Mockery::close();
@@ -1049,13 +979,11 @@ class ExpectationTest extends MockeryTestCase
         $this->assertEquals('newbar', $this->mock->foo('test'));
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testByDefaultPreventedFromSettingDefaultWhenDefaultingExpectationWasReplaced()
     {
         $exp = $this->mock->shouldReceive('foo')->andReturn(1);
         $this->mock->shouldReceive('foo')->andReturn(2);
+        $this->expectException(\Mockery\Exception::class);
         $exp->byDefault();
         Mockery::close();
     }
@@ -1087,12 +1015,10 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, 'str', 3, 4);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testAndAnyOtherConstraintDoesNotPreventMatchingOfRegularArguments()
     {
         $this->mock->shouldReceive('foo')->with(1, 2, Mockery::andAnyOthers());
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo(10, 2, 3, 4, 5);
         Mockery::close();
     }
@@ -1112,12 +1038,10 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, 2, 3);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testArrayConstraintThrowsExceptionWhenConstraintUnmatched()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::type('array'));
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo(1);
         Mockery::close();
     }
@@ -1137,12 +1061,10 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, 2, 3);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testBoolConstraintThrowsExceptionWhenConstraintUnmatched()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::type('bool'));
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo(1);
         Mockery::close();
     }
@@ -1164,12 +1086,10 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, 2, 3);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testCallableConstraintThrowsExceptionWhenConstraintUnmatched()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::type('callable'));
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo(1);
         Mockery::close();
     }
@@ -1189,12 +1109,10 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, 2, 3);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testDoubleConstraintThrowsExceptionWhenConstraintUnmatched()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::type('double'));
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo(1);
         Mockery::close();
     }
@@ -1214,12 +1132,10 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, 2, 3);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testFloatConstraintThrowsExceptionWhenConstraintUnmatched()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::type('float'));
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo(1);
         Mockery::close();
     }
@@ -1239,12 +1155,10 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, 2, 3);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testIntConstraintThrowsExceptionWhenConstraintUnmatched()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::type('int'));
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo('f');
         Mockery::close();
     }
@@ -1264,12 +1178,10 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, 2, 3);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testLongConstraintThrowsExceptionWhenConstraintUnmatched()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::type('long'));
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo('f');
         Mockery::close();
     }
@@ -1289,12 +1201,10 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, 2, 3);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testNullConstraintThrowsExceptionWhenConstraintUnmatched()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::type('null'));
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo('f');
         Mockery::close();
     }
@@ -1314,12 +1224,10 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, 2, 3);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testNumericConstraintThrowsExceptionWhenConstraintUnmatched()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::type('numeric'));
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo('f');
         Mockery::close();
     }
@@ -1339,12 +1247,10 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, 2, 3);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testObjectConstraintThrowsExceptionWhenConstraintUnmatched()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::type('object'));
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo('f');
         Mockery::close();
     }
@@ -1364,12 +1270,10 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, 2, 3);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testRealConstraintThrowsExceptionWhenConstraintUnmatched()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::type('real'));
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo('f');
         Mockery::close();
     }
@@ -1390,12 +1294,10 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, 2, 3);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testResourceConstraintThrowsExceptionWhenConstraintUnmatched()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::type('resource'));
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo('f');
         Mockery::close();
     }
@@ -1415,12 +1317,10 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, 2, 3);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testScalarConstraintThrowsExceptionWhenConstraintUnmatched()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::type('scalar'));
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo(array());
         Mockery::close();
     }
@@ -1440,12 +1340,10 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, 2, 3);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testStringConstraintThrowsExceptionWhenConstraintUnmatched()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::type('string'));
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo(1);
         Mockery::close();
     }
@@ -1465,12 +1363,10 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, 2, 3);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testClassConstraintThrowsExceptionWhenConstraintUnmatched()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::type('stdClass'));
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo(new Exception);
         Mockery::close();
     }
@@ -1490,12 +1386,10 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, 2, 3);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testDucktypeConstraintThrowsExceptionWhenConstraintUnmatched()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::ducktype('quack', 'swim'));
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo(new Mockery_Duck_Nonswimmer);
         Mockery::close();
     }
@@ -1515,12 +1409,10 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, 2, 3);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testArrayContentConstraintThrowsExceptionWhenConstraintUnmatched()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::subset(array('a'=>1, 'b'=>2)));
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo(array('a'=>1, 'c'=>3));
         Mockery::close();
     }
@@ -1540,12 +1432,10 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, 2, 3);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testContainsConstraintThrowsExceptionWhenConstraintUnmatched()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::contains(1, 2));
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo(array('a'=>1, 'c'=>3));
         Mockery::close();
     }
@@ -1565,12 +1455,10 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, array('a'=>1), 3);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testHasKeyConstraintThrowsExceptionWhenConstraintUnmatched()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::hasKey('c'));
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo(array('a'=>1, 'b'=>3));
         Mockery::close();
     }
@@ -1590,12 +1478,10 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, array('a'=>1), 3);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testHasValueConstraintThrowsExceptionWhenConstraintUnmatched()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::hasValue(2));
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo(array('a'=>1, 'b'=>3));
         Mockery::close();
     }
@@ -1618,15 +1504,13 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo([4, 5]);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testOnConstraintThrowsExceptionWhenConstraintUnmatched_ClosureEvaluatesToFalse()
     {
         $function = function ($arg) {
             return $arg % 2 == 0;
         };
         $this->mock->shouldReceive('foo')->with(Mockery::on($function));
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo(5);
         Mockery::close();
     }
@@ -1646,12 +1530,10 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, 2, 3);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testMustBeConstraintThrowsExceptionWhenConstraintUnmatched()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::mustBe(2));
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo('2');
         Mockery::close();
     }
@@ -1677,9 +1559,6 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, $a, 3);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testMustBeConstraintThrowsExceptionWhenConstraintUnmatchedWithObject()
     {
         $a = new stdClass;
@@ -1687,6 +1566,7 @@ class ExpectationTest extends MockeryTestCase
         $b = new stdClass;
         $b->foo = 2;
         $this->mock->shouldReceive('foo')->with(Mockery::mustBe($a));
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo($b);
         Mockery::close();
     }
@@ -1736,8 +1616,8 @@ class ExpectationTest extends MockeryTestCase
     public function testShouldIgnoreMissingAsDefinedProxiesToUndefinedAllowingToString()
     {
         $this->mock->shouldIgnoreMissing()->asUndefined();
-        $this->assertInternalType('string', "{$this->mock->g()}");
-        $this->assertInternalType('string', "{$this->mock}");
+        $this->assertTrue(is_string("{$this->mock->g()}"));
+        $this->assertTrue(is_string("{$this->mock}"));
     }
 
     public function testShouldIgnoreMissingDefaultReturnValue()
@@ -1780,12 +1660,10 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, 2, 3);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testNotConstraintThrowsExceptionWhenConstraintUnmatched()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::not(2));
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo(2);
         Mockery::close();
     }
@@ -1806,31 +1684,25 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, 2, 3);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testAnyOfConstraintThrowsExceptionWhenConstraintUnmatched()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::anyOf(1, 2));
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo(3);
         Mockery::close();
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testAnyOfConstraintThrowsExceptionWhenTrueIsNotAnExpectedArgument()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::anyOf(1, 2));
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo(true);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testAnyOfConstraintThrowsExceptionWhenFalseIsNotAnExpectedArgument()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::anyOf(0, 1, 2));
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo(false);
     }
 
@@ -1849,12 +1721,10 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, 4, 3);
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testNotAnyOfConstraintThrowsExceptionWhenConstraintUnmatched()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::notAnyOf(1, 2));
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo(2);
         Mockery::close();
     }
@@ -1872,46 +1742,38 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo('bar');
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testPatternConstraintThrowsExceptionWhenConstraintUnmatched()
     {
         $this->mock->shouldReceive('foo')->with(Mockery::pattern('/foo.*/'));
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo('bar');
         Mockery::close();
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testGlobalConfigMayForbidMockingNonExistentMethodsOnClasses()
     {
         \Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
         $mock = mock('stdClass');
+        $this->expectException(\Mockery\Exception::class);
         $mock->shouldReceive('foo');
         Mockery::close();
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     * @expectedExceptionMessage Mockery can't find 'SomeMadeUpClass' so can't mock it
-     */
     public function testGlobalConfigMayForbidMockingNonExistentMethodsOnAutoDeclaredClasses()
     {
         \Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
+        $this->expectException(\Mockery\Exception::class);
+        $this->expectExceptionMessage("Mockery can't find 'SomeMadeUpClass' so can't mock it");
         $mock = mock('SomeMadeUpClass');
         $mock->shouldReceive('foo');
         Mockery::close();
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testGlobalConfigMayForbidMockingNonExistentMethodsOnObjects()
     {
         \Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
         $mock = mock(new stdClass);
+        $this->expectException(\Mockery\Exception::class);
         $mock->shouldReceive('foo');
         Mockery::close();
     }
@@ -2065,11 +1927,9 @@ class ExpectationTest extends MockeryTestCase
         $this->assertEquals($this->mock->foo(), 'blue');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testTimesExpectationForbidsFloatNumbers()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->mock->shouldReceive('foo')->times(1.3);
         Mockery::close();
     }
@@ -2108,13 +1968,11 @@ class ExpectationTest extends MockeryTestCase
         $this->assertFalse($waterMock->mockery_isAnonymous());
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
     public function testWetherMockWithInterfaceOnlyCanNotImplementNonExistingMethods()
     {
         \Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
         $waterMock = \Mockery::mock('IWater');
+        $this->expectException(\Mockery\Exception::class);
         $waterMock
             ->shouldReceive('nonExistentMethod')
             ->once()

--- a/tests/Mockery/Generator/MockConfigurationTest.php
+++ b/tests/Mockery/Generator/MockConfigurationTest.php
@@ -110,10 +110,10 @@ class MockConfigurationTest extends TestCase
 
     /**
      * @test
-     * @expectedException Mockery\Exception
      */
     public function shouldThrowIfTargetClassIsFinal()
     {
+        $this->expectException(\Mockery\Exception::class);
         $config = new MockConfiguration(array("Mockery\\Generator\\TestFinal"));
         $config->getTargetClass();
     }

--- a/tests/Mockery/Generator/StringManipulation/Pass/CallTypeHintPassTest.php
+++ b/tests/Mockery/Generator/StringManipulation/Pass/CallTypeHintPassTest.php
@@ -41,7 +41,7 @@ class CallTypeHintPassTest extends TestCase
             "requiresCallTypeHintRemoval" => true,
         ))->makePartial();
         $code = $pass->apply(static::CODE, $config);
-        $this->assertContains('__call($method, $args)', $code);
+        $this->assertTrue(\mb_strpos($code, '__call($method, $args)') !== false);
     }
 
     /**
@@ -54,6 +54,6 @@ class CallTypeHintPassTest extends TestCase
             "requiresCallStaticTypeHintRemoval" => true,
         ))->makePartial();
         $code = $pass->apply(static::CODE, $config);
-        $this->assertContains('__callStatic($method, $args)', $code);
+        $this->assertTrue(\mb_strpos($code, '__callStatic($method, $args)') !== false);
     }
 }

--- a/tests/Mockery/Generator/StringManipulation/Pass/ClassNamePassTest.php
+++ b/tests/Mockery/Generator/StringManipulation/Pass/ClassNamePassTest.php
@@ -21,16 +21,14 @@
 
 namespace Mockery\Generator\StringManipulation\Pass;
 
-use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\Generator\MockConfiguration;
-use Mockery\Generator\StringManipulation\Pass\ClassNamePass;
-use PHPUnit\Framework\TestCase;
 
-class ClassNamePassTest extends TestCase
+class ClassNamePassTest extends MockeryTestCase
 {
     const CODE = "namespace Mockery; class Mock {}";
 
-    public function setup()
+    public function mockeryTestSetUp()
     {
         $this->pass = new ClassNamePass();
     }
@@ -42,7 +40,7 @@ class ClassNamePassTest extends TestCase
     {
         $config = new MockConfiguration(array(), array(), array(), "Dave\Dave");
         $code = $this->pass->apply(static::CODE, $config);
-        $this->assertNotContains('namespace Mockery;', $code);
+        $this->assertTrue(\mb_strpos($code, 'namespace Mockery;') === false);
     }
 
     /**
@@ -52,8 +50,8 @@ class ClassNamePassTest extends TestCase
     {
         $config = new MockConfiguration(array(), array(), array(), "Dave\Dave");
         $code = $this->pass->apply(static::CODE, $config);
-        $this->assertNotContains('namespace Mockery;', $code);
-        $this->assertContains('namespace Dave;', $code);
+        $this->assertTrue(\mb_strpos($code, 'namespace Mockery;') === false);
+        $this->assertTrue(\mb_strpos($code, 'namespace Dave;') !== false);
     }
 
     /**
@@ -63,7 +61,7 @@ class ClassNamePassTest extends TestCase
     {
         $config = new MockConfiguration(array(), array(), array(), "Dave");
         $code = $this->pass->apply(static::CODE, $config);
-        $this->assertContains('class Dave', $code);
+        $this->assertTrue(\mb_strpos($code, 'class Dave') !== false);
     }
 
     /**
@@ -73,6 +71,6 @@ class ClassNamePassTest extends TestCase
     {
         $config = new MockConfiguration(array(), array(), array(), "\Dave\Dave");
         $code = $this->pass->apply(static::CODE, $config);
-        $this->assertContains('namespace Dave;', $code);
+        $this->assertTrue(\mb_strpos($code, 'namespace Dave;') !== false);
     }
 }

--- a/tests/Mockery/Generator/StringManipulation/Pass/ClassPassTest.php
+++ b/tests/Mockery/Generator/StringManipulation/Pass/ClassPassTest.php
@@ -21,15 +21,14 @@
 
 namespace Mockery\Generator\StringManipulation\Pass;
 
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\Generator\MockConfiguration;
-use Mockery\Generator\StringManipulation\Pass\ClassPass;
-use PHPUnit\Framework\TestCase;
 
-class ClassPassTest extends TestCase
+class ClassPassTest extends MockeryTestCase
 {
     const CODE = "class Mock implements MockInterface {}";
 
-    public function setup()
+    public function mockeryTestSetUp()
     {
         $this->pass = new ClassPass();
     }
@@ -41,7 +40,7 @@ class ClassPassTest extends TestCase
     {
         $config = new MockConfiguration(array("Testing\TestClass"), array(), array(), "Dave\Dave");
         $code = $this->pass->apply(static::CODE, $config);
-        $this->assertContains('class Mock extends \Testing\TestClass implements MockInterface', $code);
+        $this->assertTrue(\mb_strpos($code, 'class Mock extends \Testing\TestClass implements MockInterface') !== false);
     }
 
     /**

--- a/tests/Mockery/Generator/StringManipulation/Pass/ConstantsPassTest.php
+++ b/tests/Mockery/Generator/StringManipulation/Pass/ConstantsPassTest.php
@@ -47,6 +47,6 @@ class ConstantsPassTest extends TestCase
             ['ClassWithConstants' => ['FOO' => 'test']]
         );
         $code = $pass->apply(static::CODE, $config);
-        $this->assertContains("const FOO = 'test'", $code);
+        $this->assertTrue(\mb_strpos($code, "const FOO = 'test'") !== false);
     }
 }

--- a/tests/Mockery/Generator/StringManipulation/Pass/InstanceMockPassTest.php
+++ b/tests/Mockery/Generator/StringManipulation/Pass/InstanceMockPassTest.php
@@ -38,8 +38,8 @@ class InstanceMockPassTest extends TestCase
         $config = $builder->getMockConfiguration();
         $pass = new InstanceMockPass;
         $code = $pass->apply('class Dave { }', $config);
-        $this->assertContains('public function __construct', $code);
-        $this->assertContains('protected $_mockery_ignoreVerification', $code);
-        $this->assertContains('this->_mockery_constructorCalled(func_get_args());', $code);
+        $this->assertTrue(\mb_strpos($code, 'public function __construct') !== false);
+        $this->assertTrue(\mb_strpos($code, 'protected $_mockery_ignoreVerification') !== false);
+        $this->assertTrue(\mb_strpos($code, 'this->_mockery_constructorCalled(func_get_args());') !== false);
     }
 }

--- a/tests/Mockery/Generator/StringManipulation/Pass/InterfacePassTest.php
+++ b/tests/Mockery/Generator/StringManipulation/Pass/InterfacePassTest.php
@@ -61,6 +61,6 @@ class InterfacePassTest extends TestCase
 
         $code = $pass->apply(static::CODE, $config);
 
-        $this->assertContains("implements MockInterface, \Dave\Dave, \Paddy\Paddy", $code);
+        $this->assertTrue(\mb_strpos($code, "implements MockInterface, \Dave\Dave, \Paddy\Paddy") !== false);
     }
 }

--- a/tests/Mockery/GlobalHelpersTest.php
+++ b/tests/Mockery/GlobalHelpersTest.php
@@ -18,16 +18,16 @@
  * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
  */
 
-use PHPUnit\Framework\TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class GlobalHelpersTest extends TestCase
+class GlobalHelpersTest extends MockeryTestCase
 {
-    public function setup()
+    public function mockeryTestSetUp()
     {
         \Mockery::globalHelpers();
     }
 
-    public function tearDown()
+    public function mockeryTestTearDown()
     {
         \Mockery::close();
     }

--- a/tests/Mockery/HamcrestExpectationTest.php
+++ b/tests/Mockery/HamcrestExpectationTest.php
@@ -23,17 +23,17 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 class HamcrestExpectationTest extends MockeryTestCase
 {
-    public function setUp()
+    public function mockeryTestSetUp()
     {
-        parent::setUp();
+        parent::mockeryTestSetUp();
         $this->mock = mock('foo');
     }
 
 
-    public function tearDown()
+    public function mockeryTestTearDown()
     {
         \Mockery::getConfiguration()->allowMockingNonExistentMethods(true);
-        parent::tearDown();
+        parent::mockeryTestTearDown();
     }
 
     /** Just a quickie roundup of a few Hamcrest matchers to check nothing obvious out of place **/
@@ -50,12 +50,10 @@ class HamcrestExpectationTest extends MockeryTestCase
         $this->mock->foo(2);
     }
 
-    /**
-     * @expectedException Mockery\Exception
-     */
     public function testGreaterThanConstraintNotMatchesArgument()
     {
         $this->mock->shouldReceive('foo')->with(greaterThan(1));
+        $this->expectException(\Mockery\Exception::class);
         $this->mock->foo(1);
         Mockery::close();
     }

--- a/tests/Mockery/Matcher/PHPUnitConstraintTest.php
+++ b/tests/Mockery/Matcher/PHPUnitConstraintTest.php
@@ -19,11 +19,11 @@
  * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
  */
 
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\MockInterface;
 use Mockery\Matcher\PHPUnitConstraint;
-use PHPUnit\Framework\TestCase;
 
-class PHPUnitConstraintTest extends TestCase
+class PHPUnitConstraintTest extends MockeryTestCase
 {
     /** @var  PHPUnitConstraint */
     protected $matcher;
@@ -32,7 +32,7 @@ class PHPUnitConstraintTest extends TestCase
     /** @var  MockInterface */
     protected $constraint;
 
-    public function setUp()
+    public function mockeryTestSetUp()
     {
         /*
          * Revise by PHPUnit version

--- a/tests/Mockery/MockClassWithFinalWakeupTest.php
+++ b/tests/Mockery/MockClassWithFinalWakeupTest.php
@@ -25,12 +25,12 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 class MockClassWithFinalWakeupTest extends MockeryTestCase
 {
-    protected function setUp()
+    protected function mockeryTestSetUp()
     {
         $this->container = new \Mockery\Container;
     }
 
-    protected function tearDown()
+    protected function mockeryTestTearDown()
     {
         $this->container->mockery_close();
     }

--- a/tests/Mockery/MockClassWithMethodOverloadingTest.php
+++ b/tests/Mockery/MockClassWithMethodOverloadingTest.php
@@ -6,14 +6,13 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 class MockClassWithMethodOverloadingTest extends MockeryTestCase
 {
-    /**
-     * @expectedException BadMethodCallException
-     */
     public function testCreateMockForClassWithMethodOverloading()
     {
         $mock = mock('test\Mockery\TestWithMethodOverloading')
             ->makePartial();
         $this->assertInstanceOf('test\Mockery\TestWithMethodOverloading', $mock);
+
+        $this->expectException(\BadMethodCallException::class);
 
         // TestWithMethodOverloading::__call wouldn't be used. See Gotchas!.
         $mock->randomMethod();

--- a/tests/Mockery/MockTest.php
+++ b/tests/Mockery/MockTest.php
@@ -92,23 +92,19 @@ class Mockery_MockTest extends MockeryTestCase
         $this->assertNull($mock->nonExistingMethod());
     }
 
-    /**
-     * @expectedException Mockery\Exception
-     */
     public function testShouldIgnoreMissingDisallowMockingNonExistentMethodsUsingGlobalConfiguration()
     {
         Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
         $mock = mock('ClassWithMethods')->shouldIgnoreMissing();
+        $this->expectException(\Mockery\Exception::class);
         $mock->shouldReceive('nonExistentMethod');
     }
 
-    /**
-     * @expectedException BadMethodCallException
-     */
     public function testShouldIgnoreMissingCallingNonExistentMethodsUsingGlobalConfiguration()
     {
         Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
         $mock = mock('ClassWithMethods')->shouldIgnoreMissing();
+        $this->expectException(\BadMethodCallException::class);
         $mock->nonExistentMethod();
     }
 
@@ -157,11 +153,9 @@ class Mockery_MockTest extends MockeryTestCase
         $mock->shouldReceive("");
     }
 
-    /**
-     * @expectedException Mockery\Exception
-     */
     public function testShouldThrowExceptionWithInvalidClassName()
     {
+        $this->expectException(\Mockery\Exception::class);
         mock('ClassName.CannotContainDot');
     }
 

--- a/tests/Mockery/MockingHHVMMethodsTest.php
+++ b/tests/Mockery/MockingHHVMMethodsTest.php
@@ -32,13 +32,13 @@ class MockingHHVMMethodsTest extends MockeryTestCase
      */
     private $container;
 
-    protected function setUp()
+    protected function mockeryTestSetUp()
     {
         if (!$this->isHHVM()) {
             $this->markTestSkipped('For HHVM test only');
         }
 
-        parent::setUp();
+        parent::mockeryTestSetUp();
 
         require_once __DIR__."/Fixtures/MethodWithHHVMReturnType.php";
     }

--- a/tests/Mockery/MockingNullableMethodsTest.php
+++ b/tests/Mockery/MockingNullableMethodsTest.php
@@ -35,9 +35,9 @@ class MockingNullableMethodsTest extends MockeryTestCase
      */
     private $container;
 
-    protected function setUp()
+    protected function mockeryTestSetUp()
     {
-        parent::setUp();
+        parent::mockeryTestSetUp();
 
         require_once __DIR__."/Fixtures/MethodWithNullableReturnType.php";
     }
@@ -55,13 +55,13 @@ class MockingNullableMethodsTest extends MockeryTestCase
 
     /**
      * @test
-     * @expectedException \TypeError
      */
     public function itShouldNotAllowNonNullToBeNull()
     {
         $mock = mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
 
         $mock->shouldReceive('nonNullablePrimitive')->andReturn(null);
+        $this->expectException(\TypeError::class);
         $mock->nonNullablePrimitive();
     }
 
@@ -100,13 +100,13 @@ class MockingNullableMethodsTest extends MockeryTestCase
 
     /**
      * @test
-     * @expectedException \TypeError
      */
     public function itShouldNotAllowSelfToBeNull()
     {
         $mock = mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
 
         $mock->shouldReceive('nonNullableSelf')->andReturn(null);
+        $this->expectException(\TypeError::class);
         $mock->nonNullableSelf();
     }
 
@@ -145,13 +145,13 @@ class MockingNullableMethodsTest extends MockeryTestCase
 
     /**
      * @test
-     * @expectedException \TypeError
      */
     public function itShouldNotAllowClassToBeNull()
     {
         $mock = mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
 
         $mock->shouldReceive('nonNullableClass')->andReturn(null);
+        $this->expectException(\TypeError::class);
         $mock->nonNullableClass();
     }
 

--- a/tests/Mockery/MockingVoidMethodsTest.php
+++ b/tests/Mockery/MockingVoidMethodsTest.php
@@ -28,7 +28,7 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
  */
 class MockingVoidMethodsTest extends MockeryTestCase
 {
-    protected function setUp()
+    protected function mockeryTestSetUp()
     {
         require_once __DIR__."/Fixtures/MethodWithVoidReturnType.php";
     }

--- a/tests/Mockery/NamedMockTest.php
+++ b/tests/Mockery/NamedMockTest.php
@@ -47,12 +47,12 @@ class NamedMockTest extends MockeryTestCase
 
     /**
      * @test
-     * @expectedException Mockery\Exception
-     * @expectedExceptionMessage The mock named 'Mockery\Dave7' has been already defined with a different mock configuration
      */
     public function itShouldThrowIfAttemptingToRedefineNamedMock()
     {
         $mock = Mockery::namedMock("Mockery\Dave7");
+        $this->expectException(\Mockery\Exception::class);
+        $this->expectExceptionMessage("The mock named 'Mockery\Dave7' has been already defined with a different mock configuration");
         $mock = Mockery::namedMock("Mockery\Dave7", "DateTime");
     }
 

--- a/tests/Mockery/WithFormatterExpectationTest.php
+++ b/tests/Mockery/WithFormatterExpectationTest.php
@@ -35,8 +35,6 @@ class WithFormatterExpectationTest extends TestCase
     }
 
     /**
-     * @expectedException Mockery\Exception\NoMatchingExpectationException
-     *
      * Note that without the patch checked in with this test, rather than throwing
      * an exception, the program will go into an infinite recursive loop
      */
@@ -45,6 +43,7 @@ class WithFormatterExpectationTest extends TestCase
         $mock = Mockery::mock('stdClass');
         $mock->shouldReceive('doBar')->with('foo');
         $obj = new ClassWithGetter($mock);
+        $this->expectException(\Mockery\Exception\NoMatchingExpectationException::class);
         $obj->getFoo();
     }
 
@@ -68,7 +67,7 @@ class WithFormatterExpectationTest extends TestCase
         $obj = new ClassWithGetterWithParam();
         $string = Mockery::formatObjects(array($obj));
 
-        $this->assertNotContains('Missing argument 1 for', $string);
+        $this->assertTrue(\mb_strpos($string, 'Missing argument 1 for') === false);
     }
 
     public function testFormatObjectsExcludesStaticProperties()
@@ -76,7 +75,7 @@ class WithFormatterExpectationTest extends TestCase
         $obj = new ClassWithPublicStaticProperty();
         $string = Mockery::formatObjects(array($obj));
 
-        $this->assertNotContains('excludedProperty', $string);
+        $this->assertTrue(\mb_strpos($string, 'excludedProperty') === false);
     }
 
     public function testFormatObjectsExcludesStaticGetters()
@@ -84,7 +83,7 @@ class WithFormatterExpectationTest extends TestCase
         $obj = new ClassWithPublicStaticGetter();
         $string = Mockery::formatObjects(array($obj));
 
-        $this->assertNotContains('getExcluded', $string);
+        $this->assertTrue(\mb_strpos($string, 'getExcluded') === false);
     }
 }
 

--- a/tests/PHP70/Generator/StringManipulation/Pass/MagicMethodTypeHintsPassTest.php
+++ b/tests/PHP70/Generator/StringManipulation/Pass/MagicMethodTypeHintsPassTest.php
@@ -24,11 +24,11 @@ declare(strict_types=1);
 namespace Mockery\Test\Generator\StringManipulation\Pass;
 
 use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\Generator\DefinedTargetClass;
 use Mockery\Generator\StringManipulation\Pass\MagicMethodTypeHintsPass;
-use PHPUnit\Framework\TestCase;
 
-class MagicMethodTypeHintsPassTest extends TestCase
+class MagicMethodTypeHintsPassTest extends MockeryTestCase
 {
     /**
      * @var MagicMethodTypeHintsPass
@@ -44,7 +44,7 @@ class MagicMethodTypeHintsPassTest extends TestCase
      * Setup method
      * @return void
      */
-    public function setup()
+    public function mockeryTestSetUp()
     {
         $this->pass = new MagicMethodTypeHintsPass;
         $this->mockedConfiguration = m::mock(
@@ -98,14 +98,14 @@ class MagicMethodTypeHintsPassTest extends TestCase
             'public function __isset($name) {}',
             $this->mockedConfiguration
         );
-        $this->assertContains('string $name', $code);
+        $this->assertTrue(\mb_strpos($code, 'string $name') !== false);
 
         $this->configureForInterface();
         $code = $this->pass->apply(
             'public function __isset($name) {}',
             $this->mockedConfiguration
         );
-        $this->assertContains('string $name', $code);
+        $this->assertTrue(\mb_strpos($code, 'string $name') !== false);
     }
 
     /**
@@ -121,12 +121,12 @@ class MagicMethodTypeHintsPassTest extends TestCase
             'public function __isset($name) {}',
             $this->mockedConfiguration
         );
-        $this->assertContains('string $name', $code);
+        $this->assertTrue(\mb_strpos($code, 'string $name') !== false);
         $code = $this->pass->apply(
             'public function __unset($name) {}',
             $this->mockedConfiguration
         );
-        $this->assertContains('string $name', $code);
+        $this->assertTrue(\mb_strpos($code, 'string $name') !== false);
     }
 
     /**
@@ -139,14 +139,14 @@ class MagicMethodTypeHintsPassTest extends TestCase
             'public function __isset($name) {}',
             $this->mockedConfiguration
         );
-        $this->assertContains(' : bool', $code);
+        $this->assertTrue(\mb_strpos($code, ' : bool') !== false);
 
         $this->configureForInterface();
         $code = $this->pass->apply(
             'public function __isset($name) {}',
             $this->mockedConfiguration
         );
-        $this->assertContains(' : bool', $code);
+        $this->assertTrue(\mb_strpos($code, ' : bool') !== false);
     }
 
     /**
@@ -159,14 +159,14 @@ class MagicMethodTypeHintsPassTest extends TestCase
             'public function __toString() {}',
             $this->mockedConfiguration
         );
-        $this->assertContains(' : string', $code);
+        $this->assertTrue(\mb_strpos($code, ' : string') !== false);
 
         $this->configureForInterface();
         $code = $this->pass->apply(
             'public function __toString() {}',
             $this->mockedConfiguration
         );
-        $this->assertContains(' : string', $code);
+        $this->assertTrue(\mb_strpos($code, ' : string') !== false);
     }
 
     /**
@@ -179,14 +179,14 @@ class MagicMethodTypeHintsPassTest extends TestCase
             'public function __call($method, array $args) {}',
             $this->mockedConfiguration
         );
-        $this->assertContains('string $method', $code);
+        $this->assertTrue(\mb_strpos($code, 'string $method') !== false);
 
         $this->configureForInterface();
         $code = $this->pass->apply(
             'public function __call($method, array $args) {}',
             $this->mockedConfiguration
         );
-        $this->assertContains('string $method', $code);
+        $this->assertTrue(\mb_strpos($code, 'string $method') !== false);
     }
 
     /**
@@ -199,14 +199,14 @@ class MagicMethodTypeHintsPassTest extends TestCase
             'public static function __callStatic($method, array $args) {}',
             $this->mockedConfiguration
         );
-        $this->assertContains('string $method', $code);
+        $this->assertTrue(\mb_strpos($code, 'string $method') !== false);
 
         $this->configureForInterface();
         $code = $this->pass->apply(
             'public static function __callStatic($method, array $args) {}',
             $this->mockedConfiguration
         );
-        $this->assertContains('string $method', $code);
+        $this->assertTrue(\mb_strpos($code, 'string $method') !== false);
     }
 
     /**
@@ -219,14 +219,14 @@ class MagicMethodTypeHintsPassTest extends TestCase
             'public static function __isset($parameter) {}',
             $this->mockedConfiguration
         );
-        $this->assertContains(') {', $code);
+        $this->assertTrue(\mb_strpos($code, ') {') !== false);
 
         $this->configureForInterface('Mockery\Test\Generator\StringManipulation\Pass\MagicReturnInterfaceDummy');
         $code = $this->pass->apply(
             'public static function __isset($parameter) {}',
             $this->mockedConfiguration
         );
-        $this->assertContains(') {', $code);
+        $this->assertTrue(\mb_strpos($code, ') {') !== false);
     }
 
     /**
@@ -238,7 +238,7 @@ class MagicMethodTypeHintsPassTest extends TestCase
             '\StdClass'
         );
         $magicMethods = $this->pass->getMagicMethods($targetClass);
-        $this->assertInternalType('array', $magicMethods);
+        $this->assertTrue(is_array($magicMethods));
         $this->assertEmpty($magicMethods);
     }
 
@@ -248,7 +248,7 @@ class MagicMethodTypeHintsPassTest extends TestCase
     public function itShouldReturnEmptyArrayIfClassTypeIsNotExpected()
     {
         $magicMethods = $this->pass->getMagicMethods(null);
-        $this->assertInternalType('array', $magicMethods);
+        $this->assertTrue(is_array($magicMethods));
         $this->assertEmpty($magicMethods);
     }
 
@@ -268,16 +268,16 @@ class MagicMethodTypeHintsPassTest extends TestCase
             'public function __call($method, array $args) {}',
             $this->mockedConfiguration
         );
-        $this->assertContains('$method', $code);
-        $this->assertContains('array $args', $code);
+        $this->assertTrue(\mb_strpos($code, '$method') !== false);
+        $this->assertTrue(\mb_strpos($code, 'array $args') !== false);
 
         $this->configureForInterface();
         $code = $this->pass->apply(
             'public function __call($method, array $args) {}',
             $this->mockedConfiguration
         );
-        $this->assertContains('$method', $code);
-        $this->assertContains('array $args', $code);
+        $this->assertTrue(\mb_strpos($code, '$method') !== false);
+        $this->assertTrue(\mb_strpos($code, 'array $args') !== false);
     }
 
     protected function configureForClass(string $className = 'Mockery\Test\Generator\StringManipulation\Pass\MagicDummy')

--- a/tests/PHP70/MockingParameterAndReturnTypesTest.php
+++ b/tests/PHP70/MockingParameterAndReturnTypesTest.php
@@ -80,7 +80,7 @@ class MockingParameterAndReturnTypesTest extends MockeryTestCase
         $mock = mock("test\Mockery\TestWithParameterAndReturnType");
 
         $mock->shouldReceive("returnCallable");
-        $this->assertInternalType('callable', $mock->returnCallable());
+        $this->assertTrue(is_callable($mock->returnCallable()));
     }
 
     public function testMockingClassReturnTypes()
@@ -110,7 +110,7 @@ class MockingParameterAndReturnTypesTest extends MockeryTestCase
         $this->assertSame(0.0, $mock->returnFloat());
         $this->assertFalse( $mock->returnBoolean());
         $this->assertSame([], $mock->returnArray());
-        $this->assertInternalType('callable', $mock->returnCallable());
+        $this->assertTrue(is_callable($mock->returnCallable()));
         $this->assertInstanceOf("\Generator", $mock->returnGenerator());
         $this->assertInstanceOf("test\Mockery\TestWithParameterAndReturnType", $mock->withClassReturnType());
     }


### PR DESCRIPTION
I did not deal with deprecation notices related to the usage of the `@expectedException` annotation. If you feel it should be done here, I can update the PR.