### PR TITLE
Set property values on all related mocks (0.9 branch)

### DIFF
--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -192,10 +192,17 @@ class Expectation implements ExpectationInterface
      */
     protected function _setValues()
     {
+        $mockClass = get_class($this->_mock);
+        $container = $this->_mock->mockery_getContainer();
+        $mocks = $container->getMocks();
         foreach ($this->_setQueue as $name => &$values) {
             if (count($values) > 0) {
                 $value = array_shift($values);
-                $this->_mock->{$name} = $value;
+                foreach ($mocks as $mock) {
+                    if (is_a($mock, $mockClass)) {
+                        $mock->{$name} = $value;
+                    }
+                }
             }
         }
     }

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -239,7 +239,8 @@ class Expectation implements ExpectationInterface
 
                 case 'callable':
                 case 'Closure':
-                    return function () {};
+                    return function () {
+                    };
 
                 case 'Traversable':
                 case 'Generator':
@@ -348,7 +349,8 @@ class Expectation implements ExpectationInterface
         }
         if (is_string($expected) && !is_array($actual) && !is_object($actual)) {
             # push/pop an error handler here to to make sure no error/exception thrown if $expected is not a regex
-            set_error_handler(function () {});
+            set_error_handler(function () {
+            });
             $result = preg_match($expected, (string) $actual);
             restore_error_handler();
 

--- a/tests/Mockery/ContainerTest.php
+++ b/tests/Mockery/ContainerTest.php
@@ -747,7 +747,10 @@ class ContainerTest extends MockeryTestCase
     {
         $m = $this->container->mock('MockeryTestRef1');
         $m->shouldReceive('foo')->with(
-            Mockery::on(function (&$a) {$a += 1;return true;}),
+            Mockery::on(function (&$a) {
+                $a += 1;
+                return true;
+            }),
             Mockery::any()
         );
         $a = 1;
@@ -773,7 +776,10 @@ class ContainerTest extends MockeryTestCase
         @$m = $this->container->mock('DateTime');
         $this->assertInstanceOf("Mockery\MockInterface", $m, "Mocking failed, remove @ error suppresion to debug");
         $m->shouldReceive('modify')->with(
-            Mockery::on(function (&$string) {$string = 'foo'; return true;})
+            Mockery::on(function (&$string) {
+                $string = 'foo';
+                return true;
+            })
         );
         $data ='bar';
         $m->modify($data);
@@ -799,7 +805,10 @@ class ContainerTest extends MockeryTestCase
         @$m = $this->container->mock('MongoCollection');
         $this->assertInstanceOf("Mockery\MockInterface", $m, "Mocking failed, remove @ error suppresion to debug");
         $m->shouldReceive('insert')->with(
-            Mockery::on(function (&$data) {$data['_id'] = 123; return true;}),
+            Mockery::on(function (&$data) {
+                $data['_id'] = 123;
+                return true;
+            }),
             Mockery::type('array')
         );
         $data = array('a'=>1,'b'=>2);

--- a/tests/Mockery/ContainerTest.php
+++ b/tests/Mockery/ContainerTest.php
@@ -728,6 +728,21 @@ class ContainerTest extends MockeryTestCase
         Mockery::resetContainer();
     }
 
+    /**
+     * @group issue/451
+     */
+    public function testSettingPropertyOnInstanceMockWillSetItOnActualInstance()
+    {
+        Mockery::setContainer($this->container);
+        $m = $this->container->mock('overload:MyNamespace\MyClass13');
+        $m->shouldReceive('foo')->andSet('bar', 'baz');
+        $instance = new MyNamespace\MyClass13;
+        $instance->foo();
+        $this->assertEquals('baz', $m->bar);
+        $this->assertEquals('baz', $instance->bar);
+        Mockery::resetContainer();
+    }
+
     public function testMethodParamsPassedByReferenceHaveReferencePreserved()
     {
         $m = $this->container->mock('MockeryTestRef1');


### PR DESCRIPTION
When setting values for properties, don't set them just on
the current mock, but set them on all the related mocks that
are in the container.

This way the overloaded instance mocks will get the properties
set, just as the mock itself.

Fixes #451 in the 0.9 branch (for those who can't upgrade to PHP 5.6).