### PR TITLE
Provide PHP 5.6 / PHPUnit 5.7.27 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## x.y.z (unreleased)
 
+* Fix a BC breaking change for PHP 5.6/PHPUnit 5.7.27 (#947) 
+
 ## 1.2.1 (2019-02-07)
 
 * Support for PHPUnit 8 (#942)

--- a/library/Mockery/Adapter/Phpunit/Legacy/TestListenerTrait.php
+++ b/library/Mockery/Adapter/Phpunit/Legacy/TestListenerTrait.php
@@ -20,7 +20,7 @@
 
 namespace Mockery\Adapter\Phpunit\Legacy;
 
-if (class_exists('PHPUnit_Framework_TestCase') && ! class_exists('PHPUnit\Framework\TestCase')) {
+if (class_exists('PHPUnit_Framework_TestCase') && ! class_exists('PHPUnit\Util\Blacklist')) {
     class_alias('PHPUnit_Framework_ExpectationFailedException', 'PHPUnit\Framework\ExpectationFailedException');
     class_alias('PHPUnit_Framework_Test', 'PHPUnit\Framework\Test');
     class_alias('PHPUnit_Framework_TestCase', 'PHPUnit\Framework\TestCase');

--- a/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationAssertPostConditionsForV7AndPrevious.php
+++ b/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationAssertPostConditionsForV7AndPrevious.php
@@ -18,8 +18,6 @@
  * @license    https://github.com/mockery/mockery/blob/master/LICENSE New BSD License
  */
 
-declare(strict_types=1);
-
 namespace Mockery\Adapter\Phpunit;
 
 trait MockeryPHPUnitIntegrationAssertPostConditionsForV7AndPrevious


### PR DESCRIPTION
The current combination of PHPUnit 5.7.27 with Mockery 1.2.1 cause fatal errors which are described in detail in #946. This PR addresses the two issues described in the aforementioned issue.

The commit messages will link to relevant sources and explain the proposed fixes in higher detail.