### PR TITLE
Fix type hints in the generator to return an absolute class name

### DIFF
--- a/library/Mockery/Generator/Parameter.php
+++ b/library/Mockery/Generator/Parameter.php
@@ -48,7 +48,7 @@ class Parameter
         if ((version_compare(PHP_VERSION, '5.4.1') >= 0)) {
             try {
                 if ($this->rfp->getClass()) {
-                    return $this->getOptionalSign() . $this->rfp->getClass()->getName();
+                    return $this->getOptionalSign() . '\\' . $this->rfp->getClass()->getName();
                 }
             } catch (\ReflectionException $re) {
                 // noop

--- a/tests/Mockery/Generator/ParameterTest.php
+++ b/tests/Mockery/Generator/ParameterTest.php
@@ -7,7 +7,7 @@ namespace Mockery\Generator;
         /**
          * @test
          */
-        public function shouldBringIteratorAggregateToHeadOfTargetListIfTraversablePresent()
+        public function shouldReturnAbsoluteHintPathIfNamespaceProvided()
         {
             $rfp = new \ReflectionParameter(array('\TestSubjectNameSpace\TestSubject', 'foo'), 0);
             $parameterGenerator = new Parameter($rfp);

--- a/tests/Mockery/Generator/ParameterTest.php
+++ b/tests/Mockery/Generator/ParameterTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Mockery\Generator;
+{
+    class ParameterTest extends \PHPUnit_Framework_TestCase
+    {
+        /**
+         * @test
+         */
+        public function shouldBringIteratorAggregateToHeadOfTargetListIfTraversablePresent()
+        {
+            $rfp = new \ReflectionParameter(array('\TestSubjectNameSpace\TestSubject', 'foo'), 0);
+            $parameterGenerator = new Parameter($rfp);
+            $typeHint = $parameterGenerator->getTypeHintAsString();
+
+            $this->assertEquals('\TypeHintNameSpace\TypeHint', $typeHint);
+        }
+    }
+}
+
+namespace TypeHintNameSpace;
+{
+    class TypeHint
+    {
+    }
+}
+
+namespace TestSubjectNameSpace;
+use TypeHintNameSpace\TypeHint;
+{
+    class TestSubject
+    {
+        public function foo(TypeHint $param)
+        {
+        }
+    }
+}
+
+


### PR DESCRIPTION
When mocking like this: 
```php
$guzzle = Mockery::mock('overload:'.GuzzleClient::class, ClientInterface::class);
```

I get the following error:

```php
Declaration of
GuzzleHttp\Client::send(GuzzleHttp\Psr\Http\Message\RequestInterface $request, array $options = Array)
must be compatible with
GuzzleHttp\ClientInterface::send(Psr\Http\Message\RequestInterface $request, array $options = Array)
```

Notice the first type hint begins with `GuzzleHttp\`. This is because the generator returns relative type hints, which is a bug. This PR fixes it by always return the absolute type hint.

I also added a unit test for this. The rest of the suite passes with this change.