### PR TITLE
Fix chained demeter calls with type hint

### DIFF
--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -27,6 +27,7 @@ use Mockery\Loader\EvalLoader;
 use Mockery\Loader\Loader;
 use Mockery\Matcher\MatcherAbstract;
 use Mockery\ClosureWrapper;
+use Mockery\Generator\MockNameBuilder;
 
 class Mockery
 {
@@ -855,7 +856,9 @@ class Mockery
                 $parRefMethodRetType = $parRefMethod->getReturnType();
 
                 if ($parRefMethodRetType !== null) {
-                    $mock = self::namedMock($newMockName, (string) $parRefMethodRetType);
+                    $nameBuilder = new MockNameBuilder();
+                    $nameBuilder->addPart('\\' . $newMockName);
+                    $mock = self::namedMock($nameBuilder->build(), (string) $parRefMethodRetType);
                     $exp->andReturn($mock);
 
                     return $mock;

--- a/library/Mockery/Generator/MockConfiguration.php
+++ b/library/Mockery/Generator/MockConfiguration.php
@@ -26,8 +26,6 @@ namespace Mockery\Generator;
  */
 class MockConfiguration
 {
-    protected static $mockCounter = 0;
-
     /**
      * A class that we'd like to mock
      */
@@ -363,7 +361,7 @@ class MockConfiguration
         foreach ($this->targetInterfaceNames as $targetInterface) {
             if (!interface_exists($targetInterface)) {
                 $this->targetInterfaces[] = UndefinedTargetClass::factory($targetInterface);
-                return;
+                continue;
             }
 
             $dtc = DefinedTargetClass::factory($targetInterface);
@@ -418,24 +416,21 @@ class MockConfiguration
      */
     public function generateName()
     {
-        $name = 'Mockery_' . static::$mockCounter++;
+        $nameBuilder = new MockNameBuilder();
 
         if ($this->getTargetObject()) {
-            $name .= "_" . str_replace("\\", "_", get_class($this->getTargetObject()));
+            $nameBuilder->addPart(get_class($this->getTargetObject()));
         }
 
         if ($this->getTargetClass()) {
-            $name .= "_" . str_replace("\\", "_", $this->getTargetClass()->getName());
+            $nameBuilder->addPart($this->getTargetClass()->getName());
         }
 
-        if ($this->getTargetInterfaces()) {
-            $name .= array_reduce($this->getTargetInterfaces(), function ($tmpname, $i) {
-                $tmpname .= '_' . str_replace("\\", "_", $i->getName());
-                return $tmpname;
-            }, '');
+        foreach ($this->getTargetInterfaces() as $targetInterface) {
+            $nameBuilder->addPart($targetInterface->getName());
         }
 
-        return $name;
+        return $nameBuilder->build();
     }
 
     public function getShortName()

--- a/library/Mockery/Generator/MockNameBuilder.php
+++ b/library/Mockery/Generator/MockNameBuilder.php
@@ -7,53 +7,40 @@
  * This source file is subject to the new BSD license that is bundled
  * with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
- * http://github.com/padraic/mockery/master/LICENSE
+ * http://github.com/padraic/mockery/blob/master/LICENSE
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to padraic@php.net so we can send you a copy immediately.
  *
  * @category   Mockery
  * @package    Mockery
- * @subpackage UnitTests
  * @copyright  Copyright (c) 2010 Pádraic Brady (http://blog.astrumfutura.com)
  * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
  */
 
-namespace DemeterChain;
+namespace Mockery\Generator;
 
-class C
+class MockNameBuilder
 {
-    public function baz(): \stdClass
-    {
-        return new \stdClass();
-    }
-}
+    protected static $mockCounter = 0;
 
-class B
-{
-    public function bar(): C
+    protected $parts = [];
+
+    public function addPart($part)
     {
-        return new C();
+        $this->parts[] = $part;
+
+        return $this;
     }
 
-    public function qux(): C
+    public function build()
     {
-        return new C();
-    }
-}
+        $parts = ['Mockery', static::$mockCounter++];
 
-class A
-{
-    public function foo(): B
-    {
-        return new B();
-    }
-}
+        foreach ($this->parts as $part) {
+            $parts[] = str_replace("\\", "_", $part);
+        }
 
-class Main
-{
-    public function callDemeter(A $a)
-    {
-        return $a->foo()->bar()->baz();
+        return implode('_', $parts);
     }
 }

--- a/library/Mockery/Generator/UndefinedTargetClass.php
+++ b/library/Mockery/Generator/UndefinedTargetClass.php
@@ -86,4 +86,9 @@ class UndefinedTargetClass implements TargetClassInterface
     {
         return false;
     }
+
+    public function __toString()
+    {
+        return $this->name;
+    }
 }

--- a/tests/Mockery/DemeterChainTest.php
+++ b/tests/Mockery/DemeterChainTest.php
@@ -201,4 +201,18 @@ class DemeterChainTest extends MockeryTestCase
 
         $this->assertInstanceOf(stdClass::class, $result);
     }
+
+    /**
+     * @requires PHP 7.0.0
+     */
+    public function testMultipleDemeterChainsWithClassReturnTypeHints()
+    {
+        $bar = new \DemeterChain\C;
+        $qux = new \DemeterChain\C;
+        $a = \Mockery::mock(\DemeterChain\A::class);
+        $a->shouldReceive('foo->bar')->andReturn($bar);
+        $a->shouldReceive('foo->qux')->andReturn($qux);
+        $this->assertEquals($bar, $a->foo()->bar());
+        $this->assertEquals($qux, $a->foo()->qux());
+    }
 }


### PR DESCRIPTION
The current implementation fails in the following situation:
```
$mock = \Mockery::mock(Order::class);
$mock->shouldReceive('getCustomer->getFirstName')->andReturn('John');
$mock->shouldReceive('getCustomer->getLastName')->andReturn('Doe');
```

In this case, if `getCustomer` has a type hint for return type, the mock for getLastName will not work. This happens because the named mock doesn't have the prefix `Mockery_<count>__`, so instead of `Mockery_1__demeter_02db565163e0992acfde42edfd58d833_getCustomer`, it will be named only `demeter_02db565163e0992acfde42edfd58d833_getCustomer`. 

Because of that, the method `Container::getKeyOfDemeterMockFor` will not be able to find the mock.

Some users complained about this problem in some already closed issues:
- https://github.com/mockery/mockery/issues/59
- https://github.com/mockery/mockery/issues/768