### PR TITLE
Add support for `!` to blacklist methods

### DIFF
--- a/docs/reference/creating_test_doubles.rst
+++ b/docs/reference/creating_test_doubles.rst
@@ -240,6 +240,22 @@ work.
     $foo->shouldReceive('bar')->andReturn(999);
     $foo->bar(); // int(456)
 
+It's also possible to specify explicitly which methods to run directly using
+the `!method` syntax:
+
+.. code-block:: php
+
+    class Foo {
+        function foo() { return 123; }
+        function bar() { return $this->foo(); }
+    }
+
+    $foo = mock("Foo[!foo]");
+
+    $foo->foo(); // int(123)
+
+    $foo->bar(); // error, no expectation set
+
 .. note::
 
     Even though we support generated partial test doubles, we do not recommend

--- a/library/Mockery/Container.php
+++ b/library/Mockery/Container.php
@@ -151,7 +151,13 @@ class Container
                 $parts[1] = str_replace(' ', '', $parts[1]);
                 $partialMethods = explode(',', strtolower(rtrim($parts[1], ']')));
                 $builder->addTarget($class);
-                $builder->setWhiteListedMethods($partialMethods);
+                foreach ($partialMethods as $partialMethod) {
+                    if ($partialMethod[0] === '!') {
+                        $builder->addBlackListedMethod(substr($partialMethod, 1));
+                        continue;
+                    }
+                    $builder->addWhiteListedMethod($partialMethod);
+                }
                 array_shift($args);
                 continue;
             } elseif (is_string($arg) && (class_exists($arg, true) || interface_exists($arg, true) || trait_exists($arg, true))) {

--- a/tests/Mockery/ContainerTest.php
+++ b/tests/Mockery/ContainerTest.php
@@ -440,6 +440,36 @@ class ContainerTest extends MockeryTestCase
     }
 
     /**
+     * @group partial
+     */
+    public function testCanUseExclamationToBlacklistMethod()
+    {
+        $m = mock('MockeryTest_PartialNormalClass2[!foo]');
+        $this->assertSame('abc', $m->foo());
+    }
+
+    /**
+     * @group partial
+     */
+    public function testCantCallMethodWhenUsingBlacklistAndNoExpectation()
+    {
+        $m = mock('MockeryTest_PartialNormalClass2[!foo]');
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessageRegExp('/::bar\(\), but no expectations were specified/');
+        $m->bar();
+    }
+
+    /**
+     * @group partial
+     */
+    public function testCanUseBlacklistAndExpectionOnNonBlacklistedMethod()
+    {
+        $m = mock('MockeryTest_PartialNormalClass2[!foo]');
+        $m->shouldReceive('bar')->andReturn('test')->once();
+        $this->assertSame('test', $m->bar());
+    }
+
+    /**
      * @group issue/4
      */
     public function testCanMockClassContainingMagicCallMethod()


### PR DESCRIPTION
Fixes https://github.com/mockery/mockery/issues/954