### PR TITLE
Added an argument expectation method to check if expected arguments are parts of real arguments when mocked methods are called

### DIFF
--- a/docs/reference/expectations.rst
+++ b/docs/reference/expectations.rst
@@ -135,6 +135,32 @@ arguments make the closure evaluate to true:
     $mock->foo(4); // matches the expectation
     $mock->foo(3); // throws a NoMatchingExpectationException
 
+Argument matching with some of given values
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We can provide expected arguments that match passed arguments when mocked method
+is called.
+
+.. code-block:: php
+
+    $mock = \Mockery::mock('MyClass');
+    $mock->shouldReceive('name_of_method')
+        ->withSomeOfArgs(arg1, arg2, arg3, ...);
+
+The given expected arguments order doesn't matter.
+Check if expected values are inclued or not, but type should be matched:
+
+.. code-block:: php
+
+    $mock = \Mockery::mock('MyClass');
+    $mock->shouldReceive('foo')
+        ->withSomeOfArgs(1, 2);
+
+    $mock->foo(1, 2, 3);  // matches the expectation
+    $mock->foo(3, 2, 1);  // matches the expectation (passed order doesn't matter)
+    $mock->foo('1', '2'); // throws a NoMatchingExpectationException (type should be matched) 
+    $mock->foo(3);        // throws a NoMatchingExpectationException 
+
 Any, or no arguments
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -482,6 +482,24 @@ class Expectation implements ExpectationInterface
     }
 
     /**
+     * Expected arguments should partially match the real arguments
+     *
+     * @param mixed[] ...$expectedArgs
+     * @return self
+     */
+    public function withSomeOfArgs(...$expectedArgs)
+    {
+        return $this->withArgs(function (...$args) use ($expectedArgs) {
+            foreach ($expectedArgs as $expectedArg) {
+                if (!in_array($expectedArg, $args, true)) {
+                    return false;
+                }
+            }
+            return true;
+        });
+    }
+
+    /**
      * Set a return value, or sequential queue of return values
      *
      * @param mixed[] ...$args

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -452,6 +452,27 @@ class ExpectationTest extends MockeryTestCase
         Mockery::close();
     }
 
+    public function testExpectsSomeOfArgumentsMatchRealArguments()
+    {
+        $this->mock->shouldReceive('foo')->withSomeOfArgs(1, 3, 5)->times(4);
+        $this->mock->foo(1, 2, 3, 4, 5);
+        $this->mock->foo(1, 3, 5, 2, 4);
+        $this->mock->foo(1, 'foo', 3, 'bar', 5);
+        $this->mock->foo(1, 3, 5);
+        $this->mock->shouldReceive('foo')->withSomeOfArgs('foo')->times(2);
+        $this->mock->foo('foo', 'bar');
+        $this->mock->foo('bar', 'foo');
+    }
+
+    /**
+     * @expectedException \Mockery\Exception\NoMatchingExpectationException
+     */
+    public function testExpectsSomeOfArgumentsGivenArgsDoNotMatchRealArgsAndThrowNoMatchingException()
+    {
+        $this->mock->shouldReceive('foo')->withSomeOfArgs(1, 3, 5);
+        $this->mock->foo(1, 2, 4, 5);
+    }
+
     public function testExpectsAnyArguments()
     {
         $this->mock->shouldReceive('foo')->withAnyArgs();


### PR DESCRIPTION
This PR is a wrapper of argument expectation.
Already custom validation for arguments can be possible to pass callback function to `withArgs`, which is good!
However, I'd like to suggest the feature to reduce our test code to prepare this wrapper method.
This method helps you to check if expected arguments are actually set when mocked methods are called.