### PR TITLE
allow passing thru __call in all mock types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+* Allow passing thru __call method in all mock types (experimental) (#969)
+
 ## 1.2.2 (2019-02-13)
 
 * Fix a BC breaking change for PHP 5.6/PHPUnit 5.7.27 (#947) 

--- a/docs/mockery/gotchas.rst
+++ b/docs/mockery/gotchas.rst
@@ -16,19 +16,13 @@ so it can be documented and resolved where possible. Here is a list to note:
    to mock a ``__wakeup()`` method as normal leads to a
    ``BadMethodCallException`` being thrown.
 
-2. Classes using non-real methods, i.e. where a method call triggers a
-   ``__call()`` method, will throw an exception that the non-real method does
-   not exist unless you first define at least one expectation (a simple
-   ``shouldReceive()`` call would suffice). This is necessary since there is
-   no other way for Mockery to be aware of the method name.
-
-3. Mockery has two scenarios where real classes are replaced: Instance mocks
+2. Mockery has two scenarios where real classes are replaced: Instance mocks
    and alias mocks. Both will generate PHP fatal errors if the real class is
    loaded, usually via a require or include statement. Only use these two mock
    types where autoloading is in place and where classes are not explicitly
    loaded on a per-file basis using ``require()``, ``require_once()``, etc.
 
-4. Internal PHP classes are not entirely capable of being fully analysed using
+3. Internal PHP classes are not entirely capable of being fully analysed using
    ``Reflection``. For example, ``Reflection`` cannot reveal details of
    expected parameters to the methods of such internal classes. As a result,
    there will be problems where a method parameter is defined to accept a
@@ -37,7 +31,7 @@ so it can be documented and resolved where possible. Here is a list to note:
    method parameters are needed, you should use the
    ``\Mockery\Configuration::setInternalClassMethodParamMap()`` method.
 
-5. Creating a mock implementing a certain interface with incorrect case in the
+4. Creating a mock implementing a certain interface with incorrect case in the
    interface name, and then creating a second mock implementing the same
    interface, but this time with the correct case, will have undefined behavior
    due to PHP's ``class_exists`` and related functions being case insensitive.

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -464,12 +464,10 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo('bar', 'foo');
     }
 
-    /**
-     * @expectedException \Mockery\Exception\NoMatchingExpectationException
-     */
     public function testExpectsSomeOfArgumentsGivenArgsDoNotMatchRealArgsAndThrowNoMatchingException()
     {
         $this->mock->shouldReceive('foo')->withSomeOfArgs(1, 3, 5);
+        $this->expectException(\Mockery\Exception\NoMatchingExpectationException::class);
         $this->mock->foo(1, 2, 4, 5);
     }
 
@@ -1895,6 +1893,13 @@ class ExpectationTest extends MockeryTestCase
         $this->assertEquals('bar', $mock->foo());
     }
 
+    public function testPassthruCallMagic()
+    {
+        $mock = mock('Mockery_Magic');
+        $mock->shouldReceive('theAnswer')->once()->passthru();
+        $this->assertSame(42, $mock->theAnswer());
+    }
+
     public function testShouldIgnoreMissingExpectationBasedOnArgs()
     {
         $mock = mock("MyService2")->shouldIgnoreMissing();
@@ -2126,5 +2131,13 @@ class MockeryTest_Foo
 {
     public function foo()
     {
+    }
+}
+
+class Mockery_Magic
+{
+    public function __call($method, $args)
+    {
+        return 42;
     }
 }

--- a/tests/Mockery/MockClassWithMethodOverloadingTest.php
+++ b/tests/Mockery/MockClassWithMethodOverloadingTest.php
@@ -3,6 +3,7 @@
 namespace test\Mockery;
 
 use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Mockery\Exception\BadMethodCallException;
 
 class MockClassWithMethodOverloadingTest extends MockeryTestCase
 {
@@ -12,9 +13,17 @@ class MockClassWithMethodOverloadingTest extends MockeryTestCase
             ->makePartial();
         $this->assertInstanceOf('test\Mockery\TestWithMethodOverloading', $mock);
 
-        $this->expectException(\BadMethodCallException::class);
+        $this->assertSame(42, $mock->theAnswer());
+    }
 
-        // TestWithMethodOverloading::__call wouldn't be used. See Gotchas!.
+    public function testThrowsWhenMethodDoesNotExist()
+    {
+        $mock = mock('test\Mockery\TestWithMethodOverloadingWithoutCall')
+            ->makePartial();
+        $this->assertInstanceOf('test\Mockery\TestWithMethodOverloadingWithoutCall', $mock);
+
+        $this->expectException(BadMethodCallException::class);
+
         $mock->randomMethod();
     }
 
@@ -32,11 +41,15 @@ class TestWithMethodOverloading
 {
     public function __call($name, $arguments)
     {
-        return 1;
+        return 42;
     }
 
     public function thisIsRealMethod()
     {
         return 1;
     }
+}
+
+class TestWithMethodOverloadingWithoutCall
+{
 }

--- a/tests/Mockery/ProxyMockingTest.php
+++ b/tests/Mockery/ProxyMockingTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace test\Mockery;
+
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Mockery\Exception;
+
+class ProxyMockingTest extends MockeryTestCase
+{
+    /** @test */
+    public function finalClassCannotBeMocked()
+    {
+        $this->expectException(Exception::class);
+
+        mock(UnmockableClass::class);
+    }
+
+    /** @test */
+    public function passesThruAnyMethod()
+    {
+        $mock = mock(new UnmockableClass());
+
+        $this->assertSame(1, $mock->anyMethod());
+    }
+
+    /** @test */
+    public function passesThruVirtualMethods()
+    {
+        $mock = mock(new UnmockableClass());
+
+        $this->assertSame(42, $mock->theAnswer());
+    }
+}
+
+final class UnmockableClass
+{
+    public function anyMethod()
+    {
+        return 1;
+    }
+
+    public function __call($method, $args)
+    {
+        return 42;
+    }
+}


### PR DESCRIPTION
See #969

When we see a `__call` method on the parent class we can use this method when php would do the same. This way we are not limiting the developer to not use `__call` method or not mocking classes that use `__call`.

I added tests for all 3 cases. What I didn't touch is the test for the configuration. Mockery might still fail when the mocked class has a `__call` method and the configuration `allowMockingNonExistentMethods` is set to `false`. Typically for php it would return `true` when you ask `is_callable([$object, $method])` when the class has a `__call` method. Just tell me if you want this to be fixed too.