### PR TITLE
don't use is_real which is deprecated in 7.4

### DIFF
--- a/library/Mockery/Matcher/Type.php
+++ b/library/Mockery/Matcher/Type.php
@@ -30,7 +30,11 @@ class Type extends MatcherAbstract
      */
     public function match(&$actual)
     {
-        $function = 'is_' . strtolower($this->_expected);
+        if ($this->_expected == 'real') {
+            $function = 'is_float';
+        } else {
+            $function = 'is_' . strtolower($this->_expected);
+        }
         if (function_exists($function)) {
             return $function($actual);
         } elseif (is_string($this->_expected)

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -1276,14 +1276,14 @@ class ExpectationTest extends MockeryTestCase
 
     public function testRealConstraintMatchesArgument()
     {
-        $this->mock->shouldReceive('foo')->with(Mockery::type('real'))->once();
+        $this->mock->shouldReceive('foo')->with(Mockery::type('float'))->once();
         $this->mock->foo(2.25);
     }
 
     public function testRealConstraintNonMatchingCase()
     {
         $this->mock->shouldReceive('foo')->times(3);
-        $this->mock->shouldReceive('foo')->with(1, Mockery::type('real'))->never();
+        $this->mock->shouldReceive('foo')->with(1, Mockery::type('float'))->never();
         $this->mock->foo();
         $this->mock->foo(1);
         $this->mock->foo(1, 2, 3);
@@ -1291,7 +1291,7 @@ class ExpectationTest extends MockeryTestCase
 
     public function testRealConstraintThrowsExceptionWhenConstraintUnmatched()
     {
-        $this->mock->shouldReceive('foo')->with(Mockery::type('real'));
+        $this->mock->shouldReceive('foo')->with(Mockery::type('float'));
         $this->expectException(\Mockery\Exception::class);
         $this->mock->foo('f');
         Mockery::close();


### PR DESCRIPTION
Without:

```
There were 2 errors:

1) ExpectationTest::testRealConstraintMatchesArgument
Function is_real() is deprecated

/work/GIT/mockery/tests/Mockery/ExpectationTest.php:1280

2) ExpectationTest::testRealConstraintThrowsExceptionWhenConstraintUnmatched
Function is_real() is deprecated

/work/GIT/mockery/tests/Mockery/ExpectationTest.php:1296

```