### PR TITLE
Bugfix: 'Add support for ! to blacklist methods' for empty methods

### DIFF
--- a/library/Mockery/Container.php
+++ b/library/Mockery/Container.php
@@ -149,10 +149,10 @@ class Container
                 }
                 $class = $parts[0];
                 $parts[1] = str_replace(' ', '', $parts[1]);
-                $partialMethods = explode(',', strtolower(rtrim($parts[1], ']')));
+                $partialMethods = array_filter(explode(',', strtolower(rtrim($parts[1], ']'))));
                 $builder->addTarget($class);
                 foreach ($partialMethods as $partialMethod) {
-                    if (!empty($partialMethod) && $partialMethod[0] === '!') {
+                    if ($partialMethod[0] === '!') {
                         $builder->addBlackListedMethod(substr($partialMethod, 1));
                         continue;
                     }

--- a/library/Mockery/Container.php
+++ b/library/Mockery/Container.php
@@ -152,7 +152,7 @@ class Container
                 $partialMethods = explode(',', strtolower(rtrim($parts[1], ']')));
                 $builder->addTarget($class);
                 foreach ($partialMethods as $partialMethod) {
-                    if ($partialMethod[0] === '!') {
+                    if (!empty($partialMethod) && $partialMethod[0] === '!') {
                         $builder->addBlackListedMethod(substr($partialMethod, 1));
                         continue;
                     }

--- a/tests/Mockery/ContainerTest.php
+++ b/tests/Mockery/ContainerTest.php
@@ -468,6 +468,13 @@ class ContainerTest extends MockeryTestCase
         $m->shouldReceive('bar')->andReturn('test')->once();
         $this->assertSame('test', $m->bar());
     }
+    /**
+     * @group partial
+     */
+    public function testCanUseEmptyMethodlist()
+    {
+        $m = mock('MockeryTest_PartialNormalClass2[]');
+    }
 
     /**
      * @group issue/4


### PR DESCRIPTION
it broke our tests:

```
ErrorException: Uninitialized string offset: 0

/var/www/html/src/vendor/sentry/sentry/lib/Raven/Breadcrumbs/ErrorHandler.php:34
/var/www/html/src/vendor/mockery/mockery/library/Mockery/Container.php:155
/var/www/html/src/vendor/mockery/mockery/library/Mockery.php:118
...
```