### PR TITLE
Improve exception debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Change Log
 
+## 1.2.4 (YYYY-MM-DD)
+
+## 1.2.3 (2019-08-07)
+
+* Allow mocking classes that have allows and expects methods (#868)
 * Allow passing thru __call method in all mock types (experimental) (#969)
+* Add support for `!` to blacklist methods (#959)
+* Added `withSomeOfArgs` to partial match a list of args (#967)
+* Fix chained demeter calls with type hint (#956)
 
 ## 1.2.2 (2019-02-13)
 

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -887,4 +887,12 @@ class Expectation implements ExpectationInterface
     {
         return $this->_because;
     }
+
+    /**
+     * @return array
+     */
+    public function getExpectedArgs()
+    {
+        return $this->_expectedArgs;
+    }
 }

--- a/library/Mockery/ExpectationDirector.php
+++ b/library/Mockery/ExpectationDirector.php
@@ -89,19 +89,12 @@ class ExpectationDirector
     {
         $expectation = $this->findExpectation($args);
         if (is_null($expectation)) {
-            $exception = new \Mockery\Exception\NoMatchingExpectationException(
-                'No matching handler found for '
-                . $this->_mock->mockery_getName() . '::'
-                . \Mockery::formatArgs($this->_name, $args)
-                . '. Either the method was unexpected or its arguments matched'
-                . ' no expected argument list for this method'
-                . PHP_EOL . PHP_EOL
-                . \Mockery::formatObjects($args)
+            throw new \Mockery\Exception\NoMatchingExpectationException(
+                $this->_mock,
+                $this->_name,
+                $args,
+                $this->getExpectations()
             );
-            $exception->setMock($this->_mock)
-                ->setMethodName($this->_name)
-                ->setActualArguments($args);
-            throw $exception;
         }
         return $expectation->verifyCall($args);
     }


### PR DESCRIPTION
It is often really difficult to understand and be aware of all available handlers for a given method call expectation.
Especially when the difference comes only from an entity inner property.

Here we display a list of all available handlers for the given method and for each one a diff.
Example:
```
1) Mention\SocialAccount\Tests\Application\Update\UpdateIntegrationFacebookPageServiceTest::testItems
Mockery\Exception\NoMatchingExpectationException: No matching handler found for Mockery_2_Mention_SocialAccount_Domain_Aggregate_SocialAccount_SocialAccountRepositoryInterface::get(object(Hamcrest\Core\IsEqual)). Either the method was unexpected or its arguments matched no expected argument list for this method.
Here is the list of available expectations.

Mockery_2_Mention_SocialAccount_Domain_Aggregate_SocialAccount_SocialAccountRepositoryInterface::get with arguments:
--- Expected
+++ Actual
@@ @@
 Array (
     0 => Hamcrest\Core\IsEqual Object (
         '_item' => Mention\SocialAccount\Domain\Aggregate\SocialAccount\SocialAccountId Object (
-            'id' => 'foo'
+            'id' => '223918237618995'
         )
     )
 )

Mockery_2_Mention_SocialAccount_Domain_Aggregate_SocialAccount_SocialAccountRepositoryInterface::get with arguments:
--- Expected
+++ Actual
@@ @@
 Array (
     0 => Hamcrest\Core\IsEqual Object (
         '_item' => Mention\SocialAccount\Domain\Aggregate\SocialAccount\SocialAccountId Object (
-            'id' => 'bar'
+            'id' => '223918237618995'
         )
     )
-    1 => Hamcrest\Core\IsEqual Object (...)
 )


/home/mention/mention/.composer/mockery/mockery/library/Mockery/ExpectationDirector.php:94
/home/mention/mention/src/Mention/SocialAccount/Application/Update/UpdateIntegrationFacebookPageService.php:50
/home/mention/mention/src/Mention/SocialAccount/Tests/Application/Update/UpdateIntegrationFacebookPageServiceTest.php:115

ERRORS!
Tests: 1, Assertions: 0, Errors: 1.
```