### PR TITLE
Improve exception debugging

### DIFF
--- a/library/Mockery/Exception/NoMatchingExpectationException.php
+++ b/library/Mockery/Exception/NoMatchingExpectationException.php
@@ -20,15 +20,84 @@
 
 namespace Mockery\Exception;
 
+use Hamcrest\Util;
 use Mockery;
+use SebastianBergmann\Comparator\ComparisonFailure;
+use SebastianBergmann\Comparator\Factory;
+use SebastianBergmann\Diff\Differ;
+use SebastianBergmann\Diff\Output\DiffOnlyOutputBuilder;
 
 class NoMatchingExpectationException extends Mockery\Exception
 {
-    protected $method = null;
+    /**
+     * @var string
+     */
+    protected $method;
 
-    protected $actual = array();
+    /**
+     * @var array
+     */
+    protected $actual;
 
-    protected $mockObject = null;
+    /**
+     * @var Mockery\MockInterface
+     */
+    protected $mockObject;
+
+    /**
+     * @param string $methodName
+     * @param array $actualArguments
+     * @param array $expectations
+     */
+    public function __construct(
+        Mockery\MockInterface $mock,
+        $methodName,
+        $actualArguments,
+        $expectations
+    ) {
+        $this->setMock($mock);
+        $this->setMethodName($methodName);
+        $this->setActualArguments($actualArguments);
+
+        $diffs = [];
+        foreach ($expectations as $expectation) {
+            $expectedArguments = $expectation->getExpectedArgs();
+
+            $diff = $this->diff(
+                $this->normalizeForDiff($expectedArguments),
+                $this->normalizeForDiff($actualArguments)
+            );
+            if (null === $diff) {
+                // If we reach this, it means that the exception has not been
+                // rised by a non-strict equality. So the diff is null.
+                // We do the comparison again but this time comparing references
+                // of objects.
+                $diff = $this->diff(
+                    $this->normalizeForStrictDiff($expectedArguments),
+                    $this->normalizeForStrictDiff($actualArguments)
+                );
+            }
+
+            $diffs[] = sprintf(
+                "\n%s::%s with arguments%s",
+                $expectation->getMock()->mockery_getName(),
+                $expectation->getName(),
+                null !== $diff ? $diff : "\n### No diff ###"
+            );
+        }
+
+        $message = 'No matching expectation found for '
+            . $this->getMockName() . '::'
+            . \Mockery::formatArgs($methodName, $actualArguments)
+            . '. Either the method was unexpected or its arguments matched'
+            . ' no expected argument list for this method.'
+            . PHP_EOL . PHP_EOL
+            . 'Here is the list of available expectations and their diff with actual input:'
+            . PHP_EOL
+            . implode('', $diffs);
+
+        parent::__construct($message, 0, null);
+    }
 
     public function setMock(Mockery\MockInterface $mock)
     {
@@ -66,5 +135,55 @@ class NoMatchingExpectationException extends Mockery\Exception
     public function getMockName()
     {
         return $this->getMock()->mockery_getName();
+    }
+
+    /**
+     * @param array $expectedArguments
+     * @param array $actualArguments
+     * @return string|null
+     */
+    private function diff($expectedArguments, $actualArguments)
+    {
+        $comparatorFactory = new Factory();
+        $differ = new Differ(new DiffOnlyOutputBuilder("--- Expected\n+++ Actual\n"));
+
+        $comparator = $comparatorFactory->getComparatorFor(
+            $expectedArguments,
+            $actualArguments
+        );
+        try {
+            $comparator->assertEquals($expectedArguments, $actualArguments);
+        } catch (ComparisonFailure $e) {
+            return $e->getDiff();
+        }
+
+        return null;
+    }
+
+    private function normalizeForDiff($args)
+    {
+        // Wraps items with an IsEqual matcher if it isn't a matcher already
+        // in order to be sure to compare same nature objects.
+        return Util::createMatcherArray($args);
+    }
+
+    private function normalizeForStrictDiff($args)
+    {
+        $normalized = [];
+        foreach ($args as $arg) {
+            if (!is_object($arg)) {
+                $normalizedArg = Util::createMatcherArray([$arg]);
+                $normalized[] = reset($normalizedArg);
+                continue;
+            }
+
+            $objectRef = function_exists('spl_object_id')
+                ? spl_object_id($arg)
+                : spl_object_hash($arg);
+
+            $normalized[] = get_class($arg).'#ref_'.$objectRef;
+        }
+
+        return $normalized;
     }
 }

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -869,4 +869,12 @@ class Expectation implements ExpectationInterface
     {
         return $this->_because;
     }
+
+    /**
+     * @return array
+     */
+    public function getExpectedArgs()
+    {
+        return $this->_expectedArgs;
+    }
 }

--- a/library/Mockery/ExpectationDirector.php
+++ b/library/Mockery/ExpectationDirector.php
@@ -89,19 +89,12 @@ class ExpectationDirector
     {
         $expectation = $this->findExpectation($args);
         if (is_null($expectation)) {
-            $exception = new \Mockery\Exception\NoMatchingExpectationException(
-                'No matching handler found for '
-                . $this->_mock->mockery_getName() . '::'
-                . \Mockery::formatArgs($this->_name, $args)
-                . '. Either the method was unexpected or its arguments matched'
-                . ' no expected argument list for this method'
-                . PHP_EOL . PHP_EOL
-                . \Mockery::formatObjects($args)
+            throw new \Mockery\Exception\NoMatchingExpectationException(
+                $this->_mock,
+                $this->_name,
+                $args,
+                $this->getExpectations()
             );
-            $exception->setMock($this->_mock)
-                ->setMethodName($this->_name)
-                ->setActualArguments($args);
-            throw $exception;
         }
         return $expectation->verifyCall($args);
     }


### PR DESCRIPTION
It is often really difficult to understand and be aware of all available handlers for a given method call expectation.
Especially when the difference comes only from an entity inner property.

Here we display a list of all available handlers for the given method and for each one a diff.
Example:
```
1) Mention\SocialAccount\Tests\Application\Update\UpdateIntegrationFacebookPageServiceTest::testItems
Mockery\Exception\NoMatchingExpectationException: No matching handler found for Mockery_2_Mention_SocialAccount_Domain_Aggregate_SocialAccount_SocialAccountRepositoryInterface::get(object(Hamcrest\Core\IsEqual)). Either the method was unexpected or its arguments matched no expected argument list for this method.
Here is the list of available expectations.

Mockery_2_Mention_SocialAccount_Domain_Aggregate_SocialAccount_SocialAccountRepositoryInterface::get with arguments:
--- Expected
+++ Actual
@@ @@
 Array (
     0 => Hamcrest\Core\IsEqual Object (
         '_item' => Mention\SocialAccount\Domain\Aggregate\SocialAccount\SocialAccountId Object (
-            'id' => 'foo'
+            'id' => '223918237618995'
         )
     )
 )

Mockery_2_Mention_SocialAccount_Domain_Aggregate_SocialAccount_SocialAccountRepositoryInterface::get with arguments:
--- Expected
+++ Actual
@@ @@
 Array (
     0 => Hamcrest\Core\IsEqual Object (
         '_item' => Mention\SocialAccount\Domain\Aggregate\SocialAccount\SocialAccountId Object (
-            'id' => 'bar'
+            'id' => '223918237618995'
         )
     )
-    1 => Hamcrest\Core\IsEqual Object (...)
 )


/home/mention/mention/.composer/mockery/mockery/library/Mockery/ExpectationDirector.php:94
/home/mention/mention/src/Mention/SocialAccount/Application/Update/UpdateIntegrationFacebookPageService.php:50
/home/mention/mention/src/Mention/SocialAccount/Tests/Application/Update/UpdateIntegrationFacebookPageServiceTest.php:115

ERRORS!
Tests: 1, Assertions: 0, Errors: 1.
```