### PR TITLE
Improve exception debugging

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
     "require": {
         "php": ">=5.6.0",
         "lib-pcre": ">=7.0",
-        "hamcrest/hamcrest-php": "~2.0"
+        "hamcrest/hamcrest-php": "~2.0",
+        "sebastian/comparator": "^1.2.4|^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.7.10|~6.5|~7.0|~8.0"

--- a/library/Mockery/Exception/NoMatchingExpectationException.php
+++ b/library/Mockery/Exception/NoMatchingExpectationException.php
@@ -20,51 +20,186 @@
 
 namespace Mockery\Exception;
 
+use Hamcrest\Util;
 use Mockery;
+use SebastianBergmann\Comparator\ComparisonFailure;
+use SebastianBergmann\Comparator\Factory;
 
 class NoMatchingExpectationException extends Mockery\Exception
 {
-    protected $method = null;
+    /**
+     * @var string
+     */
+    protected $method;
 
-    protected $actual = array();
+    /**
+     * @var array
+     */
+    protected $actual;
 
-    protected $mockObject = null;
+    /**
+     * @var Mockery\MockInterface
+     */
+    protected $mockObject;
 
-    public function setMock(Mockery\LegacyMockInterface $mock)
+    /**
+     * @param string $methodName
+     * @param array $actualArguments
+     * @param array $expectations
+     */
+    public function __construct(
+        Mockery\MockInterface $mock,
+        $methodName,
+        $actualArguments,
+        $expectations
+    ) {
+        $this->setMock($mock);
+        $this->setMethodName($methodName);
+        $this->setActualArguments($actualArguments);
+
+        $diffs = [];
+        foreach ($expectations as $expectation) {
+            $expectedArguments = $expectation->getExpectedArgs();
+
+            $diff = $this->diff(
+                $this->normalizeForDiff($expectedArguments),
+                $this->normalizeForDiff($actualArguments)
+            );
+            if (null === $diff) {
+                // If we reach this, it means that the exception has not been
+                // raised by a non-strict equality. So the diff is null.
+                // We do the comparison again but this time comparing references
+                // of objects.
+                $diff = $this->diff(
+                    $this->normalizeForStrictDiff($expectedArguments),
+                    $this->normalizeForStrictDiff($actualArguments)
+                );
+            }
+
+            $diffs[] = sprintf(
+                "\n%s::%s with arguments%s",
+                $expectation->getMock()->mockery_getName(),
+                $expectation->getName(),
+                null !== $diff ? $diff : "\n### No diff ###"
+            );
+        }
+
+        $message = 'No matching expectation found for '
+            . $this->getMockName() . '::'
+            . \Mockery::formatArgs($methodName, $actualArguments)
+            . '. Either the method was unexpected or its arguments matched'
+            . ' no expected argument list for this method.'
+            . PHP_EOL . PHP_EOL
+            . 'Here is the list of available expectations and their diff with actual input:'
+            . PHP_EOL
+            . implode('', $diffs);
+
+        parent::__construct($message, 0, null);
+    }
+
+    /**
+     * @return $this
+     */
+    private function setMock(Mockery\MockInterface $mock)
     {
         $this->mockObject = $mock;
         return $this;
     }
 
-    public function setMethodName($name)
+    /**
+     * @param string $name
+     *
+     * @return $this
+     */
+    private function setMethodName($name)
     {
         $this->method = $name;
         return $this;
     }
 
-    public function setActualArguments($count)
+    /**
+     * @param array $count
+     *
+     * @return $this
+     */
+    private function setActualArguments($count)
     {
         $this->actual = $count;
         return $this;
     }
 
-    public function getMock()
+    /**
+     * @return Mockery\MockInterface
+     */
+    private function getMock()
     {
         return $this->mockObject;
     }
 
-    public function getMethodName()
-    {
-        return $this->method;
-    }
-
-    public function getActualArguments()
-    {
-        return $this->actual;
-    }
-
-    public function getMockName()
+    /**
+     * @return string
+     */
+    private function getMockName()
     {
         return $this->getMock()->mockery_getName();
+    }
+
+    /**
+     * @param array $expectedArguments
+     * @param array $actualArguments
+     *
+     * @return string|null
+     */
+    private function diff($expectedArguments, $actualArguments)
+    {
+        $comparatorFactory = new Factory();
+        $comparator = $comparatorFactory->getComparatorFor(
+            $expectedArguments,
+            $actualArguments
+        );
+        try {
+            $comparator->assertEquals($expectedArguments, $actualArguments);
+        } catch (ComparisonFailure $e) {
+            return $e->getDiff();
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array $args
+     *
+     * @return array
+     */
+    private function normalizeForDiff($args)
+    {
+        // Wraps items with an IsEqual matcher if it isn't a matcher already
+        // in order to be sure to compare same nature objects.
+        return Util::createMatcherArray($args);
+    }
+
+    /**
+     * @param array $args
+     *
+     * @return array
+     */
+    private function normalizeForStrictDiff($args)
+    {
+        $normalized = [];
+        foreach ($args as $arg) {
+            if (!is_object($arg)) {
+                $normalizedArg = Util::createMatcherArray([$arg]);
+                $normalized[] = reset($normalizedArg);
+                continue;
+            }
+
+            $objectRef = function_exists('spl_object_id')
+                ? spl_object_id($arg)
+                : spl_object_hash($arg);
+
+            $normalized[] = get_class($arg).'#ref_'.$objectRef;
+        }
+
+        return $normalized;
     }
 }

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -911,4 +911,12 @@ class Expectation implements ExpectationInterface
     {
         return $this->_because;
     }
+
+    /**
+     * @return array
+     */
+    public function getExpectedArgs()
+    {
+        return $this->_expectedArgs;
+    }
 }

--- a/library/Mockery/ExpectationDirector.php
+++ b/library/Mockery/ExpectationDirector.php
@@ -89,19 +89,12 @@ class ExpectationDirector
     {
         $expectation = $this->findExpectation($args);
         if (is_null($expectation)) {
-            $exception = new \Mockery\Exception\NoMatchingExpectationException(
-                'No matching handler found for '
-                . $this->_mock->mockery_getName() . '::'
-                . \Mockery::formatArgs($this->_name, $args)
-                . '. Either the method was unexpected or its arguments matched'
-                . ' no expected argument list for this method'
-                . PHP_EOL . PHP_EOL
-                . \Mockery::formatObjects($args)
+            throw new \Mockery\Exception\NoMatchingExpectationException(
+                $this->_mock,
+                $this->_name,
+                $args,
+                $this->getExpectations()
             );
-            $exception->setMock($this->_mock)
-                ->setMethodName($this->_name)
-                ->setActualArguments($args);
-            throw $exception;
         }
         return $expectation->verifyCall($args);
     }

--- a/tests/Mockery/ContainerTest.php
+++ b/tests/Mockery/ContainerTest.php
@@ -1239,7 +1239,7 @@ class ContainerTest extends MockeryTestCase
         $mock->shouldReceive('foo')->with(array('yourself' => 21));
 
         $this->expectException(\Mockery\Exception\NoMatchingExpectationException::class);
-        $this->expectExceptionMessage('MyTestClass::foo(resource(...))');
+        $this->expectExceptionMessage("0 => Hamcrest\Core\IsEqual Object (...)");
         $mock->foo(fopen('php://memory', 'r'));
     }
 
@@ -1252,7 +1252,7 @@ class ContainerTest extends MockeryTestCase
         $mock->shouldReceive('foo')->with(array('yourself' => 21));
 
         $this->expectException(\Mockery\Exception\NoMatchingExpectationException::class);
-        $this->expectExceptionMessage("MyTestClass::foo(['myself' => [...]])");
+        $this->expectExceptionMessage("'myself' => Hamcrest\Core\IsEqual Object (...)");
         $mock->foo($testArray);
     }
 

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -1436,7 +1436,7 @@ class ExpectationTest extends MockeryTestCase
     {
         $this->mock->shouldReceive('foo')->with(Mockery::type('stdClass'));
         $this->expectException(\Mockery\Exception::class);
-        $this->mock->foo(new Exception);
+        $this->mock->foo(new \DateTime());
         Mockery::close();
     }
 


### PR DESCRIPTION
It is often really difficult to understand and be aware of all available handlers for a given method call expectation.
Especially when the difference comes only from an entity inner property.

Here we display a list of all available handlers for the given method and for each one a diff.
Example:
```
1) Foo::testItems
Mockery\Exception\NoMatchingExpectationException: No matching handler found for Mockery_2_Bar::get(object(Hamcrest\Core\IsEqual)). Either the method was unexpected or its arguments matched no expected argument list for this method.
Here is the list of available expectations.

Mockery_2_Bar::get with arguments:
--- Expected
+++ Actual
@@ @@
 Array (
     0 => Hamcrest\Core\IsEqual Object (
         '_item' => Baz Object (
-            'id' => 'foo'
+            'id' => '223918237618995'
         )
     )
 )

Mockery_2_Foo::get with arguments:
--- Expected
+++ Actual
@@ @@
 Array (
     0 => Hamcrest\Core\IsEqual Object (
         '_item' => Bar Object (
-            'id' => 'bar'
+            'id' => '223918237618995'
         )
     )
-    1 => Hamcrest\Core\IsEqual Object (...)
 )
```

Also when the diff consists only in a difference of object reference that would normally result in an empty diff, we display the object ref instead:
```
There was 1 error:

1) Foo::test
Mockery\Exception\NoMatchingExpectationException: No matching expectation found for Mockery_0_Bar::fetch(object(Baz), 'me', ['projection' => '(id)']). Either the method was unexpected or its arguments matched no expected argument list for this method.

Here is the list of available expectations and their diff with actual input:

Mockery_0_Foo::fetch with arguments
--- Expected
+++ Actual
@@ @@
 Array (
-    0 => 'Baz#ref_000000007372a668000000003e36882c'
+    0 => 'Baz#ref_000000007372a677000000003e36882c'
     1 => Hamcrest\Core\IsEqual Object (...)
     2 => Hamcrest\Core\IsEqual Object (...)
 )
```