### PR TITLE
#1005 Set properties correctly for different mocks of the same class.

### DIFF
--- a/library/Mockery/Container.php
+++ b/library/Mockery/Container.php
@@ -230,7 +230,7 @@ class Container
         $this->getLoader()->load($def);
 
         $mock = $this->_getInstance($def->getClassName(), $constructorArgs);
-        $mock->mockery_init($this, $config->getTargetObject());
+        $mock->mockery_init($this, $config->getTargetObject(), $config->isInstanceMock());
 
         if (!empty($quickdefs)) {
             $mock->shouldReceive($quickdefs)->byDefault();

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -224,12 +224,14 @@ class Expectation implements ExpectationInterface
     {
         $mockClass = get_class($this->_mock);
         $container = $this->_mock->mockery_getContainer();
+        /** @var Mock[] $mocks */
         $mocks = $container->getMocks();
         foreach ($this->_setQueue as $name => &$values) {
             if (count($values) > 0) {
                 $value = array_shift($values);
+                $this->_mock->{$name} = $value;
                 foreach ($mocks as $mock) {
-                    if (is_a($mock, $mockClass)) {
+                    if (is_a($mock, $mockClass) && $mock->mockery_isInstance()) {
                         $mock->{$name} = $value;
                     }
                 }

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -156,15 +156,18 @@ class Mock implements MockInterface
      */
     protected $_mockery_thrownExceptions = [];
 
+    protected $_mockery_instanceMock = true;
+
     /**
      * We want to avoid constructors since class is copied to Generator.php
      * for inclusion on extending class definitions.
      *
      * @param \Mockery\Container $container
      * @param object $partialObject
+     * @param bool $instanceMock
      * @return void
      */
-    public function mockery_init(\Mockery\Container $container = null, $partialObject = null)
+    public function mockery_init(\Mockery\Container $container = null, $partialObject = null, $instanceMock = true)
     {
         if (is_null($container)) {
             $container = new \Mockery\Container;
@@ -181,6 +184,8 @@ class Mock implements MockInterface
                 }
             }
         }
+
+        $this->_mockery_instanceMock = $instanceMock;
     }
 
     /**
@@ -656,6 +661,11 @@ class Mock implements MockInterface
         $onlyImplementsMock = 2 == count($interfaces);
 
         return (false === $rfc->getParentClass()) && $onlyImplementsMock;
+    }
+
+    public function mockery_isInstance()
+    {
+        return $this->_mockery_instanceMock;
     }
 
     public function __wakeup()

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -179,6 +179,27 @@ class ExpectationTest extends MockeryTestCase
         $this->assertNull($this->mock->bar);
     }
 
+    /**
+     * @group issue/1005
+     */
+    public function testSetsPublicPropertiesCorrectlyForDifferentInstancesOfSameClass()
+    {
+        $mockInstanceOne = mock('MockeryTest_Foo');
+        $mockInstanceTwo = mock('MockeryTest_Foo');
+
+        $mockInstanceOne->shouldReceive('foo')
+            ->andSet('bar', 'baz');
+
+        $mockInstanceTwo->shouldReceive('foo')
+            ->andSet('bar', 'bazz');
+
+        $mockInstanceOne->foo();
+        $mockInstanceTwo->foo();
+
+        $this->assertEquals('baz', $mockInstanceOne->bar);
+        $this->assertEquals('bazz', $mockInstanceTwo->bar);
+    }
+
     public function testReturnsSameValueForAllIfNoArgsExpectationAndSomeGiven()
     {
         $this->mock->shouldReceive('foo')->andReturn(1);


### PR DESCRIPTION
When using `andSet()` expectation, set the property only on instances of the current Mock rather than _all_ mocks of the same class.

Fixes issue #1005, which appears to have been inadvertently caused when fixing #451 

## Changes:
- Add `_mockery_instanceMock` property and `mockery_isInstance()` method.
  - Set `_mockery_instanceMock` property on `mockery_init()` using config value.
  - Default value is `true` if not passed (preserves existing behaviour).
  - Public method `mockery_isInstance()` returns value of protected `_mockery_instanceMock`
- Only set values for current mock + instances of it.

