### PR TITLE
Move constructor expectations info to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,21 +258,6 @@ $double->allows()->doFoo()->andReturns(123);
 $double->foo(); // int(123)
 ```
 
-### Testing the constructor arguments of hard Dependencies
-
-See [Mocking hard dependencies](http://docs.mockery.io/en/latest/cookbook/mocking_hard_dependencies.html)
-
-``` php
-$implementationMock = Mockery::mock('overload:\Some\Implementation');
-
-$implementationMock->shouldReceive('__construct')
-    ->once()
-    ->with(['host' => 'localhost']);
-// add other expectations as usual
-
-$implementation = new \Some\Implementation(['host' => 'localhost']);
-```
-
 ## Versioning
 
 The Mockery team attempts to adhere to [Semantic Versioning](http://semver.org),

--- a/docs/cookbook/mocking_hard_dependencies.rst
+++ b/docs/cookbook/mocking_hard_dependencies.rst
@@ -16,7 +16,7 @@ Let's take the following code for an example:
     {
         function callExternalService($param)
         {
-            $externalService = new Service\External();
+            $externalService = new Service\External($version = 5);
             $externalService->sendSomething($param);
             return $externalService->getSomething();
         }
@@ -91,6 +91,40 @@ Our test example from above now becomes:
             $this->assertSame('Tested!', $result);
         }
     }
+
+
+
+Testing the constructor arguments of hard Dependencies
+------------------------------------------------------
+
+Sometimes we might want to ensure that the hard dependency is instantiated with
+particular arguments. With overloaded mocks, we can set up expectations on the
+constructor.
+
+.. code-block:: php
+
+    <?php
+    namespace AppTest;
+    use Mockery as m;
+    /**
+     * @runTestsInSeparateProcesses
+     * @preserveGlobalState disabled
+     */
+    class ServiceTest extends \PHPUnit_Framework_TestCase
+    {
+        public function testCallingExternalService()
+        {
+            $externalMock = m::mock('overload:App\Service\External');
+            $externalMock->allows('sendSomething');
+            $externalMock->shouldReceive('__construct')
+                ->once()
+                ->with(5);
+
+            $service = new \App\Service();
+            $result = $service->callExternalService($param);
+        }
+    }
+
 
 .. note::
 


### PR DESCRIPTION
As it's not a practice I would like to promote, I'm moving this to the
docs, rather than have it on the README. I think for the future I would
prefer the README to be the Mockery - The Right Way type thing, the docs
contain all the juicy bits you can cut your hands on.