### PR TITLE
docs: fix a typo in class constants section

### DIFF
--- a/docs/cookbook/class_constants.rst
+++ b/docs/cookbook/class_constants.rst
@@ -87,7 +87,7 @@ stub:
         const FAILURE = 1;
     }
 
-    \Mockery::mock('Fetcher', 'FetcherStub')
+    \Mockery::namedMock('Fetcher', 'FetcherStub')
         ->shouldReceive('fetch')
         ->andReturn(0);
 


### PR DESCRIPTION
I found on obvious typo in the docs ('mock' call was used instead of a 'namedMock'), so here is the fix! Let me know if you have any comments, thank you!