### PR TITLE
Add capture argument matcher

### DIFF
--- a/docs/reference/argument_validation.rst
+++ b/docs/reference/argument_validation.rst
@@ -229,6 +229,27 @@ methods to call.
 
     There is no Hamcrest version of the ``ducktype()`` matcher.
 
+Capturing Arguments
+-------------------
+
+If we want to perform multiple validations on a single argument, the ``capture``
+matcher provides a streamlined alternative to using the ``on()`` matcher.
+It accepts a variable which the actual argument will be assigned.
+
+.. code-block:: php
+
+    $mock = \Mockery::mock('MyClass');
+    $mock->shouldReceive("foo")
+        ->with(\Mockery::capture($bar));
+
+This will assign *any* argument passed to ``foo`` to the local ``$bar`` variable to
+then perform additional validation using assertions.
+
+.. note::
+
+    The ``capture`` matcher always evaluates to ``true``. As such, we should always
+    perform additional argument validation.
+
 Additional Argument Matchers
 ----------------------------
 

--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -435,6 +435,23 @@ class Mockery
     /**
      * Return instance of CLOSURE matcher.
      *
+     * @param $reference
+     *
+     * @return \Mockery\Matcher\Closure
+     */
+    public static function capture(&$reference)
+    {
+        $closure = function ($argument) use (&$reference) {
+            $reference = $argument;
+            return true;
+        };
+
+        return new \Mockery\Matcher\Closure($closure);
+    }
+
+    /**
+     * Return instance of CLOSURE matcher.
+     *
      * @param mixed $closure
      *
      * @return \Mockery\Matcher\Closure

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -1555,6 +1555,25 @@ class ExpectationTest extends MockeryTestCase
         Mockery::close();
     }
 
+    public function testCaptureStoresArgumentOfTypeScalar_ClosureEvaluatesToTrue()
+    {
+        $temp = null;
+        $this->mock->shouldReceive('foo')->with(Mockery::capture($temp))->once();
+        $this->mock->foo(4);
+
+        $this->assertSame(4, $temp);
+    }
+
+    public function testCaptureStoresArgumentOfTypeArgument_ClosureEvaluatesToTrue()
+    {
+        $object = new stdClass();
+        $temp = null;
+        $this->mock->shouldReceive('foo')->with(Mockery::capture($temp))->once();
+        $this->mock->foo($object);
+
+        $this->assertSame($object, $temp);
+    }
+
     public function testOnConstraintMatchesArgument_ClosureEvaluatesToTrue()
     {
         $function = function ($arg) {


### PR DESCRIPTION
This adds a simple closure argument matcher which will _capture_ the argument into a local variable. This provides an easy way to store an argument passed to a mocked method for more complex validation without having to wrap all the logic inline within a `Mockery::on()` closure.

**Example:**
```php
$temp = null;
$mock->expects('foo')
    ->with(Mockery::capture($temp));

$mock->foo($someObject);

// $temp === $someObject
```