### PR TITLE
Add php74 to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,12 +38,32 @@ test-72: deps
 	docker run -it --rm -v "$$PWD":/opt/mockery -w /opt/mockery php:7.2-cli php vendor/bin/phpunit
 
 .PHONY: test-71
-test-71: deps
-	docker run -it --rm -v "$$PWD":/opt/mockery -w /opt/mockery php:7.1-cli php vendor/bin/phpunit
+test-71: build71
+	docker run -it --rm \
+		-v "$$PWD/library":/opt/mockery/library \
+		-v "$$PWD/tests":/opt/mockery/tests \
+		-v "$$PWD/phpunit.xml.dist":/opt/mockery/phpunit.xml \
+		-w /opt/mockery \
+		mockery_php71 \
+		php vendor/bin/phpunit
+
+.PHONY: build71
+build71:
+	docker build -t mockery_php71 -f "$$PWD/docker/php71/Dockerfile" .
 
 .PHONY: test-70
-test-70: deps
-	docker run -it --rm -v "$$PWD":/opt/mockery -w /opt/mockery php:7.0-cli php vendor/bin/phpunit
+test-70: build70
+	docker run -it --rm \
+		-v "$$PWD/library":/opt/mockery/library \
+		-v "$$PWD/tests":/opt/mockery/tests \
+		-v "$$PWD/phpunit.xml.dist":/opt/mockery/phpunit.xml \
+		-w /opt/mockery \
+		mockery_php70 \
+		php vendor/bin/phpunit
+
+.PHONY: build70
+build70:
+	docker build -t mockery_php70 -f "$$PWD/docker/php70/Dockerfile" .
 
 .PHONY: test-56
 test-56: build56

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,14 @@ docs/api/index.html: vendor/composer/installed.json $(library_files) phpDocument
 	php phpDocumentor.phar run -d library -t docs/api
 
 .PHONY: test-all
-test-all: test-73 test-72 test-71 test-70 test-56
+test-all: test-74 test-73 test-72 test-71 test-70 test-56
 
 .PHONY: test-all-7
-test-all-7: test-73 test-72 test-71 test-70
+test-all-7: test-74 test-73 test test-71 test-70
+
+.PHONY: test-74
+test-74: deps
+	docker run -it --rm -v "$$PWD":/opt/mockery -w /opt/mockery php:7.4-cli php vendor/bin/phpunit
 
 .PHONY: test-73
 test-73: deps

--- a/docker/php70/Dockerfile
+++ b/docker/php70/Dockerfile
@@ -1,0 +1,14 @@
+FROM php:7.0-cli
+
+RUN apt-get update && \
+    apt-get install -y git zip unzip && \
+    apt-get -y autoremove && \
+    apt-get clean && \
+    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+WORKDIR /opt/mockery
+
+COPY composer.json ./
+
+RUN composer install

--- a/docker/php71/Dockerfile
+++ b/docker/php71/Dockerfile
@@ -1,0 +1,14 @@
+FROM php:7.1-cli
+
+RUN apt-get update && \
+    apt-get install -y git zip unzip && \
+    apt-get -y autoremove && \
+    apt-get clean && \
+    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+WORKDIR /opt/mockery
+
+COPY composer.json ./
+
+RUN composer install

--- a/tests/PHP70/Generator/StringManipulation/Pass/MagicMethodTypeHintsPassTest.php
+++ b/tests/PHP70/Generator/StringManipulation/Pass/MagicMethodTypeHintsPassTest.php
@@ -28,6 +28,9 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\Generator\DefinedTargetClass;
 use Mockery\Generator\StringManipulation\Pass\MagicMethodTypeHintsPass;
 
+/**
+ * @requires PHP 7.0.0-dev
+ */
 class MagicMethodTypeHintsPassTest extends MockeryTestCase
 {
     /**

--- a/tests/PHP70/MockingParameterAndReturnTypesTest.php
+++ b/tests/PHP70/MockingParameterAndReturnTypesTest.php
@@ -25,6 +25,9 @@ namespace test\Mockery;
 
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
+/**
+ * @requires PHP 7.0.0-dev
+ */
 class MockingParameterAndReturnTypesTest extends MockeryTestCase
 {
     public function testMockingStringReturnType()


### PR DESCRIPTION
This PR adds php74 to makefile for local testing and moves php7.0 and php7.1 to built docker images due to phpunit version constraints.