### PR TITLE
Remove comments from mock pass

### DIFF
--- a/library/Mockery/Generator/StringManipulation/Pass/ClassNamePass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/ClassNamePass.php
@@ -32,18 +32,20 @@ class ClassNamePass implements Pass
 
         $className = $config->getShortName();
 
-        $code = str_replace(
+        $parts = preg_split("/{/", $code, 2);
+
+        $parts[0] = str_replace(
             'namespace Mockery;',
             $namespace ? 'namespace ' . $namespace . ';' : '',
-            $code
+            $parts[0]
         );
 
-        $code = str_replace(
+        $parts[0] = str_replace(
             'class Mock',
             'class ' . $className,
-            $code
+            $parts[0]
         );
 
-        return $code;
+        return $parts[0] . "{" . $parts[1];
     }
 }

--- a/library/Mockery/Generator/StringManipulation/Pass/ClassPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/ClassPass.php
@@ -47,12 +47,14 @@ class ClassPass implements Pass
             \Mockery::declareClass($className);
         }
 
-        $code = str_replace(
+        $parts = preg_split("/{/", $code, 2);
+
+        $parts[0] = str_replace(
             "implements MockInterface",
             "extends \\" . $className . " implements MockInterface",
-            $code
+            $parts[0]
         );
 
-        return $code;
+        return $parts[0] . "{" . $parts[1];
     }
 }

--- a/library/Mockery/Generator/StringManipulation/Pass/InterfacePass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/InterfacePass.php
@@ -37,12 +37,14 @@ class InterfacePass implements Pass
             return $code . ", \\" . ltrim($i->getName(), "\\");
         }, "");
 
-        $code = str_replace(
+        $parts = preg_split("/{/", $code, 2);
+
+        $parts[0] = str_replace(
             "implements MockInterface",
             "implements MockInterface" . $interfaces,
-            $code
+            $parts[0]
         );
 
-        return $code;
+        return $parts[0] . "{" . $parts[1];
     }
 }

--- a/library/Mockery/Generator/StringManipulation/Pass/RemoveCommentsFromMockPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/RemoveCommentsFromMockPass.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/blob/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ *
+ * @category   Mockery
+ * @package    Mockery
+ * @copyright  Copyright (c) 2010 Pádraic Brady (http://blog.astrumfutura.com)
+ * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
+ */
+
+namespace Mockery\Generator\StringManipulation\Pass;
+
+use Mockery\Generator\MockConfiguration;
+
+class RemoveCommentsFromMockPass implements Pass
+{
+    private $strippedCode;
+
+    private $tokens;
+
+    /**
+     * @param string $code
+     * @param MockConfiguration $config
+     * @return string
+     */
+    public function apply($code, MockConfiguration $config)
+    {
+        if ($this->strippedCode !== null) {
+            return $this->strippedCode;
+        }
+
+        $this->strippedCode = '';
+
+        $this->removeComments($code);
+
+        $this->removeEmptyLines();
+
+        return $this->strippedCode;
+    }
+
+    /**
+     * @return string
+     */
+    private function removeEmptyLines()
+    {
+        $this->strippedCode = preg_replace('#(^[\r\n]*|[\r\n]+)[\s\t]*[\r\n]+#', "\n", $this->strippedCode);
+    }
+
+    /**
+     * @param string $code
+     */
+    private function removeComments($code)
+    {
+        $tokens = token_get_all($code);
+
+        foreach ($tokens as $token) {
+            if (is_array($token)) {
+                if ($token[0] == T_DOC_COMMENT || $token[0] == T_COMMENT) {
+                    continue;
+                }
+
+                $token = $token[1];
+            }
+            $this->strippedCode .= $token;
+        }
+    }
+}

--- a/library/Mockery/Generator/StringManipulationGenerator.php
+++ b/library/Mockery/Generator/StringManipulationGenerator.php
@@ -30,6 +30,7 @@ use Mockery\Generator\StringManipulation\Pass\MagicMethodTypeHintsPass;
 use Mockery\Generator\StringManipulation\Pass\MethodDefinitionPass;
 use Mockery\Generator\StringManipulation\Pass\Pass;
 use Mockery\Generator\StringManipulation\Pass\RemoveBuiltinMethodsThatAreFinalPass;
+use Mockery\Generator\StringManipulation\Pass\RemoveCommentsFromMockPass;
 use Mockery\Generator\StringManipulation\Pass\RemoveDestructorPass;
 use Mockery\Generator\StringManipulation\Pass\RemoveUnserializeForInternalSerializableClassesPass;
 use Mockery\Generator\StringManipulation\Pass\TraitPass;
@@ -47,6 +48,7 @@ class StringManipulationGenerator implements Generator
     public static function withDefaultPasses()
     {
         return new static([
+            new RemoveCommentsFromMockPass(),
             new CallTypeHintPass(),
             new MagicMethodTypeHintsPass(),
             new ClassPass(),


### PR DESCRIPTION
While debugging the memory leak issues, I've noticed that Mockery is doing a bit more work than really necessary. The Mock class is full of docblocks and comments that increase the generated code, meaning the string manipulation passes need more memory.

I'm not really sure about this approach. I've also learned that php has `-w` switch that strips away all comments and whitespace and creates output that can be used instead of Mock.php. The problem with that approach though, that we should be generating that file ourselves for every release (probably can be automated, but still, it's a step that can go wrong.) This StrippedMock.php has better performance impacts than the changes from this MR.

Thoughts?