### PR TITLE
Test on PHP 7.4 and drop HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
-sudo: false
-
 language: php
 
 matrix:
   allow_failures:
-    - php: hhvm
-    - php: 7.4snapshot
+    - php: hhvm-3.18
     - php: nightly
   fast_finish: true
   include:
@@ -43,10 +40,10 @@ matrix:
     - php: 7.3
       env:
         - DEPS=latest
-    - php: 7.4snapshot
+    - php: 7.4
       env:
         - DEPS=lowest
-    - php: 7.4snapshot
+    - php: 7.4
       env:
         - DEPS=latest
     - php: nightly
@@ -55,10 +52,10 @@ matrix:
     - php: nightly
       env:
         - DEPS=latest
-    - php: hhvm
+    - php: hhvm-3.18
       env:
         - DEPS=lowest
-    - php: hhvm
+    - php: hhvm-3.18
       env:
         - DEPS=latest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 
 matrix:
   allow_failures:
-    - php: hhvm-3.18
     - php: nightly
   fast_finish: true
   include:
@@ -49,15 +48,11 @@ matrix:
     - php: nightly
       env:
         - DEPS=lowest
+        - COMPOSER_FLAGS="--ignore-platform-reqs"
     - php: nightly
       env:
         - DEPS=latest
-    - php: hhvm-3.18
-      env:
-        - DEPS=lowest
-    - php: hhvm-3.18
-      env:
-        - DEPS=latest
+        - COMPOSER_FLAGS="--ignore-platform-reqs"
 
 cache:
   directories:
@@ -68,8 +63,8 @@ before_install:
 
 install:
   - if [[ $PHPUNIT == 'minimum' ]]; then sed -i 's/~5.7|/5.4.*|/g' ./composer.json ; fi
-  - if [[ $DEPS == 'latest' ]]; then travis_retry composer update --no-interaction ; fi
-  - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable --no-interaction ; fi
+  - if [[ $DEPS == 'latest' ]]; then travis_retry composer update --no-interaction $COMPOSER_FLAGS ; fi
+  - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable --no-interaction $COMPOSER_FLAGS ; fi
 
 before_script:
   # Install extensions for PHP 5.x series. 7.x includes them by default.

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ test: deps
 apidocs: docs/api/index.html
 
 phpDocumentor.phar: 
-	wget https://github.com/phpDocumentor/phpDocumentor2/releases/download/v3.0.0-alpha.3/phpDocumentor.phar
-	wget https://github.com/phpDocumentor/phpDocumentor2/releases/download/v3.0.0-alpha.3/phpDocumentor.phar.pubkey
+	wget https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.0.0-rc/phpDocumentor.phar
+	wget https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.0.0-rc/phpDocumentor.phar.pubkey
 
 library_files=$(shell find library -name '*.php')
 docs/api/index.html: vendor/composer/installed.json $(library_files) phpDocumentor.phar


### PR DESCRIPTION
1. Test on stable PHP 7.4.
2. Allow composer to actually proceed on PHP 8.
3. Neither HHVM 3 or 4 seem to be able to even start running the tests, so I have dropped HHVM from the build.