### PR TITLE
Fix mocking with anonymous classes

### DIFF
--- a/library/Mockery/Generator/DefinedTargetClass.php
+++ b/library/Mockery/Generator/DefinedTargetClass.php
@@ -23,20 +23,22 @@ namespace Mockery\Generator;
 class DefinedTargetClass implements TargetClassInterface
 {
     private $rfc;
+    private $name;
 
-    public function __construct(\ReflectionClass $rfc)
+    public function __construct(\ReflectionClass $rfc, $alias = null)
     {
         $this->rfc = $rfc;
+        $this->name = $alias === null ? $rfc->getName() : $alias;
     }
 
-    public static function factory($name)
+    public static function factory($name, $alias = null)
     {
-        return new self(new \ReflectionClass($name));
+        return new self(new \ReflectionClass($name), $alias);
     }
 
     public function getName()
     {
-        return $this->rfc->getName();
+        return $this->name;
     }
 
     public function isAbstract()

--- a/library/Mockery/Generator/MockConfiguration.php
+++ b/library/Mockery/Generator/MockConfiguration.php
@@ -318,7 +318,15 @@ class MockConfiguration
         }
 
         if (class_exists($this->targetClassName)) {
-            $dtc = DefinedTargetClass::factory($this->targetClassName);
+            $alias = null;
+            if (strpos($this->targetClassName, '@') !== false) {
+                $alias = (new MockNameBuilder())
+                    ->addPart('anonymous_class')
+                    ->addPart(md5($this->targetClassName))
+                    ->build();
+                class_alias($this->targetClassName, $alias);
+            }
+            $dtc = DefinedTargetClass::factory($this->targetClassName, $alias);
 
             if ($this->getTargetObject() == false && $dtc->isFinal()) {
                 throw new \Mockery\Exception(
@@ -419,11 +427,13 @@ class MockConfiguration
         $nameBuilder = new MockNameBuilder();
 
         if ($this->getTargetObject()) {
-            $nameBuilder->addPart(get_class($this->getTargetObject()));
+            $className = get_class($this->getTargetObject());
+            $nameBuilder->addPart(strpos($className, '@') !== false ? md5($className) : $className);
         }
 
         if ($this->getTargetClass()) {
-            $nameBuilder->addPart($this->getTargetClass()->getName());
+            $className = $this->getTargetClass()->getName();
+            $nameBuilder->addPart(strpos($className, '@') !== false ? md5($className) : $className);
         }
 
         foreach ($this->getTargetInterfaces() as $targetInterface) {

--- a/tests/PHP70/MockingAnonymousClassTest.php
+++ b/tests/PHP70/MockingAnonymousClassTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ *
+ * @category   Mockery
+ * @package    Mockery
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2010 Pádraic Brady (http://blog.astrumfutura.com)
+ * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
+ */
+
+declare(strict_types=1); // Use strict types to ensure exact types are returned or passed
+
+namespace test\Mockery;
+
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+class MockingAnonymousClassTest extends MockeryTestCase
+{
+    public function testMockFromAnonymousClassName()
+    {
+        $anonymousClassName = get_class(new class {});
+
+        $mock = mock($anonymousClassName);
+
+        $this->assertInstanceOf($anonymousClassName, $mock);
+    }
+
+    public function testMockFromAnonymousClassInstance()
+    {
+        $anonymousClass = new class {};
+
+        $mock = mock($anonymousClass);
+
+        $this->assertInstanceOf(get_class($anonymousClass), $mock);
+    }
+}


### PR DESCRIPTION
Mockery throws a PHP Parse error when trying to mock an anonymous class.

This PR fixes this issue.