### PR TITLE
Fix PHPDOC since mixed[] indicates only an array of mixed values

### DIFF
--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -406,7 +406,7 @@ class Expectation implements ExpectationInterface
     /**
      * Expected argument setter for the expectation
      *
-     * @param mixed[] ...$args
+     * @param mixed|mixed[] ...$args
      * @return self
      */
     public function with(...$args)
@@ -504,7 +504,7 @@ class Expectation implements ExpectationInterface
     /**
      * Set a return value, or sequential queue of return values
      *
-     * @param mixed[] ...$args
+     * @param mixed|mixed[] ...$args
      * @return self
      */
     public function andReturn(...$args)
@@ -516,7 +516,7 @@ class Expectation implements ExpectationInterface
     /**
      * Set a return value, or sequential queue of return values
      *
-     * @param mixed[] ...$args
+     * @param mixed|mixed[] ...$args
      * @return self
      */
     public function andReturns(...$args)

--- a/library/Mockery/LegacyMockInterface.php
+++ b/library/Mockery/LegacyMockInterface.php
@@ -34,7 +34,7 @@ interface LegacyMockInterface
     /**
      * Set expected method calls
      *
-     * @param array ...$methodNames one or many methods that are expected to be called in this mock
+     * @param string|array ...$methodNames one or many methods that are expected to be called in this mock
      *
      * @return \Mockery\ExpectationInterface|\Mockery\Expectation|\Mockery\HigherOrderMessage
      */
@@ -43,7 +43,7 @@ interface LegacyMockInterface
     /**
      * Shortcut method for setting an expectation that a method should not be called.
      *
-     * @param array ...$methodNames one or many methods that are expected not to be called in this mock
+     * @param string|array ...$methodNames one or many methods that are expected not to be called in this mock
      * @return \Mockery\ExpectationInterface|\Mockery\Expectation|\Mockery\HigherOrderMessage
      */
     public function shouldNotReceive(...$methodNames);


### PR DESCRIPTION
Newer PhpStorm versions are more strict and now are warning that types don't match.
![image](https://user-images.githubusercontent.com/500491/76515856-049a9180-6463-11ea-9ad1-907bdb585764.png)

Which is basically true, since `[]` indicates that only arrays are expected.

This PR allows single mixed value as a parameter too.