### PR TITLE
Slim down mockery when loaded as a dependency

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+* text=auto
+
+/docker export-ignore
+/tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.php_cs export-ignore
+.scrutinizer.yml export-ignore
+.styleci.yml export-ignore
+.travis.yml export-ignore
+Makefile export-ignore
+phpunit.xml.dist export-ignore


### PR DESCRIPTION
This pull request slims down Mockery as a dependency by removing all unnecessary files from distributions. This means that if you install Mockery via Composer you will no longer have Mockery's tests and meta files in your vendor directory.