### PR TITLE
Fix minor spelling error

### DIFF
--- a/docs/reference/expectations.rst
+++ b/docs/reference/expectations.rst
@@ -148,7 +148,7 @@ is called.
         ->withSomeOfArgs(arg1, arg2, arg3, ...);
 
 The given expected arguments order doesn't matter.
-Check if expected values are inclued or not, but type should be matched:
+Check if expected values are included or not, but type should be matched:
 
 .. code-block:: php
 


### PR DESCRIPTION
Change misspelled "inclued" to "included".