### PR TITLE
Fix typos

### DIFF
--- a/docs/cookbook/mocking_class_within_class.rst
+++ b/docs/cookbook/mocking_class_within_class.rst
@@ -92,8 +92,8 @@ such as::
 
 That basically means that the loading prevents mocking and for each such
 a loading initiator there needs to be implemented a workaround.
-Overloading is one approach, however it polutes the global state. In this case
-we try to completely avoid the global state polution with custom
+Overloading is one approach, however it pollutes the global state. In this case
+we try to completely avoid the global state pollution with custom
 ``new Class()`` behavior per loading initiator and that can be mocked easily
 in few critical places.
 

--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -234,7 +234,7 @@ class Mockery
     }
 
     /**
-     * Setter for the $_generator static propery.
+     * Setter for the $_generator static property.
      *
      * @param \Mockery\Generator\Generator $generator
      */

--- a/library/Mockery/Configuration.php
+++ b/library/Mockery/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
     }
 
     /**
-     * Remove all overriden parameter maps from internal PHP classes.
+     * Remove all overridden parameter maps from internal PHP classes.
      */
     public function resetInternalClassMethodParamMaps()
     {

--- a/library/Mockery/Generator/StringManipulation/Pass/MagicMethodTypeHintsPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/MagicMethodTypeHintsPass.php
@@ -111,7 +111,7 @@ class MagicMethodTypeHintsPass implements Pass
     }
 
     /**
-     * Checks if the method is declared withing code.
+     * Checks if the method is declared within code.
      *
      * @param int $code
      * @param Method $method

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -36,7 +36,7 @@ class Mock implements MockInterface
     protected $_mockery_expectations = array();
 
     /**
-     * Stores an inital number of expectations that can be manipulated
+     * Stores an initial number of expectations that can be manipulated
      * while using the getter method.
      *
      * @var int

--- a/tests/PHP70/Generator/StringManipulation/Pass/MagicMethodTypeHintsPassTest.php
+++ b/tests/PHP70/Generator/StringManipulation/Pass/MagicMethodTypeHintsPassTest.php
@@ -259,7 +259,7 @@ class MagicMethodTypeHintsPassTest extends MockeryTestCase
      * Tests if the pass correclty replaces all the magic
      * method parameters with those found in the
      * Mock class. This is made to avoid variable
-     * conflicts withing Mock's magic methods
+     * conflicts within Mock's magic methods
      * implementations.
      *
      * @test


### PR DESCRIPTION
Hello,

This PR will fix : 

- 2 typos in `docs/cookbook/mocking_class_within_class.rst`
- 1 typo in `library/Mockery.php`
- 1 typo in `library/Mockery/Configuration.php`
- 1 typo in `library/Mockery/Generator/StringManipulation/Pass/MagicMethodTypeHintsPass.php`
- 1 typo in `library/Mockery/Mock.php`
- 1 typo in `tests/PHP70/Generator/StringManipulation/Pass/MagicMethodTypeHintsPassTest.php`



Cheers! :robot: