### PR TITLE
Fix andAnyOthers() to properly match earlier expectations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 1.3.2 (XXXX-XX-XX)
+* Fix andAnyOthers() to properly match earlier expectations (#1051)
+
 ## 1.3.1 (2019-12-26)
 * Revert improved exception debugging due to BC breaks (#1032)
 
@@ -24,7 +27,7 @@
 
 ## 1.2.2 (2019-02-13)
 
-* Fix a BC breaking change for PHP 5.6/PHPUnit 5.7.27 (#947) 
+* Fix a BC breaking change for PHP 5.6/PHPUnit 5.7.27 (#947)
 
 ## 1.2.1 (2019-02-07)
 
@@ -67,7 +70,7 @@
 ## 1.0.0 (2017-09-06)
 
 * Destructors (`__destruct`) are stubbed out where it makes sense
-* Allow passing a closure argument to `withArgs()` to validate multiple arguments at once. 
+* Allow passing a closure argument to `withArgs()` to validate multiple arguments at once.
 * `Mockery\Adapter\Phpunit\TestListener` has been rewritten because it
   incorrectly marked some tests as risky. It will no longer verify mock
   expectations but instead check that tests do that themselves. PHPUnit 6 is
@@ -90,7 +93,7 @@
 * BC BREAK - Fix Mockery not trying default expectations if there is any concrete expectation
 * BC BREAK - Mockery's PHPUnit integration will mark a test as risky if it
   thinks one it's exceptions has been swallowed in PHPUnit > 5.7.6. Use `$e->dismiss()` to dismiss.
- 
+
 ## 0.9.4 (XXXX-XX-XX)
 
 * `shouldIgnoreMissing` will respect global `allowMockingNonExistentMethods`

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -344,8 +344,7 @@ class Expectation implements ExpectationInterface
             reset($this->_expectedArgs);
 
             if ($this->isAndAnyOtherArgumentsMatcher($lastExpectedArgument)) {
-                $argCountToSkipMatching = $argCount - count($this->_expectedArgs);
-                $args = array_slice($args, 0, $argCountToSkipMatching);
+                $args = array_slice($args, 0, array_search($lastExpectedArgument, $this->_expectedArgs, true));
                 return $this->_matchArgs($args);
             }
 

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -1081,7 +1081,7 @@ class ExpectationTest extends MockeryTestCase
     {
         $this->mock->shouldReceive('foo')->with(1, 2, Mockery::andAnyOthers())->twice();
         $this->mock->foo(1, 2, 3, 4, 5);
-        $this->mock->foo(1, 'str', 3, 4);
+        $this->mock->foo(1, 2, 'str', 3, 4);
     }
 
     public function testAndAnyOtherConstraintDoesNotPreventMatchingOfRegularArguments()
@@ -1091,6 +1091,14 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(10, 2, 3, 4, 5);
         Mockery::close();
     }
+
+	public function testAndAnyOtherConstraintMultipleExpectations()
+	{
+		$this->mock->shouldReceive('foo')->with('a', Mockery::andAnyOthers())->andReturn('a');
+		$this->mock->shouldReceive('foo')->with('b', Mockery::andAnyOthers())->andReturn('b');
+		$this->assertEquals('a', $this->mock->foo('a'));
+		$this->assertEquals('b', $this->mock->foo('b'));
+	}
 
     public function testArrayConstraintMatchesArgument()
     {

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -428,7 +428,7 @@ class ExpectationTest extends MockeryTestCase
     {
         $this->mock->shouldReceive('foo')->withArgs(array('a string'));
         $this->expectException(\Mockery\Exception::class);
-        $this->expectExceptionMessageRegExp('/foo\(NULL\)/');
+        $this->expectExceptionMessageMatches('/foo\(NULL\)/');
         $this->mock->foo(null);
         Mockery::close();
     }
@@ -436,7 +436,7 @@ class ExpectationTest extends MockeryTestCase
     public function testExpectsArgumentsArrayThrowsExceptionIfPassedWrongArgumentType()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/invalid argument (.+), only array and closure are allowed/');
+        $this->expectExceptionMessageMatches('/invalid argument (.+), only array and closure are allowed/');
         $this->mock->shouldReceive('foo')->withArgs(5);
         Mockery::close();
     }
@@ -2078,7 +2078,7 @@ class ExpectationTest extends MockeryTestCase
     public function testCountWithBecauseExceptionMessage()
     {
         $this->expectException(InvalidCountException::class);
-        $this->expectExceptionMessageRegexp(
+        $this->expectExceptionMessageMatches(
             '/Method foo\(<Any Arguments>\) from Mockery_[\d]+ should be called' . PHP_EOL . ' ' .
             'exactly 1 times but called 0 times. Because We like foo/'
         );

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -1092,13 +1092,13 @@ class ExpectationTest extends MockeryTestCase
         Mockery::close();
     }
 
-	public function testAndAnyOtherConstraintMultipleExpectations()
-	{
-		$this->mock->shouldReceive('foo')->with('a', Mockery::andAnyOthers())->andReturn('a');
-		$this->mock->shouldReceive('foo')->with('b', Mockery::andAnyOthers())->andReturn('b');
-		$this->assertEquals('a', $this->mock->foo('a'));
-		$this->assertEquals('b', $this->mock->foo('b'));
-	}
+    public function testAndAnyOtherConstraintMultipleExpectations()
+    {
+        $this->mock->shouldReceive('foo')->with('a', Mockery::andAnyOthers())->andReturn('a');
+        $this->mock->shouldReceive('foo')->with('b', Mockery::andAnyOthers())->andReturn('b');
+        $this->assertEquals('a', $this->mock->foo('a'));
+        $this->assertEquals('b', $this->mock->foo('b'));
+    }
 
     public function testArrayConstraintMatchesArgument()
     {

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -1092,7 +1092,7 @@ class ExpectationTest extends MockeryTestCase
         Mockery::close();
     }
 
-    public function testAndAnyOtherConstraintMultipleExpectations()
+    public function testAndAnyOtherConstraintMultipleExpectationsButNoOthers()
     {
         $this->mock->shouldReceive('foo')->with('a', Mockery::andAnyOthers())->andReturn('a');
         $this->mock->shouldReceive('foo')->with('b', Mockery::andAnyOthers())->andReturn('b');

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -428,7 +428,7 @@ class ExpectationTest extends MockeryTestCase
     {
         $this->mock->shouldReceive('foo')->withArgs(array('a string'));
         $this->expectException(\Mockery\Exception::class);
-        $this->expectExceptionMessageMatches('/foo\(NULL\)/');
+        $this->expectExceptionMessageRegExp('/foo\(NULL\)/');
         $this->mock->foo(null);
         Mockery::close();
     }
@@ -436,7 +436,7 @@ class ExpectationTest extends MockeryTestCase
     public function testExpectsArgumentsArrayThrowsExceptionIfPassedWrongArgumentType()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/invalid argument (.+), only array and closure are allowed/');
+        $this->expectExceptionMessageRegExp('/invalid argument (.+), only array and closure are allowed/');
         $this->mock->shouldReceive('foo')->withArgs(5);
         Mockery::close();
     }
@@ -2086,7 +2086,7 @@ class ExpectationTest extends MockeryTestCase
     public function testCountWithBecauseExceptionMessage()
     {
         $this->expectException(InvalidCountException::class);
-        $this->expectExceptionMessageMatches(
+        $this->expectExceptionMessageRegExp(
             '/Method foo\(<Any Arguments>\) from Mockery_[\d]+ should be called' . PHP_EOL . ' ' .
             'exactly 1 times but called 0 times. Because We like foo/'
         );


### PR DESCRIPTION
This PR fixes the behavior in https://github.com/mockery/mockery/issues/1051

Additionally I updated an erroneous test case and added a test case for another edge case.