### PR TITLE
Add support for PHPUnit version 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "hamcrest/hamcrest-php": "~2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7.10|~6.5|~7.0|~8.0"
+        "phpunit/phpunit": "~5.7.10|~6.5|~7.0|~8.0|~9.0"
     },
     "autoload": {
         "psr-0": {

--- a/library/Mockery/Adapter/Phpunit/Legacy/TestListenerTrait.php
+++ b/library/Mockery/Adapter/Phpunit/Legacy/TestListenerTrait.php
@@ -85,6 +85,11 @@ class TestListenerTrait
 
     public function startTestSuite()
     {
-        Blacklist::$blacklistedClassNames[\Mockery::class] = 1;
+        if (method_exists(Blacklist::class, 'addDirectory')) {
+            (new BlackList())->getBlacklistedDirectories();
+            Blacklist::addDirectory(\dirname((new \ReflectionClass(\Mockery::class))->getFileName()));
+        } else {
+            Blacklist::$blacklistedClassNames[\Mockery::class] = 1;
+        }
     }
 }

--- a/library/Mockery/Adapter/Phpunit/MockeryTestCase.php
+++ b/library/Mockery/Adapter/Phpunit/MockeryTestCase.php
@@ -38,7 +38,7 @@ abstract class MockeryTestCase extends \PHPUnit\Framework\TestCase
     {
     }
 
-    public function expectExceptionMessageRegExp($regularExpression)
+    public function expectExceptionMessageRegEx($regularExpression)
     {
         if (method_exists(get_parent_class(), 'expectExceptionMessageRegExp')) {
             return parent::expectExceptionMessageRegExp($regularExpression);

--- a/library/Mockery/Adapter/Phpunit/MockeryTestCase.php
+++ b/library/Mockery/Adapter/Phpunit/MockeryTestCase.php
@@ -47,7 +47,7 @@ abstract class MockeryTestCase extends \PHPUnit\Framework\TestCase
         return $this->expectExceptionMessageMatches($regularExpression);
     }
 
-    public static function assertMatchesRegularExpression(string $pattern, string $string, string $message = ''): void
+    public static function assertMatchesRegEx($pattern, $string, $message = '')
     {
         if (method_exists(get_parent_class(), 'assertMatchesRegularExpression')) {
             parent::assertMatchesRegularExpression($pattern, $string, $message);

--- a/library/Mockery/Adapter/Phpunit/MockeryTestCase.php
+++ b/library/Mockery/Adapter/Phpunit/MockeryTestCase.php
@@ -46,4 +46,13 @@ abstract class MockeryTestCase extends \PHPUnit\Framework\TestCase
 
         return $this->expectExceptionMessageMatches($regularExpression);
     }
+
+    public static function assertMatchesRegularExpression(string $pattern, string $string, string $message = ''): void
+    {
+        if (method_exists(get_parent_class(), 'assertMatchesRegularExpression')) {
+            parent::assertMatchesRegularExpression($pattern, $string, $message);
+        }
+
+        self::assertRegExp($pattern, $string, $message);
+    }
 }

--- a/library/Mockery/Adapter/Phpunit/MockeryTestCase.php
+++ b/library/Mockery/Adapter/Phpunit/MockeryTestCase.php
@@ -37,4 +37,13 @@ abstract class MockeryTestCase extends \PHPUnit\Framework\TestCase
     protected function mockeryTestTearDown()
     {
     }
+
+    public function expectExceptionMessageRegExp($regularExpression)
+    {
+        if (method_exists(get_parent_class(), 'expectExceptionMessageRegExp')) {
+            return parent::expectExceptionMessageRegExp($regularExpression);
+        }
+
+        return $this->expectExceptionMessageMatches($regularExpression);
+    }
 }

--- a/tests/Mockery/Adapter/Phpunit/TestListenerTest.php
+++ b/tests/Mockery/Adapter/Phpunit/TestListenerTest.php
@@ -96,8 +96,24 @@ class TestListenerTest extends MockeryTestCase
     {
         $suite = \Mockery::mock(\PHPUnit\Framework\TestSuite::class);
 
-        $this->assertArrayNotHasKey(\Mockery::class, \PHPUnit\Util\Blacklist::$blacklistedClassNames);
-        $this->listener->startTestSuite($suite);
-        $this->assertSame(1, \PHPUnit\Util\Blacklist::$blacklistedClassNames[\Mockery::class]);
+        if (method_exists(\PHPUnit\Util\Blacklist::class, 'addDirectory')) {
+            $this->assertFalse(
+                (new \PHPUnit\Util\Blacklist())->isBlacklisted(
+                    (new \ReflectionClass(\Mockery::class))->getFileName()
+                )
+            );
+
+            $this->listener->startTestSuite($suite);
+
+            $this->assertTrue(
+                (new \PHPUnit\Util\Blacklist())->isBlacklisted(
+                    (new \ReflectionClass(\Mockery::class))->getFileName()
+                )
+            );
+        } else {
+            $this->assertArrayNotHasKey(\Mockery::class, \PHPUnit\Util\Blacklist::$blacklistedClassNames);
+            $this->listener->startTestSuite($suite);
+            $this->assertSame(1, \PHPUnit\Util\Blacklist::$blacklistedClassNames[\Mockery::class]);
+        }
     }
 }

--- a/tests/Mockery/ContainerTest.php
+++ b/tests/Mockery/ContainerTest.php
@@ -37,7 +37,7 @@ class ContainerTest extends MockeryTestCase
     {
         $m = mock();
         $m->shouldReceive('foo->bar');
-        $this->assertMatchesRegularExpression(
+        $this->expectExceptionMessageRegExp(
             '/Mockery_(\d+)__demeter_([0-9a-f]+)_foo/',
             Mockery::getContainer()->getKeyOfDemeterMockFor('foo', get_class($m))
         );

--- a/tests/Mockery/ContainerTest.php
+++ b/tests/Mockery/ContainerTest.php
@@ -37,7 +37,7 @@ class ContainerTest extends MockeryTestCase
     {
         $m = mock();
         $m->shouldReceive('foo->bar');
-        $this->assertMatchesRegularExpression(
+        $this->assertMatchesRegEx(
             '/Mockery_(\d+)__demeter_([0-9a-f]+)_foo/',
             Mockery::getContainer()->getKeyOfDemeterMockFor('foo', get_class($m))
         );

--- a/tests/Mockery/ContainerTest.php
+++ b/tests/Mockery/ContainerTest.php
@@ -455,7 +455,7 @@ class ContainerTest extends MockeryTestCase
     {
         $m = mock('MockeryTest_PartialNormalClass2[!foo]');
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessageRegExp('/::bar\(\), but no expectations were specified/');
+        $this->expectExceptionMessageRegEx('/::bar\(\), but no expectations were specified/');
         $m->bar();
     }
 
@@ -801,7 +801,7 @@ class ContainerTest extends MockeryTestCase
             ->andThrow(new \Exception('instanceMock ' . rand(100, 999)));
 
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessageRegExp('/^instanceMock \d{3}$/');
+        $this->expectExceptionMessageRegEx('/^instanceMock \d{3}$/');
         new MyNamespace\MyClass16();
     }
 

--- a/tests/Mockery/ContainerTest.php
+++ b/tests/Mockery/ContainerTest.php
@@ -37,7 +37,7 @@ class ContainerTest extends MockeryTestCase
     {
         $m = mock();
         $m->shouldReceive('foo->bar');
-        $this->expectExceptionMessageRegExp(
+        $this->assertMatchesRegularExpression(
             '/Mockery_(\d+)__demeter_([0-9a-f]+)_foo/',
             Mockery::getContainer()->getKeyOfDemeterMockFor('foo', get_class($m))
         );

--- a/tests/Mockery/ContainerTest.php
+++ b/tests/Mockery/ContainerTest.php
@@ -37,7 +37,7 @@ class ContainerTest extends MockeryTestCase
     {
         $m = mock();
         $m->shouldReceive('foo->bar');
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             '/Mockery_(\d+)__demeter_([0-9a-f]+)_foo/',
             Mockery::getContainer()->getKeyOfDemeterMockFor('foo', get_class($m))
         );

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -428,7 +428,7 @@ class ExpectationTest extends MockeryTestCase
     {
         $this->mock->shouldReceive('foo')->withArgs(array('a string'));
         $this->expectException(\Mockery\Exception::class);
-        $this->expectExceptionMessageRegExp('/foo\(NULL\)/');
+        $this->expectExceptionMessageRegEx('/foo\(NULL\)/');
         $this->mock->foo(null);
         Mockery::close();
     }
@@ -436,7 +436,7 @@ class ExpectationTest extends MockeryTestCase
     public function testExpectsArgumentsArrayThrowsExceptionIfPassedWrongArgumentType()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/invalid argument (.+), only array and closure are allowed/');
+        $this->expectExceptionMessageRegEx('/invalid argument (.+), only array and closure are allowed/');
         $this->mock->shouldReceive('foo')->withArgs(5);
         Mockery::close();
     }
@@ -2078,7 +2078,7 @@ class ExpectationTest extends MockeryTestCase
     public function testCountWithBecauseExceptionMessage()
     {
         $this->expectException(InvalidCountException::class);
-        $this->expectExceptionMessageRegexp(
+        $this->expectExceptionMessageRegex(
             '/Method foo\(<Any Arguments>\) from Mockery_[\d]+ should be called' . PHP_EOL . ' ' .
             'exactly 1 times but called 0 times. Because We like foo/'
         );


### PR DESCRIPTION
This adds support for PHPUnit version 9.

PHPUnit version 9.1.2 had a breaking change in then `@internal` marked `Blacklist` class, which was addressed in [9.1.3](https://github.com/sebastianbergmann/phpunit/blob/74a7e9b91281f5051da617fdb2201c0d619b9efe/ChangeLog-9.1.md#913---2020-04-23).

Fixes #1048