### PR TITLE
Add option to allow\disallow mocking methods unnecessarily for default expectations defined through quick definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.4.1 (XXXX-XX-XX)
+
+* Allow quick definitions to use 'at least once' expectation
+  `\Mockery::getConfiguration()->getQuickDefinitions()->shouldBeCalledAtLeastOnce(true)` (#1056)
+
 ## 1.4.0 (2020-05-19)
 
 * Fix andAnyOthers() to properly match earlier expectations (#1051)

--- a/docs/mockery/configuration.rst
+++ b/docs/mockery/configuration.rst
@@ -5,13 +5,15 @@ Mockery Global Configuration
 ============================
 
 To allow for a degree of fine-tuning, Mockery utilises a singleton
-configuration object to store a small subset of core behaviours. The two
+configuration object to store a small subset of core behaviours. The three
 currently present include:
 
 * Option to allow/disallow the mocking of methods which do not actually exist
   fulfilled (i.e. unused)
 * Setter/Getter for added a parameter map for internal PHP class methods
   (``Reflection`` cannot detect these automatically)
+* Option to drive if quick definitions should define a stub or a mock with
+  an 'at least once' expectation.
 
 By default, the first behaviour is enabled. Of course, there are
 situations where this can lead to unintended consequences. The mocking of
@@ -46,6 +48,19 @@ classes. Most of the time, you never need to do this. It's mainly needed where a
 internal class method uses pass-by-reference for a parameter - you MUST in such
 cases ensure the parameter signature includes the ``&`` symbol correctly as Mockery
 won't correctly add it automatically for internal classes.
+
+Finally there is the possibility to change what a quick definition produces.
+By default quick definitions create stubs but you can change this behaviour
+by asking Mockery to use 'at least once' expectations.
+
+.. code-block:: php
+
+    \Mockery::getConfiguration()->getQuickDefinitions()->shouldBeCalledAtLeastOnce(bool)
+
+Passing a true allows the behaviour, false disallows it. It takes effect
+immediately until switched back. By doing so you can avoid the proliferating of
+quick definitions that accumulate overtime in your code since the test would
+fail in case the 'at least once' expectation is not fulfilled.
 
 Disabling reflection caching
 ----------------------------

--- a/library/Mockery/Configuration.php
+++ b/library/Mockery/Configuration.php
@@ -41,6 +41,11 @@ class Configuration
     protected $_allowMockingMethodsUnnecessarily = true;
 
     /**
+     * @var QuickDefinitionsConfiguration
+     */
+    protected $_quickDefinitionsConfiguration;
+
+    /**
      * Parameter map for use with PHP internal classes.
      *
      * @var array
@@ -56,6 +61,11 @@ class Configuration
      * @see https://github.com/mockery/mockery/issues/268
      */
     protected $_reflectionCacheEnabled = true;
+
+    public function __construct()
+    {
+        $this->_quickDefinitionsConfiguration = new QuickDefinitionsConfiguration();
+    }
 
     /**
      * Set boolean to allow/prevent mocking of non-existent methods
@@ -152,6 +162,14 @@ class Configuration
     public function getConstantsMap()
     {
         return $this->_constantsMap;
+    }
+
+    /**
+     * Returns the quick definitions configuration
+     */
+    public function getQuickDefinitions(): QuickDefinitionsConfiguration
+    {
+        return $this->_quickDefinitionsConfiguration;
     }
 
     /**

--- a/library/Mockery/Container.php
+++ b/library/Mockery/Container.php
@@ -233,7 +233,11 @@ class Container
         $mock->mockery_init($this, $config->getTargetObject(), $config->isInstanceMock());
 
         if (!empty($quickdefs)) {
-            $mock->shouldReceive($quickdefs)->byDefault();
+            if (\Mockery::getConfiguration()->getQuickDefinitions()->shouldBeCalledAtLeastOnce()) {
+                $mock->shouldReceive($quickdefs)->atLeast()->once();
+            } else {
+                $mock->shouldReceive($quickdefs)->byDefault();
+            }
         }
         if (!empty($expectationClosure)) {
             $expectationClosure($mock);

--- a/library/Mockery/QuickDefinitionsConfiguration.php
+++ b/library/Mockery/QuickDefinitionsConfiguration.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/blob/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ *
+ * @category   Mockery
+ * @package    Mockery
+ * @copyright  Copyright (c) 2010 Pádraic Brady (http://blog.astrumfutura.com)
+ * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
+ */
+
+namespace Mockery;
+
+class QuickDefinitionsConfiguration
+{
+    private const QUICK_DEFINITIONS_MODE_MOCK_AT_LEAST_ONCE = 'QUICK_DEFINITIONS_MODE_MOCK_AT_LEAST_ONCE';
+    private const QUICK_DEFINITIONS_MODE_DEFAULT_EXPECTATION = 'QUICK_DEFINITIONS_MODE_DEFAULT_EXPECTATION';
+
+    /**
+     * Defines what a quick definition should produce.
+     * Possible options are:
+     * - self::QUICK_DEFINITIONS_MODE_DEFAULT_EXPECTATION: in this case quick
+     * definitions define a stub.
+     * - self::QUICK_DEFINITIONS_MODE_MOCK_AT_LEAST_ONCE: in this case quick
+     * definitions define a mock with an 'at least once' expectation.
+     *
+     * @var string
+     */
+    protected $_quickDefinitionsApplicationMode = self::QUICK_DEFINITIONS_MODE_DEFAULT_EXPECTATION;
+
+    /**
+     * Returns true if quick definitions should setup a stub, returns false when
+     * quick definitions should setup a mock with 'at least once' expectation.
+     * When parameter $newValue is specified it sets the configuration with the
+     * given value.
+     */
+    public function shouldBeCalledAtLeastOnce(?bool $newValue = null): bool
+    {
+        if ($newValue !== null) {
+            $this->_quickDefinitionsApplicationMode = $newValue
+                ? self::QUICK_DEFINITIONS_MODE_MOCK_AT_LEAST_ONCE
+                : self::QUICK_DEFINITIONS_MODE_DEFAULT_EXPECTATION;
+        }
+
+        return $this->_quickDefinitionsApplicationMode === self::QUICK_DEFINITIONS_MODE_MOCK_AT_LEAST_ONCE;
+    }
+}

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -1877,6 +1877,22 @@ class ExpectationTest extends MockeryTestCase
         Mockery::close();
     }
 
+    public function testGlobalConfigQuickDefinitionsConfigurationDefaultExpectation()
+    {
+        \Mockery::getConfiguration()->getQuickDefinitions()->shouldBeCalledAtLeastOnce(false);
+        mock(array('foo'=>1));
+        $this->expectNotToPerformAssertions();
+        Mockery::close();
+    }
+
+    public function testGlobalConfigQuickDefinitionsConfigurationMockAtLeastOnce()
+    {
+        \Mockery::getConfiguration()->getQuickDefinitions()->shouldBeCalledAtLeastOnce(true);
+        mock(array('foo'=>1));
+        $this->expectException(\Mockery\Exception\InvalidCountException::class);
+        Mockery::close();
+    }
+
     public function testAnExampleWithSomeExpectationAmends()
     {
         $service = mock('MyService');


### PR DESCRIPTION
…t expectations set through quick definitions