### PR TITLE
Don't prefix return type with \ if it already is prefixed with \

### DIFF
--- a/library/Mockery/Generator/Method.php
+++ b/library/Mockery/Generator/Method.php
@@ -58,7 +58,7 @@ class Method
 
             if ('self' === $returnType) {
                 $returnType = "\\" . $this->method->getDeclaringClass()->getName();
-            } elseif (!\Mockery::isBuiltInType($returnType)) {
+            } elseif (0 !== strpos($returnType, '\\') && !\Mockery::isBuiltInType($returnType)) {
                 $returnType = '\\' . $returnType;
             }
 


### PR DESCRIPTION
I was trying to mock some classes from php-couchbase and got the following error:

    ParseError : syntax error, unexpected '\' (T_NS_SEPARATOR), expecting identifier (T_STRING)

This error is coming from the generated mock class and is caused by return types of methods which are prefixed with a `\`.

Adding a `\` in the return type in PHP itself does not cause this issue, but this extension defines their classes and method return types in C. The prefixed `\` is not stripped off because of that.

For example, a method with a return type is defined like this:

    ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ai_Cluster_bucket, 0, 1, \\Couchbase\\Bucket, 0)

But it should probably be defined like this:

    ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ai_Cluster_bucket, 0, 1, Couchbase\\Bucket, 0)

This is probably more a php-couchbase problem than a mockery problem, but since the couchbase code compiles and works with the `\`'s prefixed, I think mockery should support it as well. (phpunit mock work fine as well with php-couchbase classes.)

So my fix does not prefix the `\` if it is already there.