### PR TITLE
Fixed "TypeError: method_exists(): Argument #1 ($object_or_class) must be of type object|string, bool given"

### DIFF
--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -612,7 +612,7 @@ class Mock implements MockInterface
 
     public function __isset($name)
     {
-        if (false === stripos($name, '_mockery_') && method_exists(get_parent_class($this), '__isset')) {
+        if (false === stripos($name, '_mockery_') && get_parent_class($this) && method_exists(get_parent_class($this), '__isset')) {
             return call_user_func('parent::__isset', $name);
         }
 
@@ -635,7 +635,7 @@ class Mock implements MockInterface
      */
     public function mockery_callSubjectMethod($name, array $args)
     {
-        if (!method_exists($this, $name) && method_exists(get_parent_class($this), '__call')) {
+        if (!method_exists($this, $name) && get_parent_class($this) && method_exists(get_parent_class($this), '__call')) {
             return call_user_func('parent::__call', $name, $args);
         }
         return call_user_func_array('parent::' . $name, $args);
@@ -890,9 +890,9 @@ class Mock implements MockInterface
         ) {
             return call_user_func_array(array($this->_mockery_partial, $method), $args);
         } elseif ($this->_mockery_deferMissing && is_callable("parent::$method")
-            && (!$this->hasMethodOverloadingInParentClass() || method_exists(get_parent_class($this), $method))) {
+            && (!$this->hasMethodOverloadingInParentClass() || (get_parent_class($this) && method_exists(get_parent_class($this), $method)))) {
             return call_user_func_array("parent::$method", $args);
-        } elseif ($this->_mockery_deferMissing && method_exists(get_parent_class($this), '__call')) {
+        } elseif ($this->_mockery_deferMissing && get_parent_class($this) && method_exists(get_parent_class($this), '__call')) {
             return call_user_func('parent::__call', $method, $args);
         } elseif ($method == '__toString') {
             // __toString is special because we force its addition to the class API regardless of the


### PR DESCRIPTION
This affects PHP 8.0+ users.