### PR TITLE
[1.4] Release 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
 # Change Log
 
-## 1.4.1 (XXXX-XX-XX)
+## 1.4.1 (2020-07-09)
 
 * Allow quick definitions to use 'at least once' expectation
   `\Mockery::getConfiguration()->getQuickDefinitions()->shouldBeCalledAtLeastOnce(true)` (#1056)
+* Added provisional support for PHP 8.0 (#1068, #1072,#1079)
+* Fix mocking methods with iterable return type without specifying a return value (#1075)
 
 ## 1.4.0 (2020-05-19)
 
+* Fix mocking with anonymous classes (#1039)
 * Fix andAnyOthers() to properly match earlier expectations (#1051)
 * Drops support for PHP < 7.3 and PHPUnit < 8 (#1059)
 

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "require": {
         "php": "^7.3 || ^8.0",
         "lib-pcre": ">=7.0",
-        "hamcrest/hamcrest-php": "^2.0"
+        "hamcrest/hamcrest-php": "^2.0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5 || ^9.0"


### PR DESCRIPTION
Closes https://github.com/mockery/mockery/pull/1080.