### PR TITLE
Fix: array to string conversion in ConstantsPass [1.3]

### DIFF
--- a/library/Mockery/Generator/StringManipulation/Pass/ConstantsPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/ConstantsPass.php
@@ -21,7 +21,7 @@ class ConstantsPass implements Pass
 
         $constantsCode = '';
         foreach ($cm as $constant => $value) {
-            $constantsCode .= sprintf("\n    const %s = '%s';\n", $constant, $value);
+            $constantsCode .= sprintf("\n    const %s = %s;\n", $constant, var_export($value, true));
         }
 
         $i = strrpos($code, '}');

--- a/tests/Mockery/Fixtures/ClassWithConstants.php
+++ b/tests/Mockery/Fixtures/ClassWithConstants.php
@@ -26,4 +26,8 @@ class ClassWithConstants
     const FOO = 'bar';
 
     const X = 1;
+
+    const BAZ = [
+        'qux' => 'quux'
+    ];
 }

--- a/tests/Mockery/MockingClassConstantsTest.php
+++ b/tests/Mockery/MockingClassConstantsTest.php
@@ -32,6 +32,9 @@ class MockingClassConstantsTest extends MockeryTestCase
             'ClassWithConstants' => [
                 'FOO' => 'baz',
                 'X' => 2,
+                'BAZ' => [
+                    'qux' => 'daz'
+                ]
             ]
         ]);
 
@@ -39,5 +42,6 @@ class MockingClassConstantsTest extends MockeryTestCase
 
         self::assertEquals('baz', $mock::FOO);
         self::assertEquals(2, $mock::X);
+        self::assertEquals(['qux' => 'daz'], $mock::BAZ);
     }
 }


### PR DESCRIPTION
Fix for #1084 for v.1.3.x