### PR TITLE
[1.3] Fixed StyleCI config

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,7 +1,12 @@
 preset: psr12
 
+enabled:
+  - symfony_braces
+
+disabled:
+  - const_visibility_required
+  - psr12_braces
+
 finder:
   not-name:
-    - MethodWithHHVMReturnType.php
-    - MockingParameterAndReturnTypesTest.php
     - SemiReservedWordsAsMethods.php

--- a/library/Mockery/Generator/StringManipulation/Pass/MagicMethodTypeHintsPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/MagicMethodTypeHintsPass.php
@@ -154,9 +154,7 @@ class MagicMethodTypeHintsPass implements Pass
         }
 
         $groupMatches = end($parameterMatches);
-        $parameterNames = is_array($groupMatches) ?
-            $groupMatches                         :
-            array($groupMatches);
+        $parameterNames = is_array($groupMatches) ? $groupMatches : [$groupMatches];
 
         return $parameterNames;
     }

--- a/library/Mockery/Matcher/MultiArgumentClosure.php
+++ b/library/Mockery/Matcher/MultiArgumentClosure.php
@@ -22,7 +22,6 @@ namespace Mockery\Matcher;
 
 class MultiArgumentClosure extends MatcherAbstract implements ArgumentListMatcher
 {
-
     /**
      * Check if the actual value matches the expected.
      * Actual passed by reference to preserve reference trail (where applicable)

--- a/tests/Mockery/Fixtures/SemiReservedWordsAsMethods.php
+++ b/tests/Mockery/Fixtures/SemiReservedWordsAsMethods.php
@@ -2,7 +2,7 @@
 
 namespace Mockery\Fixtures;
 
-class SemiReservedWordsAsMethods 
+class SemiReservedWordsAsMethods
 {
     function callable() {}
     function class() {}

--- a/tests/PHP70/MockingParameterAndReturnTypesTest.php
+++ b/tests/PHP70/MockingParameterAndReturnTypesTest.php
@@ -111,7 +111,7 @@ class MockingParameterAndReturnTypesTest extends MockeryTestCase
         $this->assertSame('', $mock->returnString());
         $this->assertSame(0, $mock->returnInteger());
         $this->assertSame(0.0, $mock->returnFloat());
-        $this->assertFalse( $mock->returnBoolean());
+        $this->assertFalse($mock->returnBoolean());
         $this->assertSame([], $mock->returnArray());
         $this->assertTrue(is_callable($mock->returnCallable()));
         $this->assertInstanceOf('\Generator', $mock->returnGenerator());
@@ -150,7 +150,7 @@ class MagicParams
 
 class MagicReturns
 {
-    public function __isset($property) : bool
+    public function __isset($property): bool
     {
         return false;
     }
@@ -158,23 +158,43 @@ class MagicReturns
 
 abstract class TestWithParameterAndReturnType
 {
-    public function returnString(): string {}
+    public function returnString(): string
+    {
+    }
 
-    public function returnInteger(): int {}
+    public function returnInteger(): int
+    {
+    }
 
-    public function returnFloat(): float {}
+    public function returnFloat(): float
+    {
+    }
 
-    public function returnBoolean(): bool {}
+    public function returnBoolean(): bool
+    {
+    }
 
-    public function returnArray(): array {}
+    public function returnArray(): array
+    {
+    }
 
-    public function returnCallable(): callable {}
+    public function returnCallable(): callable
+    {
+    }
 
-    public function returnGenerator(): \Generator {}
+    public function returnGenerator(): \Generator
+    {
+    }
 
-    public function withClassReturnType(): TestWithParameterAndReturnType {}
+    public function withClassReturnType(): TestWithParameterAndReturnType
+    {
+    }
 
-    public function withScalarParameters(int $integer, float $float, bool $boolean, string $string) {}
+    public function withScalarParameters(int $integer, float $float, bool $boolean, string $string)
+    {
+    }
 
-    public function returnSelf(): self {}
+    public function returnSelf(): self
+    {
+    }
 }


### PR DESCRIPTION
1. Disable PHP 5.6 non-compatible PSR-12 fixer.
2. Allow short closures (it was a bug that StyleCI allowed them in the old PSR-12 preset).
3. Apply remaining fixes from StyleCI.

---

Travis is currently failing due to further PHP 8.0 changes, which I will address later this week when I work on https://github.com/mockery/mockery/issues/1083.