### PR TITLE
[1.3] Improved PHP 8.0 support

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -9,4 +9,5 @@ disabled:
 
 finder:
   not-name:
+    - Php80LanguageFeaturesTest.php
     - SemiReservedWordsAsMethods.php

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,7 +1,12 @@
 preset: psr12
 
+enabled:
+  - symfony_braces
+
+disabled:
+  - const_visibility_required
+  - psr12_braces
+
 finder:
   not-name:
-    - MethodWithHHVMReturnType.php
-    - MockingParameterAndReturnTypesTest.php
     - SemiReservedWordsAsMethods.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ before_install:
       ' >> ~/.phpenv/versions/"$(phpenv version-name)"/etc/conf.d/travis.ini
     fi
     if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
-      composer require --dev --no-update "phpunit/phpunit:^8.5|^9.0"
+      composer require --dev --no-update "phpunit/phpunit:^9.3.2"
     fi
 
 install:
@@ -68,9 +68,11 @@ install:
 script:
 - |
     if [[ $TRAVIS_PHP_VERSION == 5.6 ]]; then
-      ./vendor/bin/phpunit --coverage-text --coverage-clover="build/logs/clover.xml" --testsuite="Mockery Test Suite PHP56";
+      ./vendor/bin/phpunit --coverage-text --coverage-clover="build/logs/clover.xml" --testsuite="Mockery Test Suite PHP5";
+    elif [[ $TRAVIS_PHP_VERSION == 'nightly' ]]; then
+      ./vendor/bin/phpunit --coverage-text --coverage-clover="build/logs/clover.xml" --testsuite="Mockery Test Suite PHP8";
     else
-      ./vendor/bin/phpunit --coverage-text --coverage-clover="build/logs/clover.xml" --testsuite="Mockery Test Suite";
+      ./vendor/bin/phpunit --coverage-text --coverage-clover="build/logs/clover.xml" --testsuite="Mockery Test Suite PHP7";
     fi
 
 after_success:

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "hamcrest/hamcrest-php": "^2.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7.10|~6.5|~7.0|~8.0|~9.0"
+        "phpunit/phpunit": "^5.7.10|^6.5|^7.5|^8.5|^9.3"
     },
     "autoload": {
         "psr-0": {
@@ -47,6 +47,9 @@
         "psr-4": {
             "test\\": "tests/"
         }
+    },
+    "config": {
+        "preferred-install": "dist"
     },
     "extra": {
         "branch-alias": {

--- a/library/Mockery/Generator/Parameter.php
+++ b/library/Mockery/Generator/Parameter.php
@@ -46,6 +46,8 @@ class Parameter
      * This will be null if there was no type, or it was a scalar or a union.
      *
      * @return \ReflectionClass|null
+     *
+     * @deprecated since 1.3.3 and will be removed in 2.0.
      */
     public function getClass()
     {

--- a/library/Mockery/Generator/StringManipulation/Pass/MagicMethodTypeHintsPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/MagicMethodTypeHintsPass.php
@@ -154,9 +154,7 @@ class MagicMethodTypeHintsPass implements Pass
         }
 
         $groupMatches = end($parameterMatches);
-        $parameterNames = is_array($groupMatches) ?
-            $groupMatches                         :
-            array($groupMatches);
+        $parameterNames = is_array($groupMatches) ? $groupMatches : [$groupMatches];
 
         return $parameterNames;
     }

--- a/library/Mockery/Matcher/MultiArgumentClosure.php
+++ b/library/Mockery/Matcher/MultiArgumentClosure.php
@@ -22,7 +22,6 @@ namespace Mockery\Matcher;
 
 class MultiArgumentClosure extends MatcherAbstract implements ArgumentListMatcher
 {
-
     /**
      * Check if the actual value matches the expected.
      * Actual passed by reference to preserve reference trail (where applicable)

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,20 +4,26 @@
          verbose="true"
 >
     <testsuites>
-        <testsuite name="Mockery Test Suite">
+        <testsuite name="Mockery Test Suite PHP8">
+            <directory suffix="Test.php">./tests</directory>
+            <directory phpVersion="8.0.0" phpVersionOperator=">=">./tests/PHP80</directory>
+        </testsuite>
+
+        <testsuite name="Mockery Test Suite PHP7">
             <directory suffix="Test.php">./tests</directory>
             <directory phpVersion="7.0.0" phpVersionOperator=">=">./tests/PHP70</directory>
             <directory phpVersion="7.1.0" phpVersionOperator=">=">./tests/PHP71</directory>
             <directory phpVersion="7.2.0" phpVersionOperator=">=">./tests/PHP72</directory>
+            <exclude>./tests/PHP80</exclude>
         </testsuite>
 
-        <testsuite name="Mockery Test Suite PHP56">
+        <testsuite name="Mockery Test Suite PHP5">
             <directory suffix="Test.php">./tests</directory>
             <directory suffix="Test.php">./tests/PHP56</directory>
-
             <exclude>./tests/PHP70</exclude>
             <exclude>./tests/PHP71</exclude>
             <exclude>./tests/PHP72</exclude>
+            <exclude>./tests/PHP80</exclude>
         </testsuite>
     </testsuites>
 

--- a/tests/Mockery/Fixtures/SemiReservedWordsAsMethods.php
+++ b/tests/Mockery/Fixtures/SemiReservedWordsAsMethods.php
@@ -2,7 +2,7 @@
 
 namespace Mockery\Fixtures;
 
-class SemiReservedWordsAsMethods 
+class SemiReservedWordsAsMethods
 {
     function callable() {}
     function class() {}

--- a/tests/PHP70/MockingParameterAndReturnTypesTest.php
+++ b/tests/PHP70/MockingParameterAndReturnTypesTest.php
@@ -111,7 +111,7 @@ class MockingParameterAndReturnTypesTest extends MockeryTestCase
         $this->assertSame('', $mock->returnString());
         $this->assertSame(0, $mock->returnInteger());
         $this->assertSame(0.0, $mock->returnFloat());
-        $this->assertFalse( $mock->returnBoolean());
+        $this->assertFalse($mock->returnBoolean());
         $this->assertSame([], $mock->returnArray());
         $this->assertTrue(is_callable($mock->returnCallable()));
         $this->assertInstanceOf('\Generator', $mock->returnGenerator());
@@ -150,7 +150,7 @@ class MagicParams
 
 class MagicReturns
 {
-    public function __isset($property) : bool
+    public function __isset($property): bool
     {
         return false;
     }
@@ -158,23 +158,43 @@ class MagicReturns
 
 abstract class TestWithParameterAndReturnType
 {
-    public function returnString(): string {}
+    public function returnString(): string
+    {
+    }
 
-    public function returnInteger(): int {}
+    public function returnInteger(): int
+    {
+    }
 
-    public function returnFloat(): float {}
+    public function returnFloat(): float
+    {
+    }
 
-    public function returnBoolean(): bool {}
+    public function returnBoolean(): bool
+    {
+    }
 
-    public function returnArray(): array {}
+    public function returnArray(): array
+    {
+    }
 
-    public function returnCallable(): callable {}
+    public function returnCallable(): callable
+    {
+    }
 
-    public function returnGenerator(): \Generator {}
+    public function returnGenerator(): \Generator
+    {
+    }
 
-    public function withClassReturnType(): TestWithParameterAndReturnType {}
+    public function withClassReturnType(): TestWithParameterAndReturnType
+    {
+    }
 
-    public function withScalarParameters(int $integer, float $float, bool $boolean, string $string) {}
+    public function withScalarParameters(int $integer, float $float, bool $boolean, string $string)
+    {
+    }
 
-    public function returnSelf(): self {}
+    public function returnSelf(): self
+    {
+    }
 }

--- a/tests/PHP80/Php80LanguageFeaturesTest.php
+++ b/tests/PHP80/Php80LanguageFeaturesTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace test\Mockery;
+
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+/**
+ * @requires PHP 8.0.0-dev
+ */
+class Php80LanguageFeaturesTest extends MockeryTestCase
+{
+    /** @test */
+    public function it_can_mock_a_class_with_a_mixed_argument_type_hint()
+    {
+        $mock = mock(ArgumentMixedTypeHint::class);
+        $object = new \stdClass();
+        $mock->allows()->foo($object);
+
+        $mock->foo($object);
+    }
+
+    /** @test */
+    public function it_can_mock_a_class_with_a_union_argument_type_hint()
+    {
+        $mock = mock(ArgumentUnionTypeHint::class);
+        $object = new ArgumentUnionTypeHint();
+        $mock->allows()->foo($object);
+
+        $mock->foo($object);
+    }
+
+    /** @test */
+    public function it_can_mock_a_class_with_a_parent_argument_type_hint()
+    {
+        $mock = mock(ArgumentParentTypeHint::class);
+        $object = new ArgumentParentTypeHint();
+        $mock->allows()->foo($object);
+
+        $mock->foo($object);
+    }
+
+    /** @test */
+    public function it_can_mock_a_class_with_a_mixed_return_type_hint()
+    {
+        $mock = spy(ReturnTypeMixedTypeHint::class);
+
+        $this->assertNull($mock->foo());
+    }
+
+    /** @test */
+    public function it_can_mock_a_class_with_a_union_return_type_hint()
+    {
+        $mock = spy(ReturnTypeUnionTypeHint::class);
+
+        $this->assertTrue(is_object($mock->foo()));
+    }
+
+    /** @test */
+    public function it_can_mock_a_class_with_a_parent_return_type_hint()
+    {
+        $mock = spy(ReturnTypeParentTypeHint::class);
+
+        $this->assertInstanceOf(\stdClass::class, $mock->foo());
+    }
+}
+
+class ArgumentMixedTypeHint
+{
+    public function foo(mixed $foo)
+    {
+    }
+}
+
+class ArgumentUnionTypeHint
+{
+    public function foo(string|array|self $foo)
+    {
+    }
+}
+
+class ArgumentParentTypeHint extends \stdClass
+{
+    public function foo(parent $foo)
+    {
+    }
+}
+
+class ReturnTypeMixedTypeHint
+{
+    public function foo(): mixed
+    {
+    }
+}
+
+class ReturnTypeUnionTypeHint
+{
+    public function foo(): ReturnTypeMixedTypeHint|self
+    {
+    }
+}
+
+class ReturnTypeParentTypeHint extends \stdClass
+{
+    public function foo(): parent
+    {
+    }
+}


### PR DESCRIPTION
This PR addresses some issues from the previous PR, some of which were caused by additional changes made to PHP 8.0, after the other PR was done. This doesn't address automatic creation of return values for methods typed as `static`. I am not sure if we even want to support this...

---

Depends on https://github.com/mockery/mockery/pull/1087. Related to https://github.com/mockery/mockery/issues/1083. 