### PR TITLE
Allow shouldIgnoreMissing() to behave in a recursive fashion

### DIFF
--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -53,6 +53,14 @@ class Mock implements MockInterface
     protected $_mockery_ignoreMissing = false;
 
     /**
+     * Flag to indicate whether we want to set the ignoreMissing flag on
+     * mocks generated form this calls to this one
+     *
+     * @var bool
+     */
+    protected $_mockery_ignoreMissingRecursive = false;
+
+    /**
      * Flag to indicate whether we can defer method calls missing from our
      * expectations
      *
@@ -308,11 +316,13 @@ class Mock implements MockInterface
     /**
      * Set mock to ignore unexpected methods and return Undefined class
      * @param mixed $returnValue the default return value for calls to missing functions on this mock
+     * @param bool $recursive Speficy if returned mocks should also have shouldIgnoreMissing set
      * @return Mock
      */
-    public function shouldIgnoreMissing($returnValue = null)
+    public function shouldIgnoreMissing($returnValue = null, $recursive = false)
     {
         $this->_mockery_ignoreMissing = true;
+        $this->_mockery_ignoreMissingRecursive = $recursive;
         $this->_mockery_defaultReturnValue = $returnValue;
         return $this;
     }
@@ -739,10 +749,18 @@ class Mock implements MockInterface
                 return null;
 
             case 'object':
-                return \Mockery::mock();
+                $mock = \Mockery::mock();
+                if ($this->_mockery_ignoreMissingRecursive) {
+                    $mock->shouldIgnoreMissing($this->_mockery_defaultReturnValue, true);
+                }
+                return $mock;
 
             default:
-                return \Mockery::mock($returnType);
+                $mock = \Mockery::mock($returnType);
+                if ($this->_mockery_ignoreMissingRecursive) {
+                    $mock->shouldIgnoreMissing($this->_mockery_defaultReturnValue, true);
+                }
+                return $mock;
         }
     }
 


### PR DESCRIPTION
When setting up lazy mocks I often run into issues where the test just breaks at the secound link and I end up having to explicity set expectations for the functions any way. This PR aims to solve that by allowing for `shouldIgnoreMissing()` to behave in a recursive fashion.

code:
```php
class A {
    function now(): DateTime {
        return new DateTime();
    }
}
class Factory {
    function makeA(): A {
        return new A();
    }
}
class Aubject {
    $factory;
    function __construct($factory) {
        $this->factory = $factory;
    }
    function testMe() {
        return $this->factory->makeA()->now()->format('c');
    }
}
```

Before:
```php
$mockedFactory = Mockery::spy(Factory::class):
$aMock->allows('now')->andReturn(Mockery::spy(DateTime::class));
$mockedFactory->allows('makeA')->andReturn($aMock);

$subject = new Aubject($mockedFactory);
$subject->testMe();
```

After:
```php
$mockedFactory = Mockery::mock(Factory::class)->shouldIgnoreMissing(null, true):

$subject = new Aubject($mockedFactory);
$subject->testMe();
```