### PR TITLE
fix shouldHaveReceived $args param typehint

### DIFF
--- a/library/Mockery/LegacyMockInterface.php
+++ b/library/Mockery/LegacyMockInterface.php
@@ -84,7 +84,7 @@ interface LegacyMockInterface
 
     /**
      * @param null|string $method
-     * @param null $args
+     * @param null|array|Closure $args
      * @return mixed
      */
     public function shouldHaveReceived($method, $args = null);
@@ -96,7 +96,7 @@ interface LegacyMockInterface
 
     /**
      * @param null|string $method
-     * @param null $args
+     * @param null|array|Closure $args
      * @return mixed
      */
     public function shouldNotHaveReceived($method, $args = null);


### PR DESCRIPTION
Current type hint suggests that $args can only be null, and static analysis tools complain when you call the method with something else.

Add types that you can pass to withArgs.

Thanks