### PR TITLE
Fix crash on a union type including null

### DIFF
--- a/library/Mockery/Reflector.php
+++ b/library/Mockery/Reflector.php
@@ -192,9 +192,11 @@ class Reflector
     {
         // PHP 8 union types can be recursively processed
         if ($type instanceof \ReflectionUnionType) {
-            return \implode('|', \array_map(function (\ReflectionType $type) use ($declaringClass) {
-                return self::typeToString($type, $declaringClass);
-            }, $type->getTypes()));
+            return \implode('|', \array_filter(\array_map(function (\ReflectionType $type) use ($declaringClass) {
+                $typeHint = self::typeToString($type, $declaringClass);
+
+                return $typeHint === 'null' ? null : $typeHint;
+            }, $type->getTypes())));
         }
 
         // PHP 7.0 doesn't have named types, but 7.1+ does

--- a/tests/PHP80/Php80LanguageFeaturesTest.php
+++ b/tests/PHP80/Php80LanguageFeaturesTest.php
@@ -30,6 +30,15 @@ class Php80LanguageFeaturesTest extends MockeryTestCase
     }
 
     /** @test */
+    public function it_can_mock_a_class_with_a_union_argument_type_hint_including_null()
+    {
+        $mock = mock(ArgumentUnionTypeHintWithNull::class);
+        $mock->allows()->foo(null);
+
+        $mock->foo(null);
+    }
+
+    /** @test */
     public function it_can_mock_a_class_with_a_parent_argument_type_hint()
     {
         $mock = mock(ArgumentParentTypeHint::class);
@@ -74,6 +83,13 @@ class ArgumentMixedTypeHint
 class ArgumentUnionTypeHint
 {
     public function foo(string|array|self $foo)
+    {
+    }
+}
+
+class ArgumentUnionTypeHintWithNull
+{
+    public function foo(string|array|null $foo)
     {
     }
 }


### PR DESCRIPTION
This change prevents the generation of type hints with 2 "null".

For example, "string|array|null" should generate the code "string|array|null" instead of "string|array|null|null" to avoid a PHP fatal error "Duplicate type null is redundant".

Closes #1105.