### PR TITLE
Stop testing with '--prefer-lowest'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,49 +3,12 @@ language: php
 matrix:
   include:
     - php: 5.6
-      env:
-        - DEPS=lowest
-    - php: 5.6
-      env:
-        - DEPS=latest
     - php: 7.0
-      env:
-        - DEPS=lowest
-    - php: 7.0
-      env:
-        - DEPS=latest
     - php: 7.1
-      env:
-        - DEPS=lowest
-    - php: 7.1
-      env:
-        - DEPS=latest
     - php: 7.2
-      env:
-        - DEPS=lowest
-    - php: 7.2
-      env:
-        - DEPS=latest
     - php: 7.3
-      env:
-        - DEPS=lowest
-    - php: 7.3
-      env:
-        - DEPS=latest
     - php: 7.4
-      env:
-        - DEPS=lowest
-    - php: 7.4
-      env:
-        - DEPS=latest
-    - php: nightly
-      env:
-        - DEPS=lowest
-        - COMPOSER_FLAGS="--ignore-platform-reqs"
-    - php: nightly
-      env:
-        - DEPS=latest
-        - COMPOSER_FLAGS="--ignore-platform-reqs"
+    - php: 8.0
 
 before_install:
   # Install extensions for PHP 5.x series. 7.x includes them by default.
@@ -57,19 +20,15 @@ before_install:
         extension=redis.so
       ' >> ~/.phpenv/versions/"$(phpenv version-name)"/etc/conf.d/travis.ini
     fi
-    if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
-      composer require --dev --no-update "phpunit/phpunit:^9.3.2"
-    fi
 
 install:
-  - if [[ $DEPS == 'latest' ]]; then travis_retry composer update --no-interaction $COMPOSER_FLAGS ; fi
-  - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable --no-interaction $COMPOSER_FLAGS ; fi
+  - travis_retry composer update --no-interaction
 
 script:
 - |
     if [[ $TRAVIS_PHP_VERSION == 5.6 ]]; then
       ./vendor/bin/phpunit --coverage-text --coverage-clover="build/logs/clover.xml" --testsuite="Mockery Test Suite PHP5";
-    elif [[ $TRAVIS_PHP_VERSION == 'nightly' ]]; then
+    elif [[ $TRAVIS_PHP_VERSION == '8.0' ]]; then
       ./vendor/bin/phpunit --coverage-text --coverage-clover="build/logs/clover.xml" --testsuite="Mockery Test Suite PHP8";
     else
       ./vendor/bin/phpunit --coverage-text --coverage-clover="build/logs/clover.xml" --testsuite="Mockery Test Suite PHP7";
@@ -99,4 +58,3 @@ deploy:
   on:
     branch: master
     php: '7.1'
-    condition: $DEPS = latest


### PR DESCRIPTION
This solve issues with PHPUnit and Xdebug 3.0 when running tests for PHP 7.3 and 7.4.

mockery has basically no dependencies so the part of the matrix testing with '--prefer-lowest' brings little/no value.

See the discussion in https://github.com/mockery/mockery/pull/1106#issuecomment-739831499