### PR TITLE
Build API docs with phpDocumentor 3.0.0 final instead of RC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ phpunit.xml
 docs/api
 phpDocumentor.phar*
 .phpunit.result.cache
+.phpdoc/

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ test: deps
 apidocs: docs/api/index.html
 
 phpDocumentor.phar: 
-	wget https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.0.0-rc/phpDocumentor.phar
-	wget https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.0.0-rc/phpDocumentor.phar.pubkey
+	wget https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.0.0/phpDocumentor.phar
+	wget https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.0.0/phpDocumentor.phar.asc
 
 library_files=$(shell find library -name '*.php')
 docs/api/index.html: vendor/composer/installed.json $(library_files) phpDocumentor.phar


### PR DESCRIPTION
phpDocumentor cache has been added to the .gitignore so it does not end up committed into the repo/a PR by mistake.