### PR TITLE
Update error message to be more accurate

### DIFF
--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -565,7 +565,7 @@ class Expectation implements ExpectationInterface
     public function andReturnArg($index)
     {
         if (!is_int($index) || $index < 0) {
-            throw new \InvalidArgumentException("Invalid argument index supplied. Index must be a positive integer.");
+            throw new \InvalidArgumentException("Invalid argument index supplied. Index must be a non-negative integer.");
         }
         $closure = function (...$args) use ($index) {
             if (array_key_exists($index, $args)) {


### PR DESCRIPTION
Previously `andReturnArg` threw an exception with the message `Invalid argument index supplied. Index must be a positive integer.`. However this is confusing because the method accepts the number `0`. 

This PR changes the wording to `non-negative integer` to be more accurate.