### PR TITLE
Fix Mockery::fetchMock() without initialized container

### DIFF
--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -214,7 +214,7 @@ class Mockery
      */
     public static function fetchMock($name)
     {
-        return self::$_container->fetchMock($name);
+        return self::getContainer()->fetchMock($name);
     }
 
     /**


### PR DESCRIPTION
Calling `Mockery::fetchMock()` first doesn't make much sense and likely indicates a logic error, but Mockery should nevertheless throw `Call to a member function fetchMock() on null` errors.

Maybe we should throw a `LogicException` instead when no container was initialized yet (just like `Mockery::self()`)? If no container was initialized yet, `Mockery::fetchMock()` will always return `null`, just like if the mock in question simply doesn't exist (yet). Other opinions?