### PR TITLE
Advocate for the use of interfaces, rather than against the use of final

### DIFF
--- a/docs/reference/final_methods_classes.rst
+++ b/docs/reference/final_methods_classes.rst
@@ -9,9 +9,10 @@ classes or methods marked final is hard. The final keyword prevents methods so
 marked from being replaced in subclasses (subclassing is how mock objects can
 inherit the type of the class or object being mocked).
 
-The simplest solution is to not mark classes or methods as final!
+The simplest solution is to implement an interface in your final class and 
+typehint against / mock this.
 
-However, in a compromise between mocking functionality and type safety,
+However this may not be possible in some third party libraries.
 Mockery does allow creating "proxy mocks" from classes marked final, or from
 classes with methods marked final. This offers all the usual mock object
 goodness but the resulting mock will not inherit the class type of the object


### PR DESCRIPTION
Use of interfaces in final classes removes the need for proxy mocks.