### PR TITLE
update meta to properly infer type of string parameters

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -2,10 +2,10 @@
 
 namespace PHPSTORM_META;
 
-override(\Mockery::mock(0), map(["" => "$0"]));
-override(\Mockery::spy(0), map(["" => "$0"]));
-override(\Mockery::namedMock(0), map(["" => "$0"]));
-override(\Mockery::instanceMock(0), map(["" => "$0"]));
-override(\mock(0), map(["" => "$0"]));
-override(\spy(0), map(["" => "$0"]));
-override(\namedMock(0), map(["" => "$0"]));
+override(\Mockery::mock(0), map(["" => "@"]));
+override(\Mockery::spy(0), map(["" => "@"]));
+override(\Mockery::namedMock(0), map(["" => "@"]));
+override(\Mockery::instanceMock(0), map(["" => "@"]));
+override(\mock(0), map(["" => "@"]));
+override(\spy(0), map(["" => "@"]));
+override(\namedMock(0), map(["" => "@"]));

--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -2,10 +2,10 @@
 
 namespace PHPSTORM_META;
 
-override(\Mockery::mock(0), type(0));
-override(\Mockery::spy(0), type(0));
-override(\Mockery::namedMock(0), type(0));
-override(\Mockery::instanceMock(0), type(0));
-override(\mock(0), type(0));
-override(\spy(0), type(0));
-override(\namedMock(0), type(0));
+override(\Mockery::mock(0), map(["" => "$0"]));
+override(\Mockery::spy(0), map(["" => "$0"]));
+override(\Mockery::namedMock(0), map(["" => "$0"]));
+override(\Mockery::instanceMock(0), map(["" => "$0"]));
+override(\mock(0), map(["" => "$0"]));
+override(\spy(0), map(["" => "$0"]));
+override(\namedMock(0), map(["" => "$0"]));


### PR DESCRIPTION
After the fix of https://youtrack.jetbrains.com/issue/WI-60544 type() meta directive won't treat string literals contents as types anymore, prefered way is to use (map([""=>"$0"])). This PR updates meta file according to preferred way.