### PR TITLE
updated reserved methods in docs

### DIFF
--- a/docs/mockery/reserved_method_names.rst
+++ b/docs/mockery/reserved_method_names.rst
@@ -12,7 +12,20 @@ name collision (reported as a PHP fatal error). The methods reserved by
 Mockery are:
 
 * ``shouldReceive()``
-* ``shouldBeStrict()``
+* ``shouldNotReceive()``
+* ``allows()``
+* ``expects()``
+* ``shouldAllowMockingMethod()``
+* ``shouldIgnoreMissing()``
+* ``asUndefined()``
+* ``shouldAllowMockingProtectedMethods()``
+* ``makePartial()``
+* ``byDefault()``
+* ``shouldHaveReceived()``
+* ``shouldHaveBeenCalled()``
+* ``shouldNotHaveReceived()``
+* ``shouldNotHaveBeenCalled()``
+
 
 In addition, all mocks utilise a set of added methods and protected properties
 which cannot exist on the class or object being mocked. These are far less


### PR DESCRIPTION
Updated the reserved methods in the docs. I am curious what `shouldBeStrict()` was?