### PR TITLE
Fixes for PHP 8.1

### DIFF
--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -803,7 +803,7 @@ class Mock implements MockInterface
             throw new BadMethodCallException(
                 'Static method ' . $associatedRealObject->mockery_getName() . '::' . $method
                 . '() does not exist on this mock object',
-                null,
+                0,
                 $e
             );
         }

--- a/library/Mockery/Reflector.php
+++ b/library/Mockery/Reflector.php
@@ -84,11 +84,20 @@ class Reflector
     public static function getReturnType(\ReflectionMethod $method, $withoutNullable = false)
     {
         // Strip all return types for HHVM and skip PHP 5.
-        if (method_exists($method, 'getReturnTypeText') || \PHP_VERSION_ID < 70000 || !$method->hasReturnType()) {
+        if (method_exists($method, 'getReturnTypeText') || \PHP_VERSION_ID < 70000) {
             return null;
         }
 
         $type = $method->getReturnType();
+
+        if (is_null($type) && method_exists($method, 'getTentativeReturnType')) {
+            $type = $method->getTentativeReturnType();
+        }
+
+        if (is_null($type)) {
+            return null;
+        }
+
         $declaringClass = $method->getDeclaringClass();
         $typeHint = self::typeToString($type, $declaringClass);
 

--- a/tests/Mockery/ContainerTest.php
+++ b/tests/Mockery/ContainerTest.php
@@ -1356,6 +1356,7 @@ class ContainerTest extends MockeryTestCase
     /**
      * @test
      * @group issue/339
+     * @requires PHP <8.1
      */
     public function canMockClassesThatImplementSerializable()
     {
@@ -1844,13 +1845,15 @@ class MockeryTest_ClassThatDescendsFromInternalClass extends DateTime
 {
 }
 
-class MockeryTest_ClassThatImplementsSerializable implements Serializable
-{
-    public function serialize()
+if (PHP_VERSION_ID < 80100) {
+    class MockeryTest_ClassThatImplementsSerializable implements Serializable
     {
-    }
+        public function serialize()
+        {
+        }
 
-    public function unserialize($serialized)
-    {
+        public function unserialize($serialized)
+        {
+        }
     }
 }

--- a/tests/PHP80/Php80LanguageFeaturesTest.php
+++ b/tests/PHP80/Php80LanguageFeaturesTest.php
@@ -2,7 +2,9 @@
 
 namespace test\Mockery;
 
+use DateTime;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
+use ReturnTypeWillChange;
 
 /**
  * @requires PHP 8.0.0-dev
@@ -71,6 +73,33 @@ class Php80LanguageFeaturesTest extends MockeryTestCase
 
         $this->assertInstanceOf(\stdClass::class, $mock->foo());
     }
+
+    /**
+     * @test
+     * @requires PHP 8.1
+     */
+    public function it_can_mock_an_internal_class_with_tentative_return_types()
+    {
+        $mock = spy(DateTime::class);
+
+        $this->assertSame(0, $mock->getTimestamp());
+    }
+
+    /** @test */
+    public function it_can_mock_a_class_with_return_type_will_change_attribute_and_no_return_type()
+    {
+        $mock = spy(ReturnTypeWillChangeAttributeNoReturnType::class);
+
+        $this->assertNull($mock->getTimestamp());
+    }
+
+    /** @test */
+    public function it_can_mock_a_class_with_return_type_will_change_attribute_and_wrong_return_type()
+    {
+        $mock = spy(ReturnTypeWillChangeAttributeWrongReturnType::class);
+
+        $this->assertSame(0.0, $mock->getTimestamp());
+    }
 }
 
 class ArgumentMixedTypeHint
@@ -118,6 +147,22 @@ class ReturnTypeUnionTypeHint
 class ReturnTypeParentTypeHint extends \stdClass
 {
     public function foo(): parent
+    {
+    }
+}
+
+class ReturnTypeWillChangeAttributeNoReturnType extends DateTime
+{
+    #[ReturnTypeWillChange]
+    public function getTimestamp()
+    {
+    }
+}
+
+class ReturnTypeWillChangeAttributeWrongReturnType extends DateTime
+{
+    #[ReturnTypeWillChange]
+    public function getTimestamp(): float
     {
     }
 }


### PR DESCRIPTION
- Avoid passing null to non-nullable parameters of internal functions
- Skip `Serializable` test on PHP <8.1
- Add support for tentative return types

