### PR TITLE
add existing/non-existent method helpers

### DIFF
--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -20,6 +20,8 @@
 
 namespace Mockery;
 
+use Closure;
+use Mockery;
 use Mockery\Exception\BadMethodCallException;
 use Mockery\ExpectsHigherOrderMessage;
 use Mockery\HigherOrderMessage;
@@ -244,6 +246,37 @@ class Mock implements MockInterface
             }
         );
         return $lastExpectation;
+    }
+
+    public function shouldReceiveExisting(...$methodNames)
+    {
+        return $this->mockery_withMockingNonExistentMethodsAllowed(false, function() use ($methodNames) {
+            return  $this->shouldReceive(...$methodNames);
+        });
+    }
+
+    public function shouldReceiveNonExistent(...$methodNames)
+    {
+        return $this->mockery_withMockingNonExistentMethodsAllowed(true, function() use ($methodNames) {
+            return  $this->shouldReceive(...$methodNames);
+        });
+    }
+
+    private function mockery_withMockingNonExistentMethodsAllowed($flag, Closure $callback)
+    {
+        $config = Mockery::getConfiguration();
+        $allowed = $config->mockingNonExistentMethodsAllowed();
+        $config->allowMockingNonExistentMethods($flag);
+
+        try {
+
+            $result = $callback();
+
+        } finally {
+            $config->allowMockingNonExistentMethods($allowed);
+        }
+
+        return $result;
     }
 
     // start method allows


### PR DESCRIPTION
This PR adds some helper methods I proposed in this issue:
https://github.com/mockery/mockery/issues/1129

### Context

Currently you can set methods to be strictly checked to exist and match the method signature and return type via 
```php
Mockery::getConfiguration()->allowMockingNonExistentMethods(true/false);
```

This is set to false by default. There is no clean API to be able to specify the desired behavior for the method you are mocking.

### Changes
2 methods are added to the mock object. They wrap the `$mock->shouldReceive()` method.

`$mock->shouldReceiveExisting()`
sets `Mockery::getConfiguration()->allowMockingNonExistentMethods(true);`
then stores the mocked method
then reverts `Mockery::getConfiguration()->allowMockingNonExistentMethods($prev);` to whatever it was set to previously

`$mock->shouldReceiveNonExistent()`
Does the same as above but the reverse. Sets to allow non-existent methods then sets it back to what it was previously.

### Testing

I have not been able to get the tests to run locally. I get a ton of ```The use statement with non-compound name 'Closure' has no effect
``` errors. I have not been able to find any reference to this error message anywhere. There are no docs on running the tests locally either. Any help would be appreciated.