### PR TITLE
[1.3] Fix auto-generated return values with union types

### DIFF
--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -705,18 +705,13 @@ class Mock implements MockInterface
      */
     public function mockery_returnValueForMethod($name)
     {
-        if (\PHP_VERSION_ID < 70000) {
-            return null;
-        }
-
         $rm = $this->mockery_getMethod($name);
 
-        // Default return value for methods with nullable type is null
-        if ($rm === null || $rm->getReturnType() === null || $rm->getReturnType()->allowsNull()) {
+        if ($rm === null) {
             return null;
         }
 
-        $returnType = Reflector::getReturnType($rm, true);
+        $returnType = Reflector::getSimplestReturnType($rm);
 
         switch ($returnType) {
             case null:     return null;

--- a/library/Mockery/Reflector.php
+++ b/library/Mockery/Reflector.php
@@ -98,11 +98,51 @@ class Reflector
             return null;
         }
 
-        $declaringClass = $method->getDeclaringClass();
-        $typeHint = self::typeToString($type, $declaringClass);
+        $typeHint = self::typeToString($type, $method->getDeclaringClass());
 
         // PHP 7.1+ supports nullable types via a leading question mark
         return (!$withoutNullable && \PHP_VERSION_ID >= 70100 && $type->allowsNull()) ? self::formatNullableType($typeHint) : $typeHint;
+    }
+
+    /**
+     * Compute the string representation for the simplest return type.
+     *
+     * @param \ReflectionParameter $param
+     *
+     * @return string|null
+     */
+    public static function getSimplestReturnType(\ReflectionMethod $method)
+    {
+        // Strip all return types for HHVM and skip PHP 5.
+        if (method_exists($method, 'getReturnTypeText') || \PHP_VERSION_ID < 70000) {
+            return null;
+        }
+
+        $type = $method->getReturnType();
+
+        if (is_null($type) && method_exists($method, 'getTentativeReturnType')) {
+            $type = $method->getTentativeReturnType();
+        }
+
+        if (is_null($type) || $type->allowsNull()) {
+            return null;
+        }
+
+        $typeInformation = self::getTypeInformation($type, $method->getDeclaringClass());
+
+        // return the first primitive type hint
+        foreach ($typeInformation as $info) {
+            if ($info['isPrimitive']) {
+                return $info['typeHint'];
+            }
+        }
+
+        // if no primitive type, return the first type
+        foreach ($typeInformation as $info) {
+            return $info['typeHint'];
+        }
+
+        return null;
     }
 
     /**
@@ -199,21 +239,61 @@ class Reflector
      */
     private static function typeToString(\ReflectionType $type, \ReflectionClass $declaringClass)
     {
+        return \implode('|', \array_map(function (array $typeInformation) {
+            return $typeInformation['typeHint'];
+        }, self::getTypeInformation($type, $declaringClass)));
+    }
+
+    /**
+     * Get the string representation of the given type.
+     *
+     * This method MUST only be called on PHP 7+.
+     *
+     * @param \ReflectionType  $type
+     * @param \ReflectionClass $declaringClass
+     *
+     * @return list<array{typeHint: string, isPrimitive: bool}>
+     */
+    private static function getTypeInformation(\ReflectionType $type, \ReflectionClass $declaringClass)
+    {
         // PHP 8 union types can be recursively processed
         if ($type instanceof \ReflectionUnionType) {
-            return \implode('|', \array_filter(\array_map(function (\ReflectionType $type) use ($declaringClass) {
-                $typeHint = self::typeToString($type, $declaringClass);
+            $types = [];
 
-                return $typeHint === 'null' ? null : $typeHint;
-            }, $type->getTypes())));
+            foreach ($type->getTypes() as $innterType) {
+                foreach (self::getTypeInformation($innterType, $declaringClass) as $info) {
+                    if ($info['typeHint'] === 'null' && $info['isPrimitive']) {
+                        continue;
+                    }
+
+                    $types[] = $info;
+                }
+            }
+
+            return $types;
         }
 
         // PHP 7.0 doesn't have named types, but 7.1+ does
         $typeHint = $type instanceof \ReflectionNamedType ? $type->getName() : (string) $type;
 
-        // builtins and 'static' can be returned as is
-        if (($type->isBuiltin() || $typeHint === 'static')) {
-            return $typeHint;
+        // builtins can be returned as is
+        if ($type->isBuiltin()) {
+            return [
+                [
+                    'typeHint' => $typeHint,
+                    'isPrimitive' => in_array($typeHint, ['array', 'bool', 'int', 'float', 'null', 'object', 'string']),
+                ],
+            ];
+        }
+
+        // 'static' can be returned as is
+        if ($typeHint === 'static') {
+            return [
+                [
+                    'typeHint' => $typeHint,
+                    'isPrimitive' => false,
+                ],
+            ];
         }
 
         // 'self' needs to be resolved to the name of the declaring class
@@ -227,7 +307,12 @@ class Reflector
         }
 
         // class names need prefixing with a slash
-        return sprintf('\\%s', $typeHint);
+        return [
+            [
+                'typeHint' => sprintf('\\%s', $typeHint),
+                'isPrimitive' => false,
+            ],
+        ];
     }
 
     /**

--- a/tests/PHP81/Php81LanguageFeaturesTest.php
+++ b/tests/PHP81/Php81LanguageFeaturesTest.php
@@ -4,6 +4,7 @@ namespace test\Mockery;
 
 use DateTime;
 use Serializable;
+use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use ReturnTypeWillChange;
 
@@ -28,6 +29,24 @@ class Php81LanguageFeaturesTest extends MockeryTestCase
         $mock = spy(DateTime::class);
 
         $this->assertSame(0, $mock->getTimestamp());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_mock_an_internal_class_with_tentative_union_return_types()
+    {
+        $mock = m::mock('PDO');
+
+        $this->assertInstanceOf('PDO', $mock);
+
+        $mock->shouldReceive('exec')->once();
+
+        try {
+            $this->assertSame(0, $mock->exec('select * from foo.bar'));
+        } finally {
+            m::close();
+        }
     }
 
     /** @test */


### PR DESCRIPTION
The logic is now:
* if nullable or no return type, return null
* otherwise, return a primitive if possible
* otherwise, mock the first class in the type and return that

So, `int|false` will auto-return `0` and `Foo|false` will auto-return `false`. The old logic was very similar, but broken because it looked at the string `int|false`, decided it was not primitive, and then tried to mock it.

---

Before fix:

```
PHPUnit 9.5.9 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.1.0RC1
Configuration: /data/phpunit.xml.dist
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

....................R...................W......................  63 / 615 ( 10%)
...................S....R.............R......................S. 126 / 615 ( 20%)
.........R...R....S....S.....................S................. 189 / 615 ( 30%)
............................................................... 252 / 615 ( 40%)
............................................................... 315 / 615 ( 51%)
............................................................... 378 / 615 ( 61%)
...................................................S........... 441 / 615 ( 71%)
.............................................................SS 504 / 615 ( 81%)
SSSS........................................................... 567 / 615 ( 92%)
.............................................PHP Fatal error:  Cannot use 'int' as class name as it is reserved in /tmp/Mockery6UM2gx on line 1
```

After fix:

```
PHPUnit 9.5.9 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.1.0RC1
Configuration: /data/phpunit.xml.dist
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

....................R...................W......................  63 / 615 ( 10%)
...................S....R.............R......................S. 126 / 615 ( 20%)
.........R...R....S....S.....................S................. 189 / 615 ( 30%)
............................................................... 252 / 615 ( 40%)
............................................................... 315 / 615 ( 51%)
............................................................... 378 / 615 ( 61%)
...................................................S........... 441 / 615 ( 71%)
.............................................................SS 504 / 615 ( 81%)
SSSS........................................................... 567 / 615 ( 92%)
................................................                615 / 615 (100%)

Time: 00:01.497, Memory: 46.00 MB
```

---

Blocks https://github.com/laravel/framework/pull/38404. cc @davedevelopment, @driesvints.