### PR TITLE
[1.4] Fix auto-generated return values with union types

### DIFF
--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -717,12 +717,11 @@ class Mock implements MockInterface
     {
         $rm = $this->mockery_getMethod($name);
 
-        // Default return value for methods with nullable type is null
-        if ($rm === null || $rm->getReturnType() === null || $rm->getReturnType()->allowsNull()) {
+        if ($rm === null) {
             return null;
         }
 
-        $returnType = Reflector::getReturnType($rm, true);
+        $returnType = Reflector::getSimplestReturnType($rm);
 
         switch ($returnType) {
             case null:     return null;

--- a/tests/PHP81/Php81LanguageFeaturesTest.php
+++ b/tests/PHP81/Php81LanguageFeaturesTest.php
@@ -4,6 +4,7 @@ namespace test\Mockery;
 
 use DateTime;
 use Serializable;
+use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use ReturnTypeWillChange;
 
@@ -28,6 +29,24 @@ class Php81LanguageFeaturesTest extends MockeryTestCase
         $mock = spy(DateTime::class);
 
         $this->assertSame(0, $mock->getTimestamp());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_mock_an_internal_class_with_tentative_union_return_types()
+    {
+        $mock = m::mock('PDO');
+
+        $this->assertInstanceOf('PDO', $mock);
+
+        $mock->shouldReceive('exec')->once();
+
+        try {
+            $this->assertSame(0, $mock->exec('select * from foo.bar'));
+        } finally {
+            m::close();
+        }
     }
 
     /** @test */


### PR DESCRIPTION
Same as https://github.com/mockery/mockery/pull/1143 for the 1.4 branch. Easier than dealing with those merge PRs.

---

Blocks https://github.com/laravel/framework/pull/38404. cc @davedevelopment, @driesvints.