### PR TITLE
Override default call count expectations via `expects()`

### DIFF
--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -728,7 +728,12 @@ class Expectation implements ExpectationInterface
             throw new \InvalidArgumentException('The passed Times limit should be an integer value');
         }
         $this->_countValidators[$this->_countValidatorClass] = new $this->_countValidatorClass($this, $limit);
-        $this->_countValidatorClass = 'Mockery\CountValidator\Exact';
+
+        if('Mockery\CountValidator\Exact' !== $this->_countValidatorClass){
+            $this->_countValidatorClass = 'Mockery\CountValidator\Exact';
+            unset($this->_countValidators[$this->_countValidatorClass]);
+        }
+
         return $this;
     }
 

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -683,6 +683,22 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
     }
 
+    public function testExpectsStringArgumentCalledAtLeastOnceOverridingDefaultOnceCall()
+    {
+        $this->mock->expects('foo')->atLeast()->once();
+        $this->mock->foo();
+        $this->mock->foo();
+        $this->mock->foo();
+    }
+
+    public function testExpectsNoArgumentCalledAtLeastOnceOverridingDefaultOnceCall()
+    {
+        $this->mock->expects()->foo()->atLeast()->once();
+        $this->mock->foo();
+        $this->mock->foo();
+        $this->mock->foo();
+    }
+
     public function testCalledAtLeastThrowsExceptionOnTooFewCalls()
     {
         $this->mock->shouldReceive('foo')->atLeast()->twice();


### PR DESCRIPTION
**By default `expects()` sets up an expectation that the method should be called once and once only.** 

http://docs.mockery.io/en/stable/reference/alternative_should_receive_syntax.html#expects
http://docs.mockery.io/en/stable/reference/expectations.html#declaring-call-count-expectations

If accepted, this example code will run as expected.
```php
$this->mock->expects('foo')->atLeast()->once();

// and or

$this->mock->expects()->foo()->atMost()->once();
```

- Add failing test
- Implement the bug fix 
- Resolves #1138