### PR TITLE
Mock methods with `static` return types

### DIFF
--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -747,6 +747,9 @@ class Mock implements MockInterface
             case 'void':
                 return null;
 
+            case 'static':
+                return $this;
+                
             case 'object':
                 $mock = \Mockery::mock();
                 if ($this->_mockery_ignoreMissingRecursive) {

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -749,7 +749,7 @@ class Mock implements MockInterface
 
             case 'static':
                 return $this;
-                
+
             case 'object':
                 $mock = \Mockery::mock();
                 if ($this->_mockery_ignoreMissingRecursive) {

--- a/tests/Mockery/Fixtures/MethodWithStaticReturnType.php
+++ b/tests/Mockery/Fixtures/MethodWithStaticReturnType.php
@@ -21,10 +21,12 @@
 
 namespace test\Mockery\Fixtures;
 
-class MethodWithStaticReturnType
-{
-    public function returnType(): static
+if (\PHP_VERSION_ID >= 80000) {
+    class MethodWithStaticReturnType
     {
-        return $this;
+        public function returnType(): static
+        {
+            return $this;
+        }
     }
 }

--- a/tests/Mockery/Fixtures/MethodWithStaticReturnType.php
+++ b/tests/Mockery/Fixtures/MethodWithStaticReturnType.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ *
+ * @category   Mockery
+ * @package    Mockery
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2010 Pádraic Brady (http://blog.astrumfutura.com)
+ * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
+ */
+
+namespace test\Mockery\Fixtures;
+
+class MethodWithStaticReturnType
+{
+    public function returnType(): static
+    {
+        return $this;
+    }
+}

--- a/tests/Mockery/MockingMethodsWithStaticReturnTypeTest.php
+++ b/tests/Mockery/MockingMethodsWithStaticReturnTypeTest.php
@@ -28,6 +28,10 @@ class MockingMethodsWithStaticReturnTypeTest extends MockeryTestCase
 {
     public function testMockingStaticReturnType()
     {
+        if (\PHP_VERSION_ID < 80000) {
+            $this->markTestSkipped('Requires PHP >= 8');
+        }
+        
         $mock = mock(MethodWithStaticReturnType::class);
 
         $mock->shouldReceive("returnType");

--- a/tests/Mockery/MockingMethodsWithStaticReturnTypeTest.php
+++ b/tests/Mockery/MockingMethodsWithStaticReturnTypeTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ *
+ * @category   Mockery
+ * @package    Mockery
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2010 Pádraic Brady (http://blog.astrumfutura.com)
+ * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
+ */
+
+namespace test\Mockery;
+
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use test\Mockery\Fixtures\MethodWithStaticReturnType;
+
+class MockingMethodsWithStaticReturnTypeTest extends MockeryTestCase
+{
+    public function testMockingStaticReturnType()
+    {
+        $mock = mock(MethodWithStaticReturnType::class);
+
+        $mock->shouldReceive("returnType");
+
+        $this->assertSame($mock, $mock->returnType());
+    }
+}

--- a/tests/Mockery/MockingMethodsWithStaticReturnTypeTest.php
+++ b/tests/Mockery/MockingMethodsWithStaticReturnTypeTest.php
@@ -31,7 +31,7 @@ class MockingMethodsWithStaticReturnTypeTest extends MockeryTestCase
         if (\PHP_VERSION_ID < 80000) {
             $this->markTestSkipped('Requires PHP >= 8');
         }
-        
+
         $mock = mock(MethodWithStaticReturnType::class);
 
         $mock->shouldReceive("returnType");


### PR DESCRIPTION
This patch resolves #1155, via the following changes:

 - Add tests and fixtures
 - Mock methods with `static` return type.

``` php
class Foo
{
    public function getFoo(): static
    {
        return $this;
    }
}
```