### PR TITLE
Mock classes with `new` in initializers on PHP 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,19 +5,19 @@ on:
   pull_request:
 
 jobs:
-  php7:
-    name: PHP ${{ matrix.php }}
-    runs-on: ubuntu-20.04
+  phpunit:
+    name: PHPUnit on PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.4', '8.0', '8.1']
 
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
 
-      - name: Setup PHP
+      - name: Setup PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -36,71 +36,4 @@ jobs:
           command: composer update --no-interaction --no-progress
 
       - name: Execute PHPUnit
-        run: vendor/bin/phpunit --coverage-text --testsuite="Mockery Test Suite PHP7"
-
-  php80:
-    name: PHP ${{ matrix.php }}
-    runs-on: ubuntu-20.04
-
-    strategy:
-      matrix:
-        php: ['8.0']
-
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v2
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          tools: composer:v2
-          coverage: xdebug
-
-      - name: Setup Problem Matchers
-        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
-
-      - name: Install Dependencies
-        uses: nick-invision/retry@v1
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer update --no-interaction --no-progress
-
-      - name: Execute PHPUnit
-        run: vendor/bin/phpunit --coverage-text --testsuite="Mockery Test Suite PHP8"
-
-  php81:
-    name: PHP ${{ matrix.php }}
-    runs-on: ubuntu-20.04
-
-    strategy:
-      matrix:
-        php: ['8.1']
-
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v2
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          tools: composer:v2
-          coverage: none
-
-      - name: Setup Problem Matchers
-        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
-
-      - name: Mimic PHP 8.0
-        run: composer config platform.php 8.0.999
-
-      - name: Install Dependencies
-        uses: nick-invision/retry@v1
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer update --no-interaction --no-progress
-
-      - name: Execute PHPUnit
-        run: vendor/bin/phpunit --testsuite="Mockery Test Suite PHP8"
+        run: vendor/bin/phpunit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 * Override default call count expectations via expects() #1146
 * Mock methods with static return types #1157
 * Mock methods with mixed return type #1156
+* Mock classes with new in initializers on PHP 8.1 #1160
 
 ## 1.4.4 (2021-09-13)
+
 * Fixes auto-generated return values #1144
 * Adds support for tentative types #1130
 * Fixes for PHP 8.1 Support (#1130 and #1140)
@@ -14,16 +16,19 @@
 * Added option to configure default matchers for objects `\Mockery::getConfiguration()->setDefaultMatcher($class, $matcherClass)` #1120
 
 ## 1.4.3 (2021-02-24)
+
 * Fixes calls to fetchMock before initialisation #1113
 * Allow shouldIgnoreMissing() to behave in a recursive fashion #1097
 * Custom object formatters #766 (Needs Docs)
 * Fix crash on a union type including null #1106
 
 ## 1.3.4 (2021-02-24)
+
 * Fixes calls to fetchMock before initialisation #1113
 * Fix crash on a union type including null #1106
 
 ## 1.4.2 (2020-08-11)
+
 * Fix array to string conversion in ConstantsPass (#1086)
 * Fixed nullable PHP 8.0 union types (#1088, #1089)
 * Fixed support for PHP 8.0 parent type (#1088, #1089)
@@ -38,6 +43,7 @@
 * Fix mocking methods with iterable return type without specifying a return value (#1075)
 
 ## 1.3.3 (2020-08-11)
+
 * Fix array to string conversion in ConstantsPass (#1086)
 * Fixed nullable PHP 8.0 union types (#1088)
 * Fixed support for PHP 8.0 parent type (#1088)
@@ -45,6 +51,7 @@
 * Fixed PHP 8.0 union return types (#1088)
 
 ## 1.3.2 (2020-07-09)
+
 * Fix mocking with anonymous classes (#1039)
 * Fix andAnyOthers() to properly match earlier expectations (#1051)
 * Added provisional support for PHP 8.0 (#1068, #1072,#1079)
@@ -57,6 +64,7 @@
 * Drops support for PHP < 7.3 and PHPUnit < 8 (#1059)
 
 ## 1.3.1 (2019-12-26)
+
 * Revert improved exception debugging due to BC breaks (#1032)
 
 ## 1.3.0 (2019-11-24)

--- a/library/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php
@@ -75,7 +75,8 @@ class MethodDefinitionPass implements Pass
 
             if (!$param->isVariadic()) {
                 if (false !== $param->isDefaultValueAvailable()) {
-                    $paramDef .= ' = ' . var_export($param->getDefaultValue(), true);
+                    $defaultValue = $param->getDefaultValue();
+                    $paramDef .= ' = ' . (is_object($defaultValue) ? get_class($defaultValue) : var_export($defaultValue, true));
                 } elseif ($param->isOptional()) {
                     $paramDef .= ' = null';
                 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,16 +4,19 @@
          verbose="true"
 >
     <testsuites>
-        <testsuite name="Mockery Test Suite PHP8">
-            <directory suffix="Test.php">./tests</directory>
-            <directory phpVersion="8.0.0-dev" phpVersionOperator=">=">./tests/PHP80</directory>
-            <directory phpVersion="8.1.0-dev" phpVersionOperator=">=">./tests/PHP81</directory>
-        </testsuite>
-
         <testsuite name="Mockery Test Suite PHP7">
             <directory suffix="Test.php">./tests</directory>
             <exclude>./tests/PHP80</exclude>
             <exclude>./tests/PHP81</exclude>
+        </testsuite>
+
+        <testsuite name="Mockery Test Suite PHP80">
+            <directory phpVersion="8.0.0-dev" phpVersionOperator=">=">./tests</directory>
+            <exclude>./tests/PHP81</exclude>
+        </testsuite>
+        
+        <testsuite name="Mockery Test Suite PHP81">
+            <directory phpVersion="8.1.0-dev" phpVersionOperator=">=">./tests</directory>
         </testsuite>
     </testsuites>
 
@@ -28,5 +31,4 @@
             </exclude>
         </whitelist>
     </filter>
-
 </phpunit>

--- a/tests/PHP81/Php81LanguageFeaturesTest.php
+++ b/tests/PHP81/Php81LanguageFeaturesTest.php
@@ -85,8 +85,9 @@ class NullLogger implements LoggerInterface
 class ClassWithNewInInitializer
 {
     public function __construct(
-        private Logger $logger = new NullLogger,
-    ) {}
+        private Logger $logger = new NullLogger(),
+    ) {
+    }
 }
 
 class ClassThatImplementsSerializable implements Serializable

--- a/tests/PHP81/Php81LanguageFeaturesTest.php
+++ b/tests/PHP81/Php81LanguageFeaturesTest.php
@@ -3,10 +3,10 @@
 namespace test\Mockery;
 
 use DateTime;
-use Serializable;
-use Mockery as m;
+use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use ReturnTypeWillChange;
+use Serializable;
 
 /**
  * @requires PHP 8.1.0-dev
@@ -36,7 +36,7 @@ class Php81LanguageFeaturesTest extends MockeryTestCase
      */
     public function it_can_mock_an_internal_class_with_tentative_union_return_types()
     {
-        $mock = m::mock('PDO');
+        $mock = Mockery::mock('PDO');
 
         $this->assertInstanceOf('PDO', $mock);
 
@@ -45,7 +45,7 @@ class Php81LanguageFeaturesTest extends MockeryTestCase
         try {
             $this->assertSame(0, $mock->exec('select * from foo.bar'));
         } finally {
-            m::close();
+            Mockery::close();
         }
     }
 
@@ -64,6 +64,29 @@ class Php81LanguageFeaturesTest extends MockeryTestCase
 
         $this->assertSame(0.0, $mock->getTimestamp());
     }
+
+    /** @test */
+    public function testMockingClassWithNewInInitializer()
+    {
+        $mock = Mockery::mock(ClassWithNewInInitializer::class);
+
+        $this->assertInstanceOf(ClassWithNewInInitializer::class, $mock);
+    }
+}
+
+interface LoggerInterface
+{
+}
+
+class NullLogger implements LoggerInterface
+{
+}
+
+class ClassWithNewInInitializer
+{
+    public function __construct(
+        private Logger $logger = new NullLogger,
+    ) {}
 }
 
 class ClassThatImplementsSerializable implements Serializable


### PR DESCRIPTION
This patch resolves #1154, via the following changes:

 - Add tests and fixtures 
 - Mock classes with `new` in initializers 