### PR TITLE
PHP 8.2 | Tests: fix newly introduced dynamic property

### DIFF
--- a/tests/Mockery/MockClassWithFinalToStringTest.php
+++ b/tests/Mockery/MockClassWithFinalToStringTest.php
@@ -25,6 +25,8 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 class MockClassWithFinalToStringTest extends MockeryTestCase
 {
+    protected $container;
+
     protected function mockeryTestSetUp()
     {
         $this->container = new \Mockery\Container();


### PR DESCRIPTION
Follow up on PR #1162, which introduced a new test which again set a dynamic property.