### PR TITLE
GH Actions: run tests against PHP 8.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,9 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.4', '8.0', '8.1']
+        php: ['7.4', '8.0', '8.1', '8.2']
+
+    continue-on-error: ${{ matrix.php == '8.2' }}
 
     steps:
       - name: Checkout Code
@@ -29,11 +31,20 @@ jobs:
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Install Dependencies
+        if: ${{ matrix.php != '8.2' }}
         uses: nick-invision/retry@v1
         with:
           timeout_minutes: 5
           max_attempts: 5
           command: composer update --no-interaction --no-progress
+
+      - name: Install Dependencies (ignore platform)
+        if: ${{ matrix.php == '8.2' }}
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer update --no-interaction --no-progress --ignore-platform-req=php
 
       - name: Execute PHPUnit
         run: vendor/bin/phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
           tools: composer:v2
           extensions: mongodb, redis
           coverage: xdebug

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,8 @@ name: Tests
 on:
   push:
   pull_request:
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
 
 jobs:
   phpunit:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="./tests/Bootstrap.php"
+         convertErrorsToExceptions="true"
+         convertWarningsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertDeprecationsToExceptions="true"
          colors="true"
          verbose="true"
 >


### PR DESCRIPTION
## TL;DR

PHP 8.2 is likely to cause significant amounts of deprecation notices again in most projects.

As Mockery is a testing tool and projects will use their tests as a starting point to start fixing their code, it would be wonderful for Mockery to be PHP 8.2 ready early (before PHP 8.2-beta1).

PR #1168, #1170 and #1174 fix the bulk of the issues in Mockery itself as found via Mockery's own tests. As of now and with the WIP current state of PHP 8.2, there are only 11 failing tests left.

To keep on top of what additional work is and will be still needed to make Mockery compatible with PHP 8.2, I propose to start running the tests against PHP 8.2 in GitHub Actions.


## Commit details

### GH Actions: run tests against PHP 8.2

... for early warning about problems which need addressing.

For now, a failing test run against PHP 8.2 won't stop the build.

### GH Actions: allow for manually triggering a workflow

Triggering a workflow for a branch manually is not supported by default in GH Actions, but has to be explicitly allowed.

This is useful if, for instance, an external action script or composer dependency has broken.
Once a fix is available, failing builds for open PRs can be retriggered manually instead of having to be re-pushed to retrigger the workflow.

Ref: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/

### GH Actions: turn on error reporting

The default setting for `error_reporting` used by the SetupPHP action is `error_reporting=E_ALL & ~E_DEPRECATED & ~E_STRICT` and `display_errors` is set to `Off`.

For the purposes of CI, I'd recommend running with `-1` and `display_errors=On` to ensure **all** PHP notices are shown.

### PHPUnit: update configuration

PHPUnit 9.5.10 and 8.5.21 were released a while ago and contain a particular (IMO breaking) change:

> * PHPUnit no longer converts PHP deprecations to exceptions by default (configure `convertDeprecationsToExceptions="true"` to enable this)

Let's unpack this:

Previously (PHPUnit < 9.5.10/8.5.21), if PHPUnit would encounter a PHP native deprecation notice, it would:
1. Show a test which causes a deprecation notice to be thrown as **"errored"**,
2. Show the **first** deprecation notice it encountered and
3. PHPUnit would exit with a **non-0 exit code** (2), which will fail a CI build.

As of PHPUnit 9.5.10/8.5.21, if PHPUnit encounters a PHP native deprecation notice, it will no longer do so. Instead PHPUnit will:
1. Show a test which causes a PHP deprecation notice to be thrown as **"risky"**,
2. Show **all** deprecation notices it encounters inline in the progress report and
3. PHPUnit will exit with a **0 exit code**, which will show a CI build as passing.

This commit reverts PHPUnit to the previous behaviour by adding `convertDeprecationsToExceptions="true"` to the PHPUnit configuration.
It also adds the other related directives for consistency.

Refs:
* https://github.com/sebastianbergmann/phpunit/blob/9.5/ChangeLog-8.5.md
* https://github.com/sebastianbergmann/phpunit/blob/9.5/ChangeLog-9.5.md