### PR TITLE
[8.1] Support `never` return type

### DIFF
--- a/library/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php
@@ -157,7 +157,7 @@ BODY;
 
         $body .= "\$ret = {$invoke}(__FUNCTION__, \$argv);\n";
 
-        if ($method->getReturnType() !== "void") {
+        if (! in_array($method->getReturnType(), ['never','void'], true)) {
             $body .= "return \$ret;\n";
         }
 

--- a/tests/PHP81/Php81LanguageFeaturesTest.php
+++ b/tests/PHP81/Php81LanguageFeaturesTest.php
@@ -6,6 +6,7 @@ use DateTime;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use ReturnTypeWillChange;
+use RuntimeException;
 use Serializable;
 
 /**
@@ -82,6 +83,15 @@ class Php81LanguageFeaturesTest extends MockeryTestCase
 
         $mock->foo($object);
     }
+
+    /** @test */
+    public function it_can_mock_a_class_with_a_never_returning_type_hint()
+    {
+        $mock = Mockery::mock(NeverReturningTypehintClass::class)->makePartial();
+
+        $this->expectException(RuntimeException::class);
+        $mock->throws();
+    }
 }
 
 interface LoggerInterface
@@ -135,6 +145,18 @@ class ReturnTypeWillChangeAttributeWrongReturnType extends DateTime
     }
 }
 
+class NeverReturningTypehintClass
+{
+    public function throws(): never
+    {
+        throw new RuntimeException('Never!');
+    }
+
+    public function exits(): never
+    {
+        exit;
+    }
+}
 class IntersectionTypeHelperClass
 {
 }


### PR DESCRIPTION
This patch resolves #1167, via the following changes:

 - MethodDefinitionPass will not generate a `return` statement for a `never` return typehint.

A function/method that is declared with the `never` return type indicates that it will never `return` a value, and **always** throws an exception or terminates with a `die/exit `call.