### PR TITLE
Update the changelog to include changes from #1180

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.5.2 (2022-xx-xx)
+
+* Updated changelog for version 1.5.1 to include changes from #1180
+
 ## 1.3.6 (2022-09-07)
 * PHP 8.2 | Fix "Use of "parent" in callables is deprecated" notice #1169
 
@@ -9,6 +13,7 @@
 * [PHP 8.2] Fix "Use of "parent" in callables is deprecated" notice #1169
 * [PHP 8.1] Support intersection types #1164
 * Handle final `__toString` methods #1162
+* Only count assertions on expectations which can fail a test #1180
 
 ## 1.5.0 (2022-01-20)
 


### PR DESCRIPTION
In response to issue #1190, I have updated the documentation to record the changes from #1180 

I haven't labelled the change as a BC break to avoid contention; the scope of this MR is purely to make people aware that the change happened. To that end, I hope we can release this under 1.5.2 quickly, even if this is the only change.