### PR TITLE
Deal with null type in PHP8.2

### DIFF
--- a/library/Mockery/Reflector.php
+++ b/library/Mockery/Reflector.php
@@ -220,10 +220,10 @@ class Reflector
             return sprintf('?%s', $typeHint);
         }
 
-        if ($typeHint === 'null') {
-            return 'null';
+        if ($typeHint === 'null' || $typeHint === 'mixed') {
+            return $typeHint;
         }
 
-        return $typeHint === 'mixed' ? 'mixed' : sprintf('%s|null', $typeHint);
+        return sprintf('%s|null', $typeHint);
     }
 }

--- a/library/Mockery/Reflector.php
+++ b/library/Mockery/Reflector.php
@@ -220,6 +220,10 @@ class Reflector
             return sprintf('?%s', $typeHint);
         }
 
+        if ($typeHint === 'null') {
+            return 'null';
+        }
+
         return $typeHint === 'mixed' ? 'mixed' : sprintf('%s|null', $typeHint);
     }
 }

--- a/tests/PHP82/Php82LanguageFeaturesTest.php
+++ b/tests/PHP82/Php82LanguageFeaturesTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace test\Mockery;
+
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+/**
+ * @requires PHP 8.2.0-dev
+ */
+class Php82LanguageFeaturesTest extends MockeryTestCase
+{
+    /** @test */
+    public function it_can_mock_an_class_with_null_return_type()
+    {
+        $mock = Mockery::mock(HasNullReturnType::class);
+
+        $this->assertInstanceOf(HasNullReturnType::class, $mock);
+    }
+}
+
+class HasNullReturnType
+{
+    public function getChildren(): null
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
Because the `null` type in PHP 8.2 is nullable, the `formatNullableType` method appends `|null` to the`null` type. This results in `null|null` as a generated return type. When parsing, this results in the following error:
```
PHP Fatal error:  Duplicate type null is redundant 
```

This PR fixes this by simply formatting returning `null` when the passed type is `null`.

Fixes #1204.