### PR TITLE
Allow Dynamic Properties on PHP 8.2

### DIFF
--- a/library/Mockery/Generator/StringManipulation/Pass/ClassNamePass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/ClassNamePass.php
@@ -40,7 +40,7 @@ class ClassNamePass implements Pass
 
         $code = str_replace(
             'class Mock',
-            'class ' . $className,
+            sprintf("#[\AllowDynamicProperties]\nclass %s", $className),
             $code
         );
 


### PR DESCRIPTION
If accepted, this patch allows Mockery to add `#[\AllowDynamicProperties]` PHP Attribute to the mock classes it generates.

before: 
```php
class Mockery_Foo {
    // snip
}
```
after:
```php
#[\AllowDynamicProperties]
class Mockery_Foo {
    // snip
}
```
