### PR TITLE
Add `MockeryExceptionInterface`

### DIFF
--- a/library/Mockery/CountValidator/Exception.php
+++ b/library/Mockery/CountValidator/Exception.php
@@ -20,6 +20,8 @@
 
 namespace Mockery\CountValidator;
 
-class Exception extends \OutOfBoundsException
+use Mockery\Exception\MockeryExceptionInterface;
+
+class Exception extends \OutOfBoundsException implements MockeryExceptionInterface
 {
 }

--- a/library/Mockery/Exception.php
+++ b/library/Mockery/Exception.php
@@ -22,6 +22,6 @@ namespace Mockery;
 
 use Mockery\Exception\MockeryExceptionInterface;
 
-class Exception extends \UnexpectedValueException  implements MockeryExceptionInterface
+class Exception extends \UnexpectedValueException implements MockeryExceptionInterface
 {
 }

--- a/library/Mockery/Exception.php
+++ b/library/Mockery/Exception.php
@@ -20,6 +20,8 @@
 
 namespace Mockery;
 
-class Exception extends \UnexpectedValueException
+use Mockery\Exception\MockeryExceptionInterface;
+
+class Exception extends \UnexpectedValueException  implements MockeryExceptionInterface
 {
 }

--- a/library/Mockery/Exception/BadMethodCallException.php
+++ b/library/Mockery/Exception/BadMethodCallException.php
@@ -2,7 +2,7 @@
 
 namespace Mockery\Exception;
 
-class BadMethodCallException extends \BadMethodCallException
+class BadMethodCallException extends \BadMethodCallException implements MockeryExceptionInterface
 {
     private $dismissed = false;
 

--- a/library/Mockery/Exception/InvalidArgumentException.php
+++ b/library/Mockery/Exception/InvalidArgumentException.php
@@ -20,6 +20,6 @@
 
 namespace Mockery\Exception;
 
-class InvalidArgumentException extends \InvalidArgumentException
+class InvalidArgumentException extends \InvalidArgumentException implements MockeryExceptionInterface
 {
 }

--- a/library/Mockery/Exception/MockeryExceptionInterface.php
+++ b/library/Mockery/Exception/MockeryExceptionInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mockery\Exception;
+
+use Throwable;
+
+interface MockeryExceptionInterface extends Throwable
+{
+}

--- a/library/Mockery/Exception/RuntimeException.php
+++ b/library/Mockery/Exception/RuntimeException.php
@@ -20,6 +20,6 @@
 
 namespace Mockery\Exception;
 
-class RuntimeException extends \Exception
+class RuntimeException extends \Exception implements MockeryExceptionInterface
 {
 }


### PR DESCRIPTION
If accepted, this patch adds.

- `MockeryExceptionInterface`
- Implements `MockeryExceptionInterface` on Mockery's Exception classes.

> As of https://github.com/sebastianbergmann/phpunit/commit/74ce5b661a74b488e4a515256b9f35c5a8562683, all exceptions thrown in third-party subscribers are ignored.

This will allow us to register all of Mocker's Exceptions as PHPUnit failures via `TestCase::registerFailureType()` implemented in https://github.com/sebastianbergmann/phpunit/commit/28766f5aac456f8093a1e946aad79c9cf96bb0ca for `PHPUnit 10.1`.

`TestCase::registerFailureType(MockeryExceptionInterface::class)` in `MockeryTestCase` 