### PR TITLE
Add dump helper

### DIFF
--- a/library/Mockery/Exception/Dump.php
+++ b/library/Mockery/Exception/Dump.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Mockery\Exception;
+
+class BadMethodCallException extends \Mockery\Exception {}

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -616,6 +616,22 @@ class Expectation implements ExpectationInterface
     }
 
     /**
+     * Dump the args supplied by the method call.
+     *
+     * @return self
+     */
+    public function andDump()
+    {
+        $this->_closureQueue = [
+            fn(...$args) => throw new Exception(
+                'Called ' . \Mockery::formatArgs($this->_name, $args)
+            ),
+        ];
+
+        return clone $this;
+    }
+
+    /**
      * Set Exception class and arguments to that class to be thrown
      *
      * @param string|\Exception $exception

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -623,7 +623,7 @@ class Expectation implements ExpectationInterface
     public function andDump()
     {
         $this->_closureQueue = [
-            fn(...$args) => throw new Exception(
+            fn(...$args) => throw new Exception\Dump(
                 'Called ' . \Mockery::formatArgs($this->_name, $args)
             ),
         ];

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -260,6 +260,21 @@ class ExpectationTest extends MockeryTestCase
         $this->assertNull($this->mock->foo(...$args));
     }
 
+    public function testDumpsCalls()
+    {
+        $this->expectException(Mockery\Exception\Dump::class);
+        $this->expectExceptionMessage("Called foo('bar')");
+        $this->mock->shouldReceive('foo')->andDump();
+        $this->mock->foo('bar');
+    }
+
+    public function testDumperIgnoresMatchers()
+    {
+        $this->expectException(Mockery\Exception\Dump::class);
+        $this->mock->shouldReceive('foo')->andDump()->with('baz');
+        $this->mock->foo('bar');
+    }
+
     public function testExceptionOnInvalidArgumentIndexValue()
     {
         $this->expectException(\InvalidArgumentException::class);


### PR DESCRIPTION
This PR proposes a new expectation method to help in debugging expectations. When your expectation doesn't match and you want to understand what was actually called, call `->andDump()` on your expectation like this:

```php
$connection
    ->shouldReceive('update')->andDump()
    ->with('arg1', 'arg2')
    ->once();
```

The dump method will throw an exception showing the called method, args and the stack trace.

The rest of the chain will have no effect as `andDump()` returns a clone of the expectation. Thus unlike with dumping in an `andReturn` or putting a dumping matcher inside the `with()`, this does not require commenting out or modifying your non-matching `with` and other method calls.