### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# https://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 /.github export-ignore
 /docker export-ignore
 /tests export-ignore
+.editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .php_cs export-ignore


### PR DESCRIPTION
While working on my PR (#1221) I ran into some issues with wrong EOLs and trailing whitespaces.

[EditorConfig](https://editorconfig.org/) file instructs the editor or IDE to take care of these issues. Most of the editors and IDEs either natively recognize and honour these files or can do that using a [plugin](https://editorconfig.org/#download).