### PR TITLE
Update PHPStorm metadata to support Intersection Types

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -2,10 +2,10 @@
 
 namespace PHPSTORM_META;
 
-override(\Mockery::mock(0), map(["" => "@"]));
-override(\Mockery::spy(0), map(["" => "@"]));
-override(\Mockery::namedMock(0), map(["" => "@"]));
-override(\Mockery::instanceMock(0), map(["" => "@"]));
-override(\mock(0), map(["" => "@"]));
-override(\spy(0), map(["" => "@"]));
-override(\namedMock(0), map(["" => "@"]));
+override(\Mockery::mock(0), map(["" => "@&\Mockery\MockInterface"]));
+override(\Mockery::spy(0), map(["" => "@&\Mockery\MockInterface"]));
+override(\Mockery::namedMock(0), map(["" => "@&\Mockery\MockInterface"]));
+override(\Mockery::instanceMock(0), map(["" => "@&\Mockery\MockInterface"]));
+override(\mock(0), map(["" => "@&\Mockery\MockInterface"]));
+override(\spy(0), map(["" => "@&\Mockery\MockInterface"]));
+override(\namedMock(0), map(["" => "@&\Mockery\MockInterface"]));


### PR DESCRIPTION
This pull request updates the PHPStorm `>=2021.3` metadata file to support Intersection Types.

References:

[Blog post on PHPStorm 2021.3 release](https://blog.jetbrains.com/phpstorm/2021/12/phpstorm-2021-3-release/#pure_intersection_types)

[PHPStorm documentation on advanced metadata mapping](https://www.jetbrains.com/help/phpstorm/ide-advanced-metadata.html#map)

An example of the changes made to the meta file: 

```diff
- override(\mock(0), map(["" => "@"]));
+ override(\mock(0), map(["" => "@&\ArrayAccess"]));
```

These changes will enable developers using PHPStorm to take full advantage of Intersection Types when mocking objects.

![image](https://user-images.githubusercontent.com/9754361/232171867-9e6d7208-943c-4f65-855b-ad5e9f54700b.png)

![image](https://user-images.githubusercontent.com/9754361/232171981-f6fa9183-fd32-4b1e-9379-d946939c5989.png)

This will be followed by an additional PR adding the doc comments to indicate intersection types for static analysis tools.

```
/** 
* @template T of object
* @return T&\Mockery\MockInterface
*/
```

Thank you for reviewing this pull request!