### PR TITLE
Split PHPUnit TestSuites for PHP 8.2

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,15 +12,22 @@
             <directory suffix="Test.php">./tests</directory>
             <exclude>./tests/PHP80</exclude>
             <exclude>./tests/PHP81</exclude>
+            <exclude>./tests/PHP82</exclude>
         </testsuite>
 
         <testsuite name="Mockery Test Suite PHP80">
             <directory phpVersion="8.0.0-dev" phpVersionOperator=">=">./tests</directory>
             <exclude>./tests/PHP81</exclude>
+            <exclude>./tests/PHP82</exclude>
         </testsuite>
         
         <testsuite name="Mockery Test Suite PHP81">
             <directory phpVersion="8.1.0-dev" phpVersionOperator=">=">./tests</directory>
+            <exclude>./tests/PHP82</exclude>
+        </testsuite>
+
+        <testsuite name="Mockery Test Suite PHP82">
+            <directory phpVersion="8.2.0-dev" phpVersionOperator=">=">./tests</directory>
         </testsuite>
     </testsuites>
 


### PR DESCRIPTION
This pull request updates the `phpunit.xml.dist` configuration file to exclude tests based on the PHP version that is being used.

This will allow us to run tests for different PHP versions in isolation, which will make it easier to identify and fix issues that are specific to certain PHP versions.