### PR TITLE
Setup `Codecov` for code coverage

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,31 @@
+name: Codecov
+on:
+  pull_request:
+  push:
+    branches:
+      - "[0-9]+.[0-9]+.x"
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up php 8.1
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+
+      - name: Install dependencies
+        run: composer self-update && composer install && composer dump-autoload
+
+      - name: Run tests and collect coverage
+        run: composer phpunit
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ${{ github.workspace }}/.cache/phpunit/
+          verbose: true

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Mockery
 =======
 
 [![Build Status](https://github.com/mockery/mockery/actions/workflows/tests.yml/badge.svg)](https://github.com/mockery/mockery/actions)
-[![Supported PHP Version](https://badgen.net/packagist/php/ghostwriter/wip?color=8892bf)](https://www.php.net/supported-versions)
+[![Supported PHP Version](https://badgen.net/packagist/php/mockery/mockery?color=8892bf)](https://www.php.net/supported-versions)
 [![Code Coverage](https://codecov.io/gh/mockery/mockery/branch/1.5.x/graph/badge.svg?token=oxHwVM56bT)](https://codecov.io/gh/mockery/mockery)
 [![Type Coverage](https://shepherd.dev/github/mockery/mockery/coverage.svg)](https://shepherd.dev/github/mockery/mockery)
 [![Latest Stable Version](https://poser.pugx.org/mockery/mockery/v/stable.svg)](https://packagist.org/packages/mockery/mockery)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Mockery
 [![Build Status](https://github.com/mockery/mockery/actions/workflows/tests.yml/badge.svg)](https://github.com/mockery/mockery/actions)
 [![Supported PHP Version](https://badgen.net/packagist/php/ghostwriter/wip?color=8892bf)](https://www.php.net/supported-versions)
 [![Code Coverage](https://codecov.io/gh/mockery/mockery/branch/1.5.x/graph/badge.svg?token=oxHwVM56bT)](https://codecov.io/gh/mockery/mockery)
+[![Type Coverage](https://shepherd.dev/github/mockery/mockery/coverage.svg)](https://shepherd.dev/github/mockery/mockery)
 [![Latest Stable Version](https://poser.pugx.org/mockery/mockery/v/stable.svg)](https://packagist.org/packages/mockery/mockery)
 [![Total Downloads](https://poser.pugx.org/mockery/mockery/downloads.svg)](https://packagist.org/packages/mockery/mockery)
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Mockery
 =======
 
 [![Build Status](https://github.com/mockery/mockery/actions/workflows/tests.yml/badge.svg)](https://github.com/mockery/mockery/actions)
+[![Supported PHP Version](https://badgen.net/packagist/php/ghostwriter/wip?color=8892bf)](https://www.php.net/supported-versions)
 [![Code Coverage](https://codecov.io/gh/mockery/mockery/branch/1.5.x/graph/badge.svg?token=oxHwVM56bT)](https://codecov.io/gh/mockery/mockery)
 [![Latest Stable Version](https://poser.pugx.org/mockery/mockery/v/stable.svg)](https://packagist.org/packages/mockery/mockery)
 [![Total Downloads](https://poser.pugx.org/mockery/mockery/downloads.svg)](https://packagist.org/packages/mockery/mockery)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Mockery
 =======
 
 [![Build Status](https://github.com/mockery/mockery/actions/workflows/tests.yml/badge.svg)](https://github.com/mockery/mockery/actions)
+[![Code Coverage](https://codecov.io/gh/mockery/mockery/branch/1.5.x/graph/badge.svg?token=oxHwVM56bT)](https://codecov.io/gh/mockery/mockery)
 [![Latest Stable Version](https://poser.pugx.org/mockery/mockery/v/stable.svg)](https://packagist.org/packages/mockery/mockery)
 [![Total Downloads](https://poser.pugx.org/mockery/mockery/downloads.svg)](https://packagist.org/packages/mockery/mockery)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Mockery
 
 [![Build Status](https://github.com/mockery/mockery/actions/workflows/tests.yml/badge.svg)](https://github.com/mockery/mockery/actions)
 [![Supported PHP Version](https://badgen.net/packagist/php/mockery/mockery?color=8892bf)](https://www.php.net/supported-versions)
-[![Code Coverage](https://codecov.io/gh/mockery/mockery/branch/1.5.x/graph/badge.svg?token=oxHwVM56bT)](https://codecov.io/gh/mockery/mockery)
+[![Code Coverage](https://codecov.io/gh/mockery/mockery/branch/1.6.x/graph/badge.svg?token=oxHwVM56bT)](https://codecov.io/gh/mockery/mockery)
 [![Type Coverage](https://shepherd.dev/github/mockery/mockery/coverage.svg)](https://shepherd.dev/github/mockery/mockery)
 [![Latest Stable Version](https://poser.pugx.org/mockery/mockery/v/stable.svg)](https://packagist.org/packages/mockery/mockery)
 [![Total Downloads](https://poser.pugx.org/mockery/mockery/downloads.svg)](https://packagist.org/packages/mockery/mockery)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+comment:
+  layout: "diff, files"
+  behavior: default
+  require_changes: true  # if true: only post the comment if coverage changes
+  require_base: yes        # [yes :: must have a base report to post]
+  require_head: yes       # [yes :: must have a head report to post]

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,45 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./tests/Bootstrap.php"
-         convertErrorsToExceptions="true"
-         convertWarningsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertDeprecationsToExceptions="true"
-         colors="true"
-         verbose="true"
+<phpunit
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        bootstrap="./tests/Bootstrap.php"
+        convertErrorsToExceptions="true"
+        convertWarningsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertDeprecationsToExceptions="true"
+        colors="true"
+        verbose="true"
+        testdox="true"
 >
-    <testsuites>
-        <testsuite name="Mockery Test Suite PHP7">
-            <directory suffix="Test.php">./tests</directory>
-            <exclude>./tests/PHP80</exclude>
-            <exclude>./tests/PHP81</exclude>
-            <exclude>./tests/PHP82</exclude>
-        </testsuite>
-
-        <testsuite name="Mockery Test Suite PHP80">
-            <directory phpVersion="8.0.0-dev" phpVersionOperator=">=">./tests</directory>
-            <exclude>./tests/PHP81</exclude>
-            <exclude>./tests/PHP82</exclude>
-        </testsuite>
-        
-        <testsuite name="Mockery Test Suite PHP81">
-            <directory phpVersion="8.1.0-dev" phpVersionOperator=">=">./tests</directory>
-            <exclude>./tests/PHP82</exclude>
-        </testsuite>
-
-        <testsuite name="Mockery Test Suite PHP82">
-            <directory phpVersion="8.2.0-dev" phpVersionOperator=">=">./tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./library/</directory>
-            <exclude>
-                <directory>./library/Mockery/Adapter/Phpunit/Legacy</directory>
-                <file>./library/Mockery/Adapter/Phpunit/TestListener.php</file>
-                <file>./library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationAssertPostConditions.php</file>
-                <file>./library/Mockery/Adapter/Phpunit/MockeryTestCaseSetUp.php</file>
-            </exclude>
-        </whitelist>
-    </filter>
+ <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./library/</directory>
+    </include>
+    <exclude>
+      <directory>./library/Mockery/Adapter/Phpunit/Legacy</directory>
+      <file>./library/Mockery/Adapter/Phpunit/TestListener.php</file>
+      <file>./library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationAssertPostConditions.php</file>
+      <file>./library/Mockery/Adapter/Phpunit/MockeryTestCaseSetUp.php</file>
+    </exclude>
+    <report>
+      <html outputDirectory=".cache/phpunit/coverage-html"/>
+      <clover outputFile=".cache/phpunit/clover.xml"/>
+      <text outputFile=".cache/phpunit/coverage.txt"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Mockery Test Suite PHP7">
+      <directory suffix="Test.php">./tests</directory>
+      <exclude>./tests/PHP80</exclude>
+      <exclude>./tests/PHP81</exclude>
+      <exclude>./tests/PHP82</exclude>
+    </testsuite>
+    <testsuite name="Mockery Test Suite PHP80">
+      <directory phpVersion="8.0.0-dev" phpVersionOperator="&gt;=">./tests</directory>
+      <exclude>./tests/PHP81</exclude>
+      <exclude>./tests/PHP82</exclude>
+    </testsuite>
+    <testsuite name="Mockery Test Suite PHP81">
+      <directory phpVersion="8.1.0-dev" phpVersionOperator="&gt;=">./tests</directory>
+      <exclude>./tests/PHP82</exclude>
+    </testsuite>
+    <testsuite name="Mockery Test Suite PHP82">
+      <directory phpVersion="8.2.0-dev" phpVersionOperator="&gt;=">./tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
This PR enables Codecov GitHub Action and Comments for code coverage.

- Create codecov.yml GitHub workflow
- Create codecov.yml Config file

Codecov provides a detailed report on the test coverage of the codebase and helps identify areas that need additional tests.

Follow the steps to finish setting up code coverage. https://app.codecov.io/gh/mockery/mockery/new

Once it's set up, visit this link to grab the markdown code for a Codecov badge https://app.codecov.io/gh/mockery/mockery/settings/badge

You can leave the markdown in a comment here, i'll update the readme with that information.

GitHub will also email you regarding my request to allow Codecov access to public organization data (read-only access to the repo).