### PR TITLE
Prevent CI run duplication

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -1,6 +1,12 @@
 name: Psalm Static analysis
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - "[0-9]+.[0-9]+.x"
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
 
 concurrency:
   group: psalm-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,10 @@
 name: Tests
 
 on:
-  push:
   pull_request:
+  push:
+    branches:
+      - "[0-9]+.[0-9]+.x"
   # Allow manually triggering the workflow.
   workflow_dispatch:
 


### PR DESCRIPTION
This patch limits the CI actions to only run on `push` events, on branches matching the regex to prevent duplicate runs in pull requests.