### PR TITLE
Add PHPUnit workflow for PHP 8.3 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,9 +15,10 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.4', '8.0', '8.1', '8.2']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3']
+        dev: ['8.3']
 
-    continue-on-error: ${{ matrix.php == '8.2' }}
+    continue-on-error: ${{ matrix.php == matrix.dev }}
 
     steps:
       - name: Checkout Code
@@ -36,15 +37,15 @@ jobs:
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Install Dependencies
-        if: ${{ matrix.php != '8.2' }}
+        if: ${{ matrix.php != matrix.dev }}
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 5
           max_attempts: 5
           command: composer update --no-interaction --no-progress
 
-      - name: Install Dependencies (ignore platform)
-        if: ${{ matrix.php == '8.2' }}
+      - name: Install Dependencies (ignore platform php:${{ matrix.dev }})
+        if: ${{ matrix.php == matrix.dev }}
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 5


### PR DESCRIPTION
This patch cleans up the `.github/workflows/tests.yml` and adds `8.3`