### PR TITLE
Improve `ClassAttributesPass` for Dynamic Properties

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
         "psalm:dry-run": "vendor/bin/psalm --alter --issues=all --dry-run",
         "psalm:missing": "vendor/bin/psalm --alter --issues=MissingReturnType",
         "psalm:security": "vendor/bin/psalm --taint-analysis",
-        "psalm:shepherd": "vendor/bin/psalm --shepherd --stats --no-diff --no-cache",
+        "psalm:shepherd": "vendor/bin/psalm --shepherd --show-info=false --stats --no-diff --no-cache",
         "test": [
             "@phpunit",
             "@psalm"

--- a/library/Mockery/Generator/DefinedTargetClass.php
+++ b/library/Mockery/Generator/DefinedTargetClass.php
@@ -22,8 +22,10 @@ namespace Mockery\Generator;
 
 use ReflectionAttribute;
 use ReflectionClass;
+
 use function array_map;
 use function array_unique;
+
 use const PHP_VERSION_ID;
 
 class DefinedTargetClass implements TargetClassInterface

--- a/library/Mockery/Generator/DefinedTargetClass.php
+++ b/library/Mockery/Generator/DefinedTargetClass.php
@@ -50,8 +50,8 @@ class DefinedTargetClass implements TargetClassInterface
             return [];
         }
 
-        return array_unique(['AllowDynamicProperties', ...array_map(
-            static fn (ReflectionAttribute $attribute): string => $attribute->getName(),
+        return array_unique(['\AllowDynamicProperties', ...array_map(
+            static fn (ReflectionAttribute $attribute): string => '\\'.$attribute->getName(),
             $this->rfc->getAttributes()
         )]);
     }

--- a/library/Mockery/Generator/DefinedTargetClass.php
+++ b/library/Mockery/Generator/DefinedTargetClass.php
@@ -21,13 +21,17 @@
 namespace Mockery\Generator;
 
 use ReflectionAttribute;
+use ReflectionClass;
+use function array_map;
+use function array_unique;
+use const PHP_VERSION_ID;
 
 class DefinedTargetClass implements TargetClassInterface
 {
     private $rfc;
     private $name;
 
-    public function __construct(\ReflectionClass $rfc, $alias = null)
+    public function __construct(ReflectionClass $rfc, $alias = null)
     {
         $this->rfc = $rfc;
         $this->name = $alias === null ? $rfc->getName() : $alias;
@@ -35,7 +39,7 @@ class DefinedTargetClass implements TargetClassInterface
 
     public static function factory($name, $alias = null)
     {
-        return new self(new \ReflectionClass($name), $alias);
+        return new self(new ReflectionClass($name), $alias);
     }
 
     public function getAttributes()
@@ -44,10 +48,10 @@ class DefinedTargetClass implements TargetClassInterface
             return [];
         }
 
-        return array_map(
+        return array_unique(['AllowDynamicProperties', ...array_map(
             static fn (ReflectionAttribute $attribute): string => $attribute->getName(),
             $this->rfc->getAttributes()
-        );
+        )]);
     }
 
     public function getName()

--- a/library/Mockery/Generator/DefinedTargetClass.php
+++ b/library/Mockery/Generator/DefinedTargetClass.php
@@ -51,7 +51,7 @@ class DefinedTargetClass implements TargetClassInterface
         }
 
         return array_unique(['\AllowDynamicProperties', ...array_map(
-            static fn (ReflectionAttribute $attribute): string => '\\'.$attribute->getName(),
+            static fn (ReflectionAttribute $attribute): string => '\\' . $attribute->getName(),
             $this->rfc->getAttributes()
         )]);
     }

--- a/library/Mockery/Generator/StringManipulation/Pass/ClassAttributesPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/ClassAttributesPass.php
@@ -18,11 +18,9 @@ class ClassAttributesPass implements Pass
         $attributes = $class->getAttributes();
 
         if ($attributes !== []) {
-            $attributes = '#[' . implode(',', $attributes) . ']';
-
             return str_replace(
                 '#[\AllowDynamicProperties]',
-                $attributes,
+                '#[' . implode(',', $attributes) . ']',
                 $code
             );
         }

--- a/library/Mockery/Generator/StringManipulation/Pass/ClassAttributesPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/ClassAttributesPass.php
@@ -14,14 +14,15 @@ class ClassAttributesPass implements Pass
             return $code;
         }
 
+        /** @var array<string> $attributes */
         $attributes = $class->getAttributes();
 
-        if (!empty($attributes)) {
-            $attributes = '#[' . implode(',', $attributes) . ']' . PHP_EOL;
+        if ($attributes !== []) {
+            $attributes = '#[' . implode(',', $attributes) . ']';
 
             return str_replace(
-                'class Mock',
-                $attributes . ' class Mock',
+                '#[\AllowDynamicProperties]',
+                $attributes,
                 $code
             );
         }

--- a/library/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php
@@ -78,12 +78,12 @@ class MethodDefinitionPass implements Pass
                 if (false !== $param->isDefaultValueAvailable()) {
                     $defaultValue = $param->getDefaultValue();
 
-                    if (is_object($defaultValue)){
+                    if (is_object($defaultValue)) {
                         $prefix = get_class($defaultValue);
                         if ($isPhp81 && enum_exists($prefix)) {
                             $prefix = var_export($defaultValue, true);
                         }
-                    }else{
+                    } else {
                         $prefix = var_export($defaultValue, true);
                     }
 

--- a/library/Mockery/Generator/UndefinedTargetClass.php
+++ b/library/Mockery/Generator/UndefinedTargetClass.php
@@ -20,6 +20,8 @@
 
 namespace Mockery\Generator;
 
+use const PHP_VERSION_ID;
+
 class UndefinedTargetClass implements TargetClassInterface
 {
     private $name;
@@ -40,7 +42,7 @@ class UndefinedTargetClass implements TargetClassInterface
             return [];
         }
 
-        return ['\AllowDynamicProperties'];
+        return ['AllowDynamicProperties'];
     }
 
     public function getName()

--- a/library/Mockery/Generator/UndefinedTargetClass.php
+++ b/library/Mockery/Generator/UndefinedTargetClass.php
@@ -38,11 +38,7 @@ class UndefinedTargetClass implements TargetClassInterface
 
     public function getAttributes()
     {
-        if (\PHP_VERSION_ID < 80000) {
-            return [];
-        }
-
-        return ['AllowDynamicProperties'];
+        return [];
     }
 
     public function getName()

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -27,6 +27,7 @@ use Mockery\LegacyMockInterface;
 use Mockery\MockInterface;
 use Mockery\Reflector;
 
+#[\AllowDynamicProperties]
 class Mock implements MockInterface
 {
     /**

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2148,9 +2148,6 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="library/Mockery/Mock.php">
-    <InvalidAttribute>
-      <code>\AllowDynamicProperties</code>
-    </InvalidAttribute>
     <MethodSignatureMustProvideReturnType>
       <code>__toString</code>
     </MethodSignatureMustProvideReturnType>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1382,11 +1382,9 @@
       <code>apply</code>
     </MissingReturnType>
     <MixedArgument>
-      <code>$attributes</code>
       <code>$code</code>
     </MixedArgument>
     <MixedAssignment>
-      <code>$attributes</code>
       <code>$class</code>
     </MixedAssignment>
     <MixedMethodCall>
@@ -2150,6 +2148,9 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="library/Mockery/Mock.php">
+    <InvalidAttribute>
+      <code>\AllowDynamicProperties</code>
+    </InvalidAttribute>
     <MethodSignatureMustProvideReturnType>
       <code>__toString</code>
     </MethodSignatureMustProvideReturnType>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <psalm
     errorLevel="1"
-    phpVersion='8.1'
+    phpVersion='8.2'
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"

--- a/tests/Mockery/Generator/StringManipulation/Pass/ClassAttributesPassTest.php
+++ b/tests/Mockery/Generator/StringManipulation/Pass/ClassAttributesPassTest.php
@@ -38,7 +38,7 @@ class ClassAttributesPassTest extends MockeryTestCase
 
         $pass = new ClassAttributesPass();
 
-        $code = $pass->apply(static::CODE, $config);
+        $code = $pass->apply(file_get_contents(__FILE__), $config);
 
         self::assertStringContainsString($expected, $code);
     }

--- a/tests/PHP81/Php81LanguageFeaturesTest.php
+++ b/tests/PHP81/Php81LanguageFeaturesTest.php
@@ -8,6 +8,7 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use ReturnTypeWillChange;
 use RuntimeException;
 use Serializable;
+
 use function pcntl_fork;
 use function pcntl_waitpid;
 use function pcntl_wexitstatus;


### PR DESCRIPTION
This patch adds the `\AllowDynamicProperties` attribute on the mock object by default.

- Allows us to use `set` and `andSet` to dynamically set properties on the object after the mock instance is created.

- `DefinedTargetClass` Appends all additional attributes on PHP >= 8.0, via `\ReflectionAttribute`

