### PR TITLE
Update branch alias for 1.6.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.4.x-dev"
+            "dev-master": "1.6.x-dev"
         }
     }
 }


### PR DESCRIPTION
The `composer.json`'s branch alias for 1.5.x points to 1.4.x-dev version.

This is making requirements for the _next_ unreleased 1.5.x impossible, unless explictly requiring the branch.