### PR TITLE
Support PHP 8.0 `false` Literal Type

### DIFF
--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -730,6 +730,7 @@ class Mock implements MockInterface
             case 'int':    return 0;
             case 'float':  return 0.0;
             case 'bool':   return false;
+            case 'false':   return false;
 
             case 'array':
             case 'iterable':

--- a/tests/PHP82/Php82LanguageFeaturesTest.php
+++ b/tests/PHP82/Php82LanguageFeaturesTest.php
@@ -26,6 +26,23 @@ class Php82LanguageFeaturesTest extends MockeryTestCase
 
         $this->assertSame('bar', $class->foo);
     }
+    public function testCanMockReservedWordFalse()
+    {
+        $mock = mock(HasReservedWordFalse::class);
+
+        $mock->expects('testFalseMethod')->once();
+
+        self::assertFalse($mock->testFalseMethod());
+        self::assertInstanceOf(HasReservedWordFalse::class, $mock);
+    }
+}
+
+class HasReservedWordFalse
+{
+    public function testFalseMethod(): false
+    {
+        return false;
+    }
 }
 
 class HasNullReturnType


### PR DESCRIPTION
This pull request introduces support for [Literal Types](https://www.php.net/manual/en/language.types.literal.php) in PHP 8.2, specifically focusing on the `false` literal type.
