### PR TITLE
Add `IsSame` Argument Matcher

### DIFF
--- a/library/Mockery/Matcher/IsSame.php
+++ b/library/Mockery/Matcher/IsSame.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Mockery\Matcher;
+
+class IsSame extends MatcherAbstract
+{
+    /**
+     * Check if the actual value matches the expected.
+     *
+     * @param mixed $actual
+     * @return bool
+     */
+    public function match(&$actual)
+    {
+        return $this->_expected === $actual;
+    }
+
+    /**
+     * Return a string representation of this Matcher
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return '<IsSame>';
+    }
+}

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.9.0@8b9ad1eb9e8b7d3101f949291da2b9f7767cd163">
+<files psalm-version="5.12.0@f90118cdeacd0088e7215e64c0c99ceca819e176">
   <file src="library/Mockery.php">
     <ArgumentTypeCoercion>
       <code>$expectation</code>
@@ -55,7 +55,6 @@
       <code>$expectations</code>
       <code>$fileName</code>
       <code>$formatter($object, $nesting)</code>
-      <code>$fqn</code>
       <code>$fqn</code>
       <code>$n</code>
       <code>$nesting</code>
@@ -1094,7 +1093,6 @@
       <code>$alias</code>
       <code><![CDATA[$class->getMethods()]]></code>
       <code>$className</code>
-      <code>$className</code>
       <code><![CDATA[$method->getName()]]></code>
       <code><![CDATA[$method->getName()]]></code>
       <code>$methods</code>
@@ -1546,7 +1544,6 @@
   <file src="library/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php">
     <InvalidCast>
       <code>$param</code>
-      <code>$param</code>
     </InvalidCast>
     <InvalidMethodCall>
       <code>getName</code>
@@ -1634,6 +1631,9 @@
     <PossiblyFalseArgument>
       <code>$lastBrace</code>
     </PossiblyFalseArgument>
+    <TypeDoesNotContainType>
+      <code><![CDATA[strpos($param, '&') !== false]]></code>
+    </TypeDoesNotContainType>
   </file>
   <file src="library/Mockery/Generator/StringManipulation/Pass/Pass.php">
     <MissingParamType>
@@ -2042,6 +2042,14 @@
       <code>$actual</code>
     </MixedArgument>
   </file>
+  <file src="library/Mockery/Matcher/IsSame.php">
+    <MethodSignatureMustProvideReturnType>
+      <code>__toString</code>
+    </MethodSignatureMustProvideReturnType>
+    <UnusedClass>
+      <code>IsSame</code>
+    </UnusedClass>
+  </file>
   <file src="library/Mockery/Matcher/MatcherAbstract.php">
     <MethodSignatureMustProvideReturnType>
       <code>__toString</code>
@@ -2361,14 +2369,6 @@
     <InvalidArgument>
       <code>$declaringClass</code>
     </InvalidArgument>
-    <InvalidReturnStatement>
-      <code><![CDATA[[
-                [
-                    'typeHint' => $typeHint,
-                    'isPrimitive' => in_array($typeHint, ['array', 'bool', 'int', 'float', 'null', 'object', 'string']),
-                ],
-            ]]]></code>
-    </InvalidReturnStatement>
     <LessSpecificReturnType>
       <code>string|null</code>
     </LessSpecificReturnType>
@@ -2381,9 +2381,15 @@
     <MixedAssignment>
       <code>$typeHint</code>
     </MixedAssignment>
-    <MoreSpecificReturnType>
+    <MixedReturnTypeCoercion>
+      <code><![CDATA[[
+                [
+                    'typeHint' => $typeHint,
+                    'isPrimitive' => in_array($typeHint, ['array', 'bool', 'int', 'float', 'null', 'object', 'string']),
+                ],
+            ]]]></code>
       <code><![CDATA[list<array{typeHint: string, isPrimitive: bool}>]]></code>
-    </MoreSpecificReturnType>
+    </MixedReturnTypeCoercion>
     <PossiblyNullArgument>
       <code>$declaringClass</code>
       <code>$typeHint</code>

--- a/tests/Mockery/Matcher/IsSameTest.php
+++ b/tests/Mockery/Matcher/IsSameTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace test\Mockery\Matcher;
+
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Mockery\Matcher\IsSame;
+
+class IsSameTest extends MockeryTestCase
+{
+    use MatcherDataProviderTrait;
+
+    /** @dataProvider isSameDataProvider */
+    public function testItWorks(mixed $expected, mixed $actual)
+    {
+        self::assertTrue((new IsSame($expected))->match($actual));
+    }
+}

--- a/tests/Mockery/Matcher/IsSameTest.php
+++ b/tests/Mockery/Matcher/IsSameTest.php
@@ -10,7 +10,7 @@ class IsSameTest extends MockeryTestCase
     use MatcherDataProviderTrait;
 
     /** @dataProvider isSameDataProvider */
-    public function testItWorks(mixed $expected, mixed $actual)
+    public function testItWorks($expected, $actual)
     {
         self::assertTrue((new IsSame($expected))->match($actual));
     }

--- a/tests/Mockery/Matcher/MatcherDataProviderTrait.php
+++ b/tests/Mockery/Matcher/MatcherDataProviderTrait.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace test\Mockery\Matcher;
+
+use stdClass;
+
+trait MatcherDataProviderTrait
+{
+    public static function isSameDataProvider(): iterable
+    {
+        $object = new stdClass();
+
+        return [
+            'string' => ['#BlackLivesMatter', '#BlackLivesMatter'],
+            'bool-true' => [true, true],
+            'bool-false' => [false, false],
+            'int' => [42, 42],
+            'float' => [2.0, 2.0],
+            'null' => [null, null],
+            'object' => [$object, $object],
+        ];
+    }
+}


### PR DESCRIPTION
This pr adds an `IsSame` [Argument Matcher](http://docs.mockery.io/en/latest/reference/argument_validation.html#additional-argument-matchers)