### PR TITLE
Add `IsEqual` Argument Matcher

### DIFF
--- a/library/Mockery/Matcher/IsEqual.php
+++ b/library/Mockery/Matcher/IsEqual.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Mockery\Matcher;
+
+class IsEqual extends MatcherAbstract
+{
+    /**
+     * Check if the actual value matches the expected.
+     *
+     * @param mixed $actual
+     * @return bool
+     */
+    public function match(&$actual)
+    {
+        return $this->_expected == $actual;
+    }
+
+    /**
+     * Return a string representation of this Matcher
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return '<IsEqual>';
+    }
+}

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2042,6 +2042,14 @@
       <code>$actual</code>
     </MixedArgument>
   </file>
+  <file src="library/Mockery/Matcher/IsEqual.php">
+    <MethodSignatureMustProvideReturnType>
+      <code>__toString</code>
+    </MethodSignatureMustProvideReturnType>
+    <UnusedClass>
+      <code>IsEqual</code>
+    </UnusedClass>
+  </file>
   <file src="library/Mockery/Matcher/IsSame.php">
     <MethodSignatureMustProvideReturnType>
       <code>__toString</code>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -13,6 +13,7 @@
     <projectFiles>
         <directory name="library"/>
         <ignoreFiles>
+            <directory name="tests"/>
             <directory name="vendor"/>
         </ignoreFiles>
     </projectFiles>

--- a/tests/Mockery/Matcher/IsEqualTest.php
+++ b/tests/Mockery/Matcher/IsEqualTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace test\Mockery\Matcher;
+
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Mockery\Matcher\IsEqual;
+
+class IsEqualTest extends MockeryTestCase
+{
+    use MatcherDataProviderTrait;
+
+    /** @dataProvider isEqualDataProvider */
+    public function testItWorks($expected, $actual)
+    {
+        self::assertTrue((new IsEqual($expected))->match($actual));
+    }
+}

--- a/tests/Mockery/Matcher/MatcherDataProviderTrait.php
+++ b/tests/Mockery/Matcher/MatcherDataProviderTrait.php
@@ -6,6 +6,25 @@ use stdClass;
 
 trait MatcherDataProviderTrait
 {
+    public static function isEqualDataProvider(): iterable
+    {
+        yield from self::isSameDataProvider();
+
+        yield from [
+            'bool-int-1' => [true, 1],
+            'bool-int-0' => [false, 0],
+            'bool-float-1' => [true, 1.0],
+            'bool-float-0' => [false, 0.0],
+            'int-string' => [42, '42'],
+            'int-float' => [42, 42.0],
+            'float-int' => [42.0, 42],
+            'int-string-float' => [42, '42.0'],
+            'float-string-int' => [42.0, '42'],
+            'null-empty-string' => [null, ''],
+            'object-different' => [new stdClass(), new stdClass()],
+        ];
+    }
+
     public static function isSameDataProvider(): iterable
     {
         $object = new stdClass();


### PR DESCRIPTION
This pr adds an `IsEqual` [Argument Matcher](http://docs.mockery.io/en/latest/reference/argument_validation.html#additional-argument-matchers)


Resolves #1268 