### PR TITLE
Correct return types of Mock for phpstan

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1914,8 +1914,8 @@
       <code>shouldNotReceive</code>
     </PossiblyUnusedMethod>
     <PossiblyUnusedReturnValue>
-      <code>Mock</code>
       <code>\Mockery\ExpectationDirector|null</code>
+      <code>static</code>
     </PossiblyUnusedReturnValue>
     <UndefinedDocblockClass>
       <code>null|array|Closure</code>

--- a/src/Mockery/LegacyMockInterface.php
+++ b/src/Mockery/LegacyMockInterface.php
@@ -47,12 +47,12 @@ interface LegacyMockInterface
     /**
      * Set mock to ignore unexpected methods and return Undefined class
      * @param mixed $returnValue the default return value for calls to missing functions on this mock
-     * @return $this
+     * @return static
      */
     public function shouldIgnoreMissing($returnValue = null);
 
     /**
-     * @return $this
+     * @return static
      */
     public function shouldAllowMockingProtectedMethods();
 
@@ -61,14 +61,14 @@ interface LegacyMockInterface
      *
      * @deprecated since 1.4.0. Please use makePartial() instead.
      *
-     * @return $this
+     * @return static
      */
     public function shouldDeferMissing();
 
     /**
      * Set mock to defer unexpected methods to its parent if possible
      *
-     * @return $this
+     * @return static
      */
     public function makePartial();
 

--- a/src/Mockery/LegacyMockInterface.php
+++ b/src/Mockery/LegacyMockInterface.php
@@ -47,12 +47,12 @@ interface LegacyMockInterface
     /**
      * Set mock to ignore unexpected methods and return Undefined class
      * @param mixed $returnValue the default return value for calls to missing functions on this mock
-     * @return Mock
+     * @return $this
      */
     public function shouldIgnoreMissing($returnValue = null);
 
     /**
-     * @return Mock
+     * @return $this
      */
     public function shouldAllowMockingProtectedMethods();
 
@@ -61,14 +61,14 @@ interface LegacyMockInterface
      *
      * @deprecated since 1.4.0. Please use makePartial() instead.
      *
-     * @return Mock
+     * @return $this
      */
     public function shouldDeferMissing();
 
     /**
      * Set mock to defer unexpected methods to its parent if possible
      *
-     * @return Mock
+     * @return $this
      */
     public function makePartial();
 

--- a/src/Mockery/Mock.php
+++ b/src/Mockery/Mock.php
@@ -308,7 +308,7 @@ class Mock implements MockInterface
      * Set mock to ignore unexpected methods and return Undefined class
      * @param mixed $returnValue the default return value for calls to missing functions on this mock
      * @param bool $recursive Specify if returned mocks should also have shouldIgnoreMissing set
-     * @return Mock
+     * @return $this
      */
     public function shouldIgnoreMissing($returnValue = null, $recursive = false)
     {
@@ -326,7 +326,7 @@ class Mock implements MockInterface
     }
 
     /**
-     * @return Mock
+     * @return $this
      */
     public function shouldAllowMockingProtectedMethods()
     {
@@ -351,7 +351,7 @@ class Mock implements MockInterface
      *
      * @deprecated 2.0.0 Please use makePartial() instead
      *
-     * @return Mock
+     * @return $this
      */
     public function shouldDeferMissing()
     {
@@ -364,7 +364,7 @@ class Mock implements MockInterface
      * It was an alias for shouldDeferMissing(), which will be removed
      * in 2.0.0.
      *
-     * @return Mock
+     * @return $this
      */
     public function makePartial()
     {

--- a/src/Mockery/Mock.php
+++ b/src/Mockery/Mock.php
@@ -308,7 +308,7 @@ class Mock implements MockInterface
      * Set mock to ignore unexpected methods and return Undefined class
      * @param mixed $returnValue the default return value for calls to missing functions on this mock
      * @param bool $recursive Specify if returned mocks should also have shouldIgnoreMissing set
-     * @return $this
+     * @return static
      */
     public function shouldIgnoreMissing($returnValue = null, $recursive = false)
     {
@@ -326,7 +326,7 @@ class Mock implements MockInterface
     }
 
     /**
-     * @return $this
+     * @return static
      */
     public function shouldAllowMockingProtectedMethods()
     {
@@ -351,7 +351,7 @@ class Mock implements MockInterface
      *
      * @deprecated 2.0.0 Please use makePartial() instead
      *
-     * @return $this
+     * @return static
      */
     public function shouldDeferMissing()
     {
@@ -364,7 +364,7 @@ class Mock implements MockInterface
      * It was an alias for shouldDeferMissing(), which will be removed
      * in 2.0.0.
      *
-     * @return $this
+     * @return static
      */
     public function makePartial()
     {


### PR DESCRIPTION
This PR should fix old problem when phpstan stop working correctly with Mockery when you do something like `$mock = Mockery::mock(SomeClass::class)->shouldIgnoreMissing();`