### PR TITLE
Update `Makefile` for contributors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,17 +15,29 @@ phpDocumentor.phar:
 	wget https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.3.1/phpDocumentor.phar
 	wget https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.3.1/phpDocumentor.phar.asc
 
-library_files=$(shell find library -name '*.php')
+library_files=$(shell find src -name '*.php')
 docs/api/index.html: vendor/composer/installed.json $(library_files) phpDocumentor.phar
-	php phpDocumentor.phar run -d library -t docs/api
+	docker run -it --rm -v $$PWD:/opt/mockery -w /opt/mockery ghcr.io/ghostwriter/php:8.1-pcov php phpDocumentor.phar run -d src -t docs/api
 
 .PHONY: test-all
-test-all: test-74 test-73
+test-all: test-83 test-82 test-81 test-80 test-74
 
 .PHONY: test-74
 test-74: deps
-	docker run -it --rm -v "$$PWD":/opt/mockery -w /opt/mockery php:7.4-cli php vendor/bin/phpunit
+	docker run -it --rm -v $$PWD:/opt/mockery -w /opt/mockery ghcr.io/ghostwriter/php:7.4-pcov php vendor/bin/phpunit
 
-.PHONY: test-73
-test-73: deps
-	docker run -it --rm -v "$$PWD":/opt/mockery -w /opt/mockery php:7.3-cli php vendor/bin/phpunit
+.PHONY: test-80
+test-80: deps
+	docker run -it --rm -v $$PWD:/opt/mockery -w /opt/mockery ghcr.io/ghostwriter/php:8.0-pcov php vendor/bin/phpunit
+
+.PHONY: test-81
+test-81: deps
+	docker run -it --rm -v $$PWD:/opt/mockery -w /opt/mockery ghcr.io/ghostwriter/php:8.1-pcov php vendor/bin/phpunit
+
+.PHONY: test-82
+test-82: deps
+	docker run -it --rm -v $$PWD:/opt/mockery -w /opt/mockery ghcr.io/ghostwriter/php:8.2-pcov php vendor/bin/phpunit
+
+.PHONY: test-83
+test-83: deps
+	docker run -it --rm -v $$PWD:/opt/mockery -w /opt/mockery ghcr.io/ghostwriter/php:8.3-rc-pcov php vendor/bin/phpunit

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,9 @@ test: deps
 .PHONY: apidocs
 apidocs: docs/api/index.html
 
-phpDocumentor.phar: 
-	wget https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.0.0/phpDocumentor.phar
-	wget https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.0.0/phpDocumentor.phar.asc
+phpDocumentor.phar:
+	wget https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.3.1/phpDocumentor.phar
+	wget https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.3.1/phpDocumentor.phar.asc
 
 library_files=$(shell find library -name '*.php')
 docs/api/index.html: vendor/composer/installed.json $(library_files) phpDocumentor.phar


### PR DESCRIPTION
This patch updates the makefile to update the docker images and commands we use for development.

- Run PHPUnit on PHP 7.4 -8.3 via `make test-all`