### PR TITLE
Fix mocking classes with `new` initializers in method and attribute params on PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
     },
     "autoload-dev": {
         "psr-4": {
+            "Fixture\\": "tests/Fixture/",
             "test\\": "tests/"
         },
         "files": [

--- a/composer.lock
+++ b/composer.lock
@@ -1279,16 +1279,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.22.0",
+            "version": "1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "ec58baf7b3c7f1c81b3b00617c953249fb8cf30c"
+                "reference": "65c39594fbd8c67abfc68bb323f86447bab79cc0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/ec58baf7b3c7f1c81b3b00617c953249fb8cf30c",
-                "reference": "ec58baf7b3c7f1c81b3b00617c953249fb8cf30c",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/65c39594fbd8c67abfc68bb323f86447bab79cc0",
+                "reference": "65c39594fbd8c67abfc68bb323f86447bab79cc0",
                 "shasum": ""
             },
             "require": {
@@ -1320,9 +1320,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.22.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.22.1"
             },
-            "time": "2023-06-01T12:35:21+00:00"
+            "time": "2023-06-29T20:46:06+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1644,16 +1644,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.9",
+            "version": "9.6.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a9aceaf20a682aeacf28d582654a1670d8826778"
+                "reference": "a6d351645c3fe5a30f5e86be6577d946af65a328"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a9aceaf20a682aeacf28d582654a1670d8826778",
-                "reference": "a9aceaf20a682aeacf28d582654a1670d8826778",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a6d351645c3fe5a30f5e86be6577d946af65a328",
+                "reference": "a6d351645c3fe5a30f5e86be6577d946af65a328",
                 "shasum": ""
             },
             "require": {
@@ -1727,7 +1727,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.9"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.10"
             },
             "funding": [
                 {
@@ -1743,7 +1743,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-11T06:13:56+00:00"
+            "time": "2023-07-10T04:04:23+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1575,6 +1575,7 @@
       <code><![CDATA[$method->getParameters()]]></code>
       <code><![CDATA[$overrides[$class_name][$method->getName()]]]></code>
       <code><![CDATA[$overrides[strtolower($class->getName())][$method->getName()]]]></code>
+      <code><![CDATA[$param->__toString()]]></code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code>$param</code>

--- a/src/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php
+++ b/src/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php
@@ -73,9 +73,7 @@ class MethodDefinitionPass implements Pass
                         if ($isPhp81) {
                             if (enum_exists($prefix)) {
                                 $prefix = var_export($defaultValue, true);
-                            }
-
-                            else if (
+                            } elseif (
                                 !$param->isDefaultValueConstant() &&
                                 // "Parameter #1 [ <optional> F\Q\CN $a = new \F\Q\CN(param1, param2: 2) ]
                                 preg_match(

--- a/src/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php
+++ b/src/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php
@@ -77,7 +77,7 @@ class MethodDefinitionPass implements Pass
                                 !$param->isDefaultValueConstant() &&
                                 // "Parameter #1 [ <optional> F\Q\CN $a = new \F\Q\CN(param1, param2: 2) ]
                                 preg_match(
-                                    '/<optional>\s.*?\s=\snew\s(.*?)\s]/',
+                                    '#<optional>\s.*?\s=\snew\s(.*?)\s]$#',
                                     $param->__toString(),
                                     $matches
                                 ) === 1

--- a/src/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php
+++ b/src/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php
@@ -70,8 +70,22 @@ class MethodDefinitionPass implements Pass
 
                     if (is_object($defaultValue)) {
                         $prefix = get_class($defaultValue);
-                        if ($isPhp81 && enum_exists($prefix)) {
-                            $prefix = var_export($defaultValue, true);
+                        if ($isPhp81) {
+                            if (enum_exists($prefix)) {
+                                $prefix = var_export($defaultValue, true);
+                            }
+
+                            else if (
+                                !$param->isDefaultValueConstant() &&
+                                // "Parameter #1 [ <optional> F\Q\CN $a = new \F\Q\CN(param1, param2: 2) ]
+                                preg_match(
+                                    '/<optional>\s.*?\s=\snew\s(.*?)\s]/',
+                                    $param->__toString(),
+                                    $matches
+                                ) === 1
+                            ) {
+                                $prefix = 'new ' . $matches[1];
+                            }
                         }
                     } else {
                         $prefix = var_export($defaultValue, true);
@@ -158,7 +172,7 @@ BODY;
 
         $body .= "\$ret = {$invoke}(__FUNCTION__, \$argv);\n";
 
-        if (! in_array($method->getReturnType(), ['never','void'], true)) {
+        if (! in_array($method->getReturnType(), ['never', 'void'], true)) {
             $body .= "return \$ret;\n";
         }
 

--- a/tests/Fixture/PHP81/A.php
+++ b/tests/Fixture/PHP81/A.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixture\PHP81;
+
+class A
+{
+    public function __construct(
+        private int $x = 1
+    ) {
+    }
+
+    function test() : int {
+        return $this->x;
+    }
+}

--- a/tests/Fixture/PHP81/A.php
+++ b/tests/Fixture/PHP81/A.php
@@ -11,7 +11,8 @@ class A
     ) {
     }
 
-    function test() : int {
+    public function test(): int
+    {
         return $this->x;
     }
 }

--- a/tests/Fixture/PHP81/B.php
+++ b/tests/Fixture/PHP81/B.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixture\PHP81;
+
+class B
+{
+    public function __construct(
+        private int $x
+    ) {
+    }
+
+    function test() : int {
+        return $this->x;
+    }
+}

--- a/tests/Fixture/PHP81/B.php
+++ b/tests/Fixture/PHP81/B.php
@@ -11,7 +11,8 @@ class B
     ) {
     }
 
-    function test() : int {
+    public function test(): int
+    {
         return $this->x;
     }
 }

--- a/tests/Fixture/PHP81/C.php
+++ b/tests/Fixture/PHP81/C.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixture\PHP81;
+
+class C
+{
+    public function __construct(
+        private int $x = 1,
+        private B $b = new B(1)
+    ) {
+    }
+
+    function test() : int {
+        return $this->x + $this->b->test();
+    }
+}

--- a/tests/Fixture/PHP81/C.php
+++ b/tests/Fixture/PHP81/C.php
@@ -12,7 +12,8 @@ class C
     ) {
     }
 
-    function test() : int {
+    public function test(): int
+    {
         return $this->x + $this->b->test();
     }
 }

--- a/tests/Fixture/PHP81/HandlerClass.php
+++ b/tests/Fixture/PHP81/HandlerClass.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixture\PHP81;
+
+class HandlerClass
+{
+    public function doStuff(MockClass $mockClass): string
+    {
+        return $mockClass->test('test');
+    }
+}

--- a/tests/Fixture/PHP81/MockClass.php
+++ b/tests/Fixture/PHP81/MockClass.php
@@ -8,6 +8,14 @@ use DateTime;
 
 class MockClass
 {
+    public function __construct(
+        public A $a = new A(),
+        protected B $b = new B(1),
+        private C $c = new C(b: new B(1), x: 2),
+        public DateTime $dateTime = new DateTime(),
+    ) {
+    }
+
     public function test(
         string $msg,
         A $a = new A(),

--- a/tests/Fixture/PHP81/MockClass.php
+++ b/tests/Fixture/PHP81/MockClass.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixture\PHP81;
+
+use DateTime;
+
+class MockClass
+{
+    public function test(
+        string $msg,
+        A $a = new A(),
+        B $b = new B(1),
+        C $c = new C(x: 2),
+        DateTime $dateTime = new DateTime(),
+    ): string {
+        return $msg . ' - ' . $a->test() . ' - ' . $b->test() . ' - ' . $c->test() . ' - ' . $dateTime->format('Y-m-d');
+    }
+}

--- a/tests/Fixture/PHP81/MockClass.php
+++ b/tests/Fixture/PHP81/MockClass.php
@@ -18,6 +18,7 @@ class MockClass
 
     public function test(
         string $msg,
+        #[SomeAttribute(param: new A())]
         A $a = new A(),
         B $b = new B(1),
         C $c = new C(x: 2),

--- a/tests/Fixture/PHP81/SomeAttribute.php
+++ b/tests/Fixture/PHP81/SomeAttribute.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixture\PHP81;
+
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+class SomeAttribute {
+    public function __construct(
+        public object $param = new stdClass()
+    ) {
+    }
+}

--- a/tests/Fixture/PHP81/SomeAttribute.php
+++ b/tests/Fixture/PHP81/SomeAttribute.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Fixture\PHP81;
 
 #[\Attribute(\Attribute::TARGET_PARAMETER)]
-class SomeAttribute {
+class SomeAttribute
+{
     public function __construct(
         public object $param = new stdClass()
     ) {

--- a/tests/Unit/PHP81/Php81LanguageFeaturesTest.php
+++ b/tests/Unit/PHP81/Php81LanguageFeaturesTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace test\Unit\PHP81;
+
+use Fixture\PHP81\HandlerClass;
+use Fixture\PHP81\MockClass;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+/**
+ * @requires PHP 8.1.0-dev
+ */
+class Php81LanguageFeaturesTest extends MockeryTestCase
+{
+    public function testNewInitializerExpression()
+    {
+        $class = mock(MockClass::class)
+            ->expects('test')
+            ->with('test')
+            ->andReturn('it works')
+            ->getMock();
+
+        self::assertSame('it works', (new HandlerClass())->doStuff($class));
+    }
+}


### PR DESCRIPTION
Resolves #1300 