### PR TITLE
Remove `extra.branch-alias` and update composer information

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,12 @@
             "email": "dave.marshall@atstsolutions.co.uk",
             "homepage": "https://davedevelopment.co.uk",
             "role": "Developer"
+        },
+        {
+            "name": "Nathanael Esayeas",
+            "email": "nathanael.esayeas@protonmail.com",
+            "homepage": "https://github.com/ghostwriter",
+            "role": "Lead Developer"
         }
     ],
     "homepage": "https://github.com/mockery/mockery",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         {
             "name": "Dave Marshall",
             "email": "dave.marshall@atstsolutions.co.uk",
-            "homepage": "http://davedevelopment.co.uk"
+            "homepage": "https://davedevelopment.co.uk",
+            "role": "Developer"
         }
     ],
     "homepage": "https://github.com/mockery/mockery",

--- a/composer.json
+++ b/composer.json
@@ -75,15 +75,12 @@
         ]
     },
     "config": {
-        "preferred-install": "dist",
+        "optimize-autoloader": true,
         "platform": {
             "php": "7.4.999"
-        }
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-main": "1.6.x-dev"
-        }
+        },
+        "preferred-install": "dist",
+        "sort-packages": true
     },
     "scripts": {
         "check": [

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "mockery/mockery",
     "description": "Mockery is a simple yet flexible PHP mock object framework",
     "license": "BSD-3-Clause",
+    "type": "library",
     "keywords": [
         "bdd",
         "library",
@@ -35,6 +36,13 @@
         }
     ],
     "homepage": "https://github.com/mockery/mockery",
+    "support": {
+        "issues": "https://github.com/mockery/mockery/issues",
+        "source": "https://github.com/mockery/mockery",
+        "docs": "https://docs.mockery.io/",
+        "rss": "https://github.com/mockery/mockery/releases.atom",
+        "security": "https://github.com/mockery/mockery/security/advisories"
+    },
     "require": {
         "php": ">=7.4,<8.3",
         "lib-pcre": ">=7.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         {
             "name": "Pádraic Brady",
             "email": "padraic.brady@gmail.com",
-            "homepage": "http://blog.astrumfutura.com"
+            "homepage": "https://github.com/padraic",
+            "role": "Author"
         },
         {
             "name": "Dave Marshall",


### PR DESCRIPTION
This pull request proposes an update to the composer.json file in order to update composer information and remove the `extra.branch-alias` section.

### Changes Made

- Removed the `extra.branch-alias` section as branch aliases are no longer maintained. We now have dedicated release branches for each major and minor version. (eg. `1.6.x-dev` and `2.0.x-dev`)
- Replaced dead links with GitHub profile links.
- Added and updated authors with their respective roles.
- Added support links and information to help users find resources and get assistance.


