### PR TITLE
Fix compatibility issues with PHP 7.3

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -21,6 +21,8 @@ body:
       description: What version of PHP do you have installed?
       multiple: true
       options:
+        - PHP 7.3
+        - PHP 7.4
         - PHP 8.0
         - PHP 8.1
         - PHP 8.2

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -25,8 +25,29 @@ jobs:
           tools: composer:v2
           extensions: mongodb, redis
 
-      - name: Install locked dependencies
-        uses: ramsey/composer-install@v2
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        working-directory: ${{ github.workspace }}
+        run: |
+          composerCommand="install"
+          composerOptions=("--no-interaction" "--no-progress" "--ansi")
+          # Use `update` if there is no composer.lock file
+          if [ ! -f "composer.lock" ]; then
+            composerCommand="update"
+          fi
+          fullCommand="composer ${composerCommand} ${composerOptions[*]}"
+          echo "Running: ${fullCommand}"
+          ${fullCommand}
 
       - name: Run PHPUnit to collect coverage
         run: composer phpunit:coverage

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up php
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 7.3
           coverage: pcov
           ini-values: assert.exception=1, zend.assertions=1, error_reporting=-1, log_errors_max_len=0, display_errors=On
 

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -27,8 +27,29 @@ jobs:
           coverage: pcov
           ini-values: assert.exception=1, zend.assertions=1, error_reporting=-1, log_errors_max_len=0, display_errors=On
 
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
       - name: Install dependencies
-        uses: ramsey/composer-install@v2
+        working-directory: ${{ github.workspace }}
+        run: |
+          composerCommand="install"
+          composerOptions=("--no-interaction" "--no-progress" "--ansi")
+          # Use `update` if there is no composer.lock file
+          if [ ! -f "composer.lock" ]; then
+            composerCommand="update"
+          fi
+          fullCommand="composer ${composerCommand} ${composerOptions[*]}"
+          echo "Running: ${fullCommand}"
+          ${fullCommand}
 
       - name: Run Psalm
         run: composer psalm

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,10 +40,35 @@ jobs:
       - name: Setup Problem Matchers
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-      - name: Install ${{ matrix.dependencies }} Dependencies
-        uses: ramsey/composer-install@v2
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
         with:
-          dependency-versions: ${{ matrix.dependencies }}
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ matrix.dependencies }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ matrix.dependencies }}-
+
+      - name: Install ${{ matrix.dependencies }} dependencies
+        working-directory: ${{ github.workspace }}
+        run: |
+          composerDependency="${{ matrix.dependencies }}"
+          composerCommand="update"
+          composerOptions=("--no-interaction" "--no-progress" "--ansi")
+          case ${composerDependency} in
+              highest) composerCommand="update" ;;
+              lowest) composerOptions+=("--prefer-lowest" "--prefer-stable") ;;
+              *) composerCommand="install" ;;
+          esac
+          # Use `update` if there is no composer.lock file
+          if [ ! -f "composer.lock" ]; then
+            composerCommand="update"
+          fi
+          fullCommand="composer ${composerCommand} ${composerOptions[*]}"
+          echo "Running: ${fullCommand}"
+          ${fullCommand}
 
       - name: Execute PHPUnit
         run: composer phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         dependencies: ['lowest','highest','locked']
         dev: ['8.3']
 
-    continue-on-error: ${{ matrix.php == matrix.dev }}
+    continue-on-error: ${{ matrix.php == matrix.dev || matrix.dependencies == 'lowest' }}
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.4', '8.0', '8.1', '8.2', '8.3']
+        php: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
         dependencies: ['lowest','highest','locked']
         dev: ['8.3']
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,11 @@ docs/api/index.html: vendor/composer/installed.json $(library_files) phpDocument
 	docker run -it --rm -v $$PWD:/opt/mockery -w /opt/mockery ghcr.io/ghostwriter/php:8.1-pcov php phpDocumentor.phar run -d src -t docs/api
 
 .PHONY: test-all
-test-all: test-83 test-82 test-81 test-80 test-74
+test-all: test-83 test-82 test-81 test-80 test-74 test-73
+
+.PHONY: test-73
+test-73: deps
+	docker run -it --rm -v $$PWD:/opt/mockery -w /opt/mockery ghcr.io/ghostwriter/php:7.3-pcov php vendor/bin/phpunit
 
 .PHONY: test-74
 test-74: deps

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "security": "https://github.com/mockery/mockery/security/advisories"
     },
     "require": {
-        "php": ">=7.3,<8.3",
+        "php": ">=7.3",
         "lib-pcre": ">=7.0",
         "hamcrest/hamcrest-php": "^2.0.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -44,15 +44,15 @@
         "security": "https://github.com/mockery/mockery/security/advisories"
     },
     "require": {
-        "php": ">=7.4,<8.3",
+        "php": ">=7.3,<8.3",
         "lib-pcre": ">=7.0",
         "hamcrest/hamcrest-php": "^2.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5 || ^9.3",
+        "phpunit/phpunit": "^8.5 || ^9.6.10",
         "psalm/plugin-phpunit": "^0.18.4",
         "symplify/easy-coding-standard": "^11.5.0",
-        "vimeo/psalm": "^5.13.1"
+        "vimeo/psalm": "^4.30"
     },
     "conflict": {
         "phpunit/phpunit": "<8.0"
@@ -79,7 +79,7 @@
     "config": {
         "optimize-autoloader": true,
         "platform": {
-            "php": "7.4.999"
+            "php": "7.3.999"
         },
         "preferred-install": "dist",
         "sort-packages": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3c3d3c4b74273c2b99fe77857fd1d6d6",
+    "content-hash": "c8b16ca187738b4ab915e497ee5ae8a4",
     "packages": [
         {
             "name": "hamcrest/hamcrest-php",
@@ -3917,7 +3917,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.3,<8.3",
+        "php": ">=7.3",
         "lib-pcre": ">=7.0"
     },
     "platform-dev": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7bd77f1dc711b159671cf644501c6594",
+    "content-hash": "3c3d3c4b74273c2b99fe77857fd1d6d6",
     "packages": [
         {
             "name": "hamcrest/hamcrest-php",
@@ -300,20 +300,20 @@
         },
         {
             "name": "composer/pcre",
-            "version": "3.1.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "4bff79ddd77851fe3cdd11616ed3f92841ba5bd2"
+                "reference": "3fdb2807b31a78a40ad89570e30ec77466c98717"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/4bff79ddd77851fe3cdd11616ed3f92841ba5bd2",
-                "reference": "4bff79ddd77851fe3cdd11616ed3f92841ba5bd2",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/3fdb2807b31a78a40ad89570e30ec77466c98717",
+                "reference": "3fdb2807b31a78a40ad89570e30ec77466c98717",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4 || ^8.0"
+                "php": "^7.2 || ^8.0"
             },
             "require-dev": {
                 "phpstan/phpstan": "^1.3",
@@ -323,7 +323,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.x-dev"
+                    "dev-main": "2.x-dev"
                 }
             },
             "autoload": {
@@ -351,7 +351,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.1.0"
+                "source": "https://github.com/composer/pcre/tree/2.1.0"
             },
             "funding": [
                 {
@@ -367,7 +367,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-17T09:50:14+00:00"
+            "time": "2022-11-16T18:32:04+00:00"
         },
         {
             "name": "composer/semver",
@@ -554,53 +554,6 @@
             "time": "2019-12-04T15:06:13+00:00"
         },
         {
-            "name": "doctrine/deprecations",
-            "version": "v1.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "612a3ee5ab0d5dd97b7cf3874a6efe24325efac3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/612a3ee5ab0d5dd97b7cf3874a6efe24325efac3",
-                "reference": "612a3ee5ab0d5dd97b7cf3874a6efe24325efac3",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^9",
-                "phpstan/phpstan": "1.4.10 || 1.10.15",
-                "phpstan/phpstan-phpunit": "^1.0",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "psalm/plugin-phpunit": "0.18.4",
-                "psr/log": "^1 || ^2 || ^3",
-                "vimeo/psalm": "4.30.0 || 5.12.0"
-            },
-            "suggest": {
-                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Deprecations\\": "lib/Doctrine/Deprecations"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
-            "homepage": "https://www.doctrine-project.org/",
-            "support": {
-                "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/v1.1.1"
-            },
-            "time": "2023-06-03T09:27:29+00:00"
-        },
-        {
             "name": "doctrine/instantiator",
             "version": "1.5.0",
             "source": {
@@ -772,67 +725,6 @@
             "time": "2022-03-02T22:36:06+00:00"
         },
         {
-            "name": "fidry/cpu-core-counter",
-            "version": "0.5.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/theofidry/cpu-core-counter.git",
-                "reference": "b58e5a3933e541dc286cc91fc4f3898bbc6f1623"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/b58e5a3933e541dc286cc91fc4f3898bbc6f1623",
-                "reference": "b58e5a3933e541dc286cc91fc4f3898bbc6f1623",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0"
-            },
-            "require-dev": {
-                "fidry/makefile": "^0.2.0",
-                "phpstan/extension-installer": "^1.2.0",
-                "phpstan/phpstan": "^1.9.2",
-                "phpstan/phpstan-deprecation-rules": "^1.0.0",
-                "phpstan/phpstan-phpunit": "^1.2.2",
-                "phpstan/phpstan-strict-rules": "^1.4.4",
-                "phpunit/phpunit": "^9.5.26 || ^8.5.31",
-                "theofidry/php-cs-fixer-config": "^1.0",
-                "webmozarts/strict-phpunit": "^7.5"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Fidry\\CpuCoreCounter\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Théo FIDRY",
-                    "email": "theo.fidry@gmail.com"
-                }
-            ],
-            "description": "Tiny utility to get the number of CPU cores.",
-            "keywords": [
-                "CPU",
-                "core"
-            ],
-            "support": {
-                "issues": "https://github.com/theofidry/cpu-core-counter/issues",
-                "source": "https://github.com/theofidry/cpu-core-counter/tree/0.5.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/theofidry",
-                    "type": "github"
-                }
-            ],
-            "time": "2022-12-24T12:35:10+00:00"
-        },
-        {
             "name": "myclabs/deep-copy",
             "version": "1.11.1",
             "source": {
@@ -997,6 +889,59 @@
                 "source": "https://github.com/nikic/PHP-Parser/tree/v4.16.0"
             },
             "time": "2023-06-25T14:52:30+00:00"
+        },
+        {
+            "name": "openlss/lib-array2xml",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nullivex/lib-array2xml.git",
+                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nullivex/lib-array2xml/zipball/a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
+                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "LSS": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Bryan Tong",
+                    "email": "bryan@nullivex.com",
+                    "homepage": "https://www.nullivex.com"
+                },
+                {
+                    "name": "Tony Butler",
+                    "email": "spudz76@gmail.com",
+                    "homepage": "https://www.nullivex.com"
+                }
+            ],
+            "description": "Array2XML conversion library credit to lalit.org",
+            "homepage": "https://www.nullivex.com",
+            "keywords": [
+                "array",
+                "array conversion",
+                "xml",
+                "xml conversion"
+            ],
+            "support": {
+                "issues": "https://github.com/nullivex/lib-array2xml/issues",
+                "source": "https://github.com/nullivex/lib-array2xml/tree/master"
+            },
+            "time": "2019-03-29T20:06:56+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1221,33 +1166,25 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.7.2",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "b2fe4d22a5426f38e014855322200b97b5362c0d"
+                "reference": "77a32518733312af16a44300404e945338981de3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/b2fe4d22a5426f38e014855322200b97b5362c0d",
-                "reference": "b2fe4d22a5426f38e014855322200b97b5362c0d",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/77a32518733312af16a44300404e945338981de3",
+                "reference": "77a32518733312af16a44300404e945338981de3",
                 "shasum": ""
             },
             "require": {
-                "doctrine/deprecations": "^1.0",
-                "php": "^7.4 || ^8.0",
-                "phpdocumentor/reflection-common": "^2.0",
-                "phpstan/phpdoc-parser": "^1.13"
+                "php": "^7.2 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0"
             },
             "require-dev": {
                 "ext-tokenizer": "*",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "^1.8",
-                "phpstan/phpstan-phpunit": "^1.1",
-                "phpunit/phpunit": "^9.5",
-                "rector/rector": "^0.13.9",
-                "vimeo/psalm": "^4.25"
+                "psalm/phar": "^4.8"
             },
             "type": "library",
             "extra": {
@@ -1273,56 +1210,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.7.2"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.1"
             },
-            "time": "2023-05-30T18:13:47+00:00"
-        },
-        {
-            "name": "phpstan/phpdoc-parser",
-            "version": "1.23.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "a2b24135c35852b348894320d47b3902a94bc494"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a2b24135c35852b348894320d47b3902a94bc494",
-                "reference": "a2b24135c35852b348894320d47b3902a94bc494",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0"
-            },
-            "require-dev": {
-                "doctrine/annotations": "^2.0",
-                "nikic/php-parser": "^4.15",
-                "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^1.5",
-                "phpstan/phpstan-phpunit": "^1.1",
-                "phpstan/phpstan-strict-rules": "^1.0",
-                "phpunit/phpunit": "^9.5",
-                "symfony/process": "^5.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "PHPStan\\PhpDocParser\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "PHPDoc parser with support for nullable, intersection and generic types",
-            "support": {
-                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.23.0"
-            },
-            "time": "2023-07-23T22:17:56+00:00"
+            "time": "2022-03-15T21:29:03+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1808,20 +1698,20 @@
         },
         {
             "name": "psr/container",
-            "version": "1.1.2",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.4.0"
+                "php": ">=7.2.0"
             },
             "type": "library",
             "autoload": {
@@ -1850,9 +1740,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.2"
+                "source": "https://github.com/php-fig/container/tree/1.1.1"
             },
-            "time": "2021-11-05T16:50:12+00:00"
+            "time": "2021-03-05T17:36:06+00:00"
         },
         {
             "name": "psr/log",
@@ -2869,81 +2759,17 @@
             "time": "2020-09-28T06:39:44+00:00"
         },
         {
-            "name": "spatie/array-to-xml",
-            "version": "2.17.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/spatie/array-to-xml.git",
-                "reference": "5cbec9c6ab17e320c58a259f0cebe88bde4a7c46"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/5cbec9c6ab17e320c58a259f0cebe88bde4a7c46",
-                "reference": "5cbec9c6ab17e320c58a259f0cebe88bde4a7c46",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "php": "^7.4|^8.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "^1.2",
-                "pestphp/pest": "^1.21",
-                "phpunit/phpunit": "^9.0",
-                "spatie/pest-plugin-snapshots": "^1.1"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Spatie\\ArrayToXml\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Freek Van der Herten",
-                    "email": "freek@spatie.be",
-                    "homepage": "https://freek.dev",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Convert an array to xml",
-            "homepage": "https://github.com/spatie/array-to-xml",
-            "keywords": [
-                "array",
-                "convert",
-                "xml"
-            ],
-            "support": {
-                "source": "https://github.com/spatie/array-to-xml/tree/2.17.1"
-            },
-            "funding": [
-                {
-                    "url": "https://spatie.be/open-source/support-us",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/spatie",
-                    "type": "github"
-                }
-            ],
-            "time": "2022-12-26T08:22:07+00:00"
-        },
-        {
             "name": "symfony/console",
-            "version": "v5.4.24",
+            "version": "v5.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "560fc3ed7a43e6d30ea94a07d77f9a60b8ed0fb8"
+                "reference": "b504a3d266ad2bb632f196c0936ef2af5ff6e273"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/560fc3ed7a43e6d30ea94a07d77f9a60b8ed0fb8",
-                "reference": "560fc3ed7a43e6d30ea94a07d77f9a60b8ed0fb8",
+                "url": "https://api.github.com/repos/symfony/console/zipball/b504a3d266ad2bb632f196c0936ef2af5ff6e273",
+                "reference": "b504a3d266ad2bb632f196c0936ef2af5ff6e273",
                 "shasum": ""
             },
             "require": {
@@ -3013,7 +2839,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.24"
+                "source": "https://github.com/symfony/console/tree/v5.4.26"
             },
             "funding": [
                 {
@@ -3029,7 +2855,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-26T05:13:16+00:00"
+            "time": "2023-07-19T20:11:33+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -3097,70 +2923,6 @@
                 }
             ],
             "time": "2022-01-02T09:53:40+00:00"
-        },
-        {
-            "name": "symfony/filesystem",
-            "version": "v5.4.25",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/filesystem.git",
-                "reference": "0ce3a62c9579a53358d3a7eb6b3dfb79789a6364"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/0ce3a62c9579a53358d3a7eb6b3dfb79789a6364",
-                "reference": "0ce3a62c9579a53358d3a7eb6b3dfb79789a6364",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.5",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-mbstring": "~1.8",
-                "symfony/polyfill-php80": "^1.16"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Filesystem\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides basic utilities for the filesystem",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.4.25"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-05-31T13:04:02+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -3739,16 +3501,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.22",
+            "version": "v5.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "8036a4c76c0dd29e60b6a7cafcacc50cf088ea62"
+                "reference": "1181fe9270e373537475e826873b5867b863883c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/8036a4c76c0dd29e60b6a7cafcacc50cf088ea62",
-                "reference": "8036a4c76c0dd29e60b6a7cafcacc50cf088ea62",
+                "url": "https://api.github.com/repos/symfony/string/zipball/1181fe9270e373537475e826873b5867b863883c",
+                "reference": "1181fe9270e373537475e826873b5867b863883c",
                 "shasum": ""
             },
             "require": {
@@ -3805,7 +3567,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.22"
+                "source": "https://github.com/symfony/string/tree/v5.4.26"
             },
             "funding": [
                 {
@@ -3821,7 +3583,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-14T06:11:53+00:00"
+            "time": "2023-06-28T12:46:07+00:00"
         },
         {
             "name": "symplify/easy-coding-standard",
@@ -3933,24 +3695,24 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "5.13.1",
+            "version": "4.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "086b94371304750d1c673315321a55d15fc59015"
+                "reference": "d0bc6e25d89f649e4f36a534f330f8bb4643dd69"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/086b94371304750d1c673315321a55d15fc59015",
-                "reference": "086b94371304750d1c673315321a55d15fc59015",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/d0bc6e25d89f649e4f36a534f330f8bb4643dd69",
+                "reference": "d0bc6e25d89f649e4f36a534f330f8bb4643dd69",
                 "shasum": ""
             },
             "require": {
                 "amphp/amp": "^2.4.2",
                 "amphp/byte-stream": "^1.5",
-                "composer-runtime-api": "^2",
+                "composer/package-versions-deprecated": "^1.8.0",
                 "composer/semver": "^1.4 || ^2.0 || ^3.0",
-                "composer/xdebug-handler": "^2.0 || ^3.0",
+                "composer/xdebug-handler": "^1.1 || ^2.0 || ^3.0",
                 "dnoegel/php-xdg-base-dir": "^0.1.1",
                 "ext-ctype": "*",
                 "ext-dom": "*",
@@ -3959,35 +3721,35 @@
                 "ext-mbstring": "*",
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
-                "felixfbecker/advanced-json-rpc": "^3.1",
-                "felixfbecker/language-server-protocol": "^1.5.2",
-                "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1",
+                "felixfbecker/advanced-json-rpc": "^3.0.3",
+                "felixfbecker/language-server-protocol": "^1.5",
                 "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-                "nikic/php-parser": "^4.14",
-                "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0",
-                "sebastian/diff": "^4.0 || ^5.0",
-                "spatie/array-to-xml": "^2.17.0 || ^3.0",
-                "symfony/console": "^4.1.6 || ^5.0 || ^6.0",
-                "symfony/filesystem": "^5.4 || ^6.0"
+                "nikic/php-parser": "^4.13",
+                "openlss/lib-array2xml": "^1.0",
+                "php": "^7.1|^8",
+                "sebastian/diff": "^3.0 || ^4.0",
+                "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0 || ^6.0",
+                "symfony/polyfill-php80": "^1.25",
+                "webmozart/path-util": "^2.3"
             },
             "provide": {
                 "psalm/psalm": "self.version"
             },
             "require-dev": {
-                "amphp/phpunit-util": "^2.0",
-                "bamarni/composer-bin-plugin": "^1.4",
-                "brianium/paratest": "^6.9",
+                "bamarni/composer-bin-plugin": "^1.2",
+                "brianium/paratest": "^4.0||^6.0",
                 "ext-curl": "*",
-                "mockery/mockery": "^1.5",
-                "nunomaduro/mock-final-classes": "^1.1",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpstan/phpdoc-parser": "^1.6",
-                "phpunit/phpunit": "^9.6",
-                "psalm/plugin-mockery": "^1.1",
-                "psalm/plugin-phpunit": "^0.18",
-                "slevomat/coding-standard": "^8.4",
-                "squizlabs/php_codesniffer": "^3.6",
-                "symfony/process": "^4.4 || ^5.0 || ^6.0"
+                "phpdocumentor/reflection-docblock": "^5",
+                "phpmyadmin/sql-parser": "5.1.0||dev-master",
+                "phpspec/prophecy": ">=1.9.0",
+                "phpstan/phpdoc-parser": "1.2.* || 1.6.4",
+                "phpunit/phpunit": "^9.0",
+                "psalm/plugin-phpunit": "^0.16",
+                "slevomat/coding-standard": "^7.0",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/process": "^4.3 || ^5.0 || ^6.0",
+                "weirdan/prophecy-shim": "^1.0 || ^2.0"
             },
             "suggest": {
                 "ext-curl": "In order to send data to shepherd",
@@ -4003,14 +3765,17 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.x-dev",
-                    "dev-4.x": "4.x-dev",
+                    "dev-master": "4.x-dev",
                     "dev-3.x": "3.x-dev",
                     "dev-2.x": "2.x-dev",
                     "dev-1.x": "1.x-dev"
                 }
             },
             "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/spl_object_id.php"
+                ],
                 "psr-4": {
                     "Psalm\\": "src/Psalm/"
                 }
@@ -4028,14 +3793,13 @@
             "keywords": [
                 "code",
                 "inspection",
-                "php",
-                "static analysis"
+                "php"
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/5.13.1"
+                "source": "https://github.com/vimeo/psalm/tree/4.30.0"
             },
-            "time": "2023-06-27T16:39:49+00:00"
+            "time": "2022-11-06T20:37:08+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -4094,6 +3858,57 @@
                 "source": "https://github.com/webmozarts/assert/tree/1.11.0"
             },
             "time": "2022-06-03T18:03:27+00:00"
+        },
+        {
+            "name": "webmozart/path-util",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/path-util.git",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/path-util/zipball/d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "webmozart/assert": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\PathUtil\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "A robust cross-platform utility for normalizing, comparing and modifying file paths.",
+            "support": {
+                "issues": "https://github.com/webmozart/path-util/issues",
+                "source": "https://github.com/webmozart/path-util/tree/2.3.0"
+            },
+            "abandoned": "symfony/filesystem",
+            "time": "2015-12-17T08:42:14+00:00"
         }
     ],
     "aliases": [],
@@ -4102,12 +3917,12 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.4,<8.3",
+        "php": ">=7.3,<8.3",
         "lib-pcre": ">=7.0"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.4.999"
+        "php": "7.3.999"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/library/Mockery/Generator/DefinedTargetClass.php
+++ b/library/Mockery/Generator/DefinedTargetClass.php
@@ -40,10 +40,17 @@ class DefinedTargetClass implements TargetClassInterface
             return [];
         }
 
-        return array_unique(['\AllowDynamicProperties', ...array_map(
-            static fn (ReflectionAttribute $attribute): string => '\\' . $attribute->getName(),
-            $this->rfc->getAttributes()
-        )]);
+        return array_unique(
+            array_merge(
+                ['\AllowDynamicProperties'],
+                array_map(
+                    static function (ReflectionAttribute $attribute): string {
+                        return '\\' . $attribute->getName();
+                    },
+                    $this->rfc->getAttributes()
+                )
+            )
+        );
     }
 
     public function getName()

--- a/library/Mockery/Reflector.php
+++ b/library/Mockery/Reflector.php
@@ -10,6 +10,8 @@
 
 namespace Mockery;
 
+use ReflectionType;
+
 /**
  * @internal
  */
@@ -64,11 +66,11 @@ class Reflector
     {
         $type = $method->getReturnType();
 
-        if (is_null($type) && method_exists($method, 'getTentativeReturnType')) {
-            $type = $method->getTentativeReturnType();
+        if (!$type instanceof ReflectionType && method_exists($method, 'getTentativeReturnType')) {
+            $type = $method->getTentativeReturnType();    
         }
 
-        if (is_null($type)) {
+        if (!$type instanceof ReflectionType) {
             return null;
         }
 
@@ -88,11 +90,11 @@ class Reflector
     {
         $type = $method->getReturnType();
 
-        if (is_null($type) && method_exists($method, 'getTentativeReturnType')) {
+        if (!$type instanceof ReflectionType && method_exists($method, 'getTentativeReturnType')) {
             $type = $method->getTentativeReturnType();
         }
 
-        if (is_null($type) || $type->allowsNull()) {
+        if (!$type instanceof ReflectionType || $type->allowsNull()) {
             return null;
         }
 
@@ -235,7 +237,9 @@ class Reflector
 
         if ($type instanceof \ReflectionIntersectionType) {
             $types = array_map(
-                fn (\ReflectionType $type) => self::getTypeFromReflectionType($type, $declaringClass),
+                static function (\ReflectionType $type) use ($declaringClass): string {
+                    return self::getTypeFromReflectionType($type, $declaringClass);
+                },
                 $type->getTypes()
             );
 
@@ -247,7 +251,9 @@ class Reflector
 
         if ($type instanceof \ReflectionUnionType) {
             $types = array_map(
-                fn (\ReflectionType $type) => self::getTypeFromReflectionType($type, $declaringClass),
+                static function (\ReflectionType $type) use ($declaringClass): string {
+                    return self::getTypeFromReflectionType($type, $declaringClass);
+                },
                 $type->getTypes()
             );
 
@@ -259,7 +265,10 @@ class Reflector
             return implode(
                 '|',
                 array_map(
-                    fn (string $type): string => strpos($type, '&') === false ? $type : sprintf('(%s)', $type),
+                    static function (string $type): string
+                    {
+                        return strpos($type, '&') === false ? $type : sprintf('(%s)', $type);
+                    },
                     $types
                 )
             );

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         bootstrap="./tests/Bootstrap.php"
-        convertErrorsToExceptions="true"
-        convertWarningsToExceptions="true"
-        convertNoticesToExceptions="true"
+        cacheResult="false"
+        forceCoversAnnotation="false"
+        stopOnFailure="true"
         convertDeprecationsToExceptions="true"
         colors="true"
         verbose="true"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,49 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.13.1@086b94371304750d1c673315321a55d15fc59015">
+<files psalm-version="4.30.0@d0bc6e25d89f649e4f36a534f330f8bb4643dd69">
   <file src="library/Mockery.php">
-    <ArgumentTypeCoercion>
+    <ArgumentTypeCoercion occurrences="2">
       <code>$expectation</code>
       <code>$expectation</code>
     </ArgumentTypeCoercion>
-    <DeprecatedClass>
+    <DeprecatedClass occurrences="2">
       <code>\Mockery\Matcher\MustBe</code>
       <code>new \Mockery\Matcher\MustBe($expected)</code>
     </DeprecatedClass>
-    <DeprecatedMethod>
+    <DeprecatedMethod occurrences="1">
       <code>\Mockery::builtInTypes()</code>
     </DeprecatedMethod>
-    <DocblockTypeContradiction>
+    <DocblockTypeContradiction occurrences="3">
       <code>is_null(self::$_config)</code>
       <code>is_null(self::$_generator)</code>
       <code>is_null(self::$_loader)</code>
     </DocblockTypeContradiction>
-    <InvalidArgument>
+    <InvalidArgument occurrences="1">
       <code>$newMockName</code>
     </InvalidArgument>
-    <LessSpecificReturnStatement>
+    <LessSpecificReturnStatement occurrences="1">
       <code>$mock</code>
     </LessSpecificReturnStatement>
-    <MissingClosureParamType>
+    <MissingClosureParamType occurrences="5">
       <code>$argument</code>
       <code>$method</code>
       <code>$n</code>
       <code>$nesting</code>
       <code>$object</code>
     </MissingClosureParamType>
-    <MissingClosureReturnType>
-      <code><![CDATA[function ($argument) use (&$reference) {]]></code>
+    <MissingClosureReturnType occurrences="4">
+      <code>function ($argument) use (&amp;$reference) {</code>
       <code>function ($method) use ($add) {</code>
       <code>function ($n) use ($mock) {</code>
       <code>function ($object, $nesting) {</code>
     </MissingClosureReturnType>
-    <MissingParamType>
+    <MissingParamType occurrences="5">
       <code>$fqn</code>
       <code>$fqn</code>
       <code>$fqn</code>
       <code>$reference</code>
       <code>$type</code>
     </MissingParamType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="6">
       <code>declareClass</code>
       <code>declareInterface</code>
       <code>declareType</code>
@@ -51,20 +51,21 @@
       <code>setGenerator</code>
       <code>setLoader</code>
     </MissingReturnType>
-    <MixedArgument>
+    <MixedArgument occurrences="8">
       <code>$expectations</code>
       <code>$fileName</code>
       <code>$formatter($object, $nesting)</code>
+      <code>$fqn</code>
       <code>$fqn</code>
       <code>$n</code>
       <code>$nesting</code>
       <code>$object</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion>
+    <MixedArgumentTypeCoercion occurrences="2">
       <code>$formattedArguments</code>
       <code>$k</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment>
+    <MixedAssignment occurrences="18">
       <code>$arg</code>
       <code>$argument</code>
       <code>$argument[$key]</code>
@@ -84,39 +85,37 @@
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedFunctionCall>
+    <MixedFunctionCall occurrences="1">
       <code>$formatter($object, $nesting)</code>
     </MixedFunctionCall>
-    <MixedInferredReturnType>
-      <code>\Mockery\ExpectationInterface</code>
+    <MixedInferredReturnType occurrences="4">
       <code>\Mockery\MockInterface|\Mockery\LegacyMockInterface</code>
       <code>\Mockery\MockInterface|\Mockery\LegacyMockInterface</code>
       <code>\Mockery\MockInterface|\Mockery\LegacyMockInterface</code>
       <code>\Mockery\MockInterface|\Mockery\LegacyMockInterface</code>
     </MixedInferredReturnType>
-    <MixedMethodCall>
+    <MixedMethodCall occurrences="3">
       <code>mockery_getExpectationsFor</code>
       <code>shouldIgnoreMissing</code>
       <code>shouldReceive</code>
     </MixedMethodCall>
-    <MixedPropertyFetch>
-      <code><![CDATA[$object->$name]]></code>
+    <MixedPropertyFetch occurrences="1">
+      <code>$object-&gt;$name</code>
     </MixedPropertyFetch>
-    <MixedReturnStatement>
+    <MixedReturnStatement occurrences="5">
       <code>$expectations</code>
-      <code>$expectations</code>
-      <code><![CDATA[call_user_func_array(array(self::getContainer(), 'mock'), $args)]]></code>
-      <code><![CDATA[call_user_func_array(array(self::getContainer(), 'mock'), $args)]]></code>
-      <code><![CDATA[call_user_func_array(array(self::getContainer(), 'mock'), $args)]]></code>
-      <code><![CDATA[call_user_func_array(array(self::getContainer(), 'mock'), $args)->shouldIgnoreMissing()]]></code>
+      <code>call_user_func_array(array(self::getContainer(), 'mock'), $args)</code>
+      <code>call_user_func_array(array(self::getContainer(), 'mock'), $args)</code>
+      <code>call_user_func_array(array(self::getContainer(), 'mock'), $args)</code>
+      <code>call_user_func_array(array(self::getContainer(), 'mock'), $args)-&gt;shouldIgnoreMissing()</code>
     </MixedReturnStatement>
-    <MoreSpecificReturnType>
+    <MoreSpecificReturnType occurrences="1">
       <code>\Mockery\Mock</code>
     </MoreSpecificReturnType>
-    <PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="25">
       <code>andAnyOtherArgs</code>
       <code>andAnyOthers</code>
       <code>any</code>
@@ -124,6 +123,7 @@
       <code>capture</code>
       <code>contains</code>
       <code>ducktype</code>
+      <code>fetchMock</code>
       <code>globalHelpers</code>
       <code>hasKey</code>
       <code>hasValue</code>
@@ -133,6 +133,7 @@
       <code>not</code>
       <code>notAnyOf</code>
       <code>on</code>
+      <code>parseShouldReturnArgs</code>
       <code>pattern</code>
       <code>resetContainer</code>
       <code>setContainer</code>
@@ -141,31 +142,31 @@
       <code>subset</code>
       <code>type</code>
     </PossiblyUnusedMethod>
-    <PossiblyUnusedReturnValue>
+    <PossiblyUnusedReturnValue occurrences="1">
       <code>\Mockery\MockInterface|\Mockery\LegacyMockInterface</code>
     </PossiblyUnusedReturnValue>
-    <RedundantConditionGivenDocblockType>
+    <RedundantConditionGivenDocblockType occurrences="1">
       <code>$parentMock !== null</code>
     </RedundantConditionGivenDocblockType>
-    <UnnecessaryVarAnnotation>
+    <UnnecessaryVarAnnotation occurrences="1">
       <code>Mockery\Container</code>
     </UnnecessaryVarAnnotation>
-    <UnresolvableInclude>
+    <UnresolvableInclude occurrences="1">
       <code>require $tmpfname</code>
     </UnresolvableInclude>
-    <UnusedVariable>
+    <UnusedVariable occurrences="2">
       <code>$parRefMethod</code>
       <code>$parRefMethodRetType</code>
     </UnusedVariable>
   </file>
   <file src="library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegration.php">
-    <InternalMethod>
+    <InternalMethod occurrences="1">
       <code>addToAssertionCount</code>
     </InternalMethod>
-    <MissingPropertyType>
+    <MissingPropertyType occurrences="1">
       <code>$mockeryOpen</code>
     </MissingPropertyType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="6">
       <code>addMockeryExpectationsToAssertionCount</code>
       <code>checkMockeryExceptions</code>
       <code>closeMockery</code>
@@ -173,91 +174,74 @@
       <code>purgeMockeryContainer</code>
       <code>startMockery</code>
     </MissingReturnType>
-    <MixedAssignment>
+    <MixedAssignment occurrences="1">
       <code>$e</code>
     </MixedAssignment>
-    <MixedMethodCall>
+    <MixedMethodCall occurrences="1">
       <code>dismissed</code>
     </MixedMethodCall>
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="2">
       <code>purgeMockeryContainer</code>
       <code>startMockery</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="library/Mockery/Adapter/Phpunit/MockeryTestCase.php">
-    <MissingReturnType>
+    <MissingReturnType occurrences="2">
       <code>mockeryTestSetUp</code>
       <code>mockeryTestTearDown</code>
     </MissingReturnType>
   </file>
   <file src="library/Mockery/Adapter/Phpunit/TestListener.php">
-    <DeprecatedInterface>
+    <DeprecatedInterface occurrences="1">
       <code>TestListener</code>
     </DeprecatedInterface>
-    <DeprecatedTrait>
+    <DeprecatedTrait occurrences="1">
       <code>TestListenerDefaultImplementation</code>
     </DeprecatedTrait>
-    <MissingPropertyType>
+    <MissingPropertyType occurrences="1">
       <code>$trait</code>
     </MissingPropertyType>
-    <MixedMethodCall>
+    <MixedMethodCall occurrences="2">
       <code>endTest</code>
       <code>startTestSuite</code>
     </MixedMethodCall>
-    <UnusedClass>
+    <UnusedClass occurrences="1">
       <code>TestListener</code>
     </UnusedClass>
   </file>
   <file src="library/Mockery/Adapter/Phpunit/TestListenerTrait.php">
-    <DeprecatedClass>
-      <code><![CDATA[Blacklist::addDirectory(\dirname((new \ReflectionClass(\Mockery::class))->getFileName()))]]></code>
+    <DeprecatedClass occurrences="3">
+      <code>Blacklist::addDirectory(\dirname((new \ReflectionClass(\Mockery::class))-&gt;getFileName()))</code>
       <code>Blacklist::class</code>
       <code>new BlackList()</code>
     </DeprecatedClass>
-    <InternalClass>
+    <InternalClass occurrences="2">
       <code>BaseTestRunner::STATUS_PASSED</code>
-      <code><![CDATA[new ExpectationFailedException(
-            \sprintf(
-                "Mockery's expectations have not been verified. Make sure that \Mockery::close() is called at the end of the test. Consider using %s\MockeryPHPUnitIntegration or extending %s\MockeryTestCase.",
-                __NAMESPACE__,
-                __NAMESPACE__
-            )
-        )]]></code>
     </InternalClass>
-    <InternalMethod>
+    <InternalMethod occurrences="3">
       <code>addFailure</code>
       <code>getTestResultObject</code>
-      <code><![CDATA[new ExpectationFailedException(
-            \sprintf(
-                "Mockery's expectations have not been verified. Make sure that \Mockery::close() is called at the end of the test. Consider using %s\MockeryPHPUnitIntegration or extending %s\MockeryTestCase.",
-                __NAMESPACE__,
-                __NAMESPACE__
-            )
-        )]]></code>
     </InternalMethod>
-    <MissingReturnType>
+    <MissingReturnType occurrences="2">
       <code>endTest</code>
       <code>startTestSuite</code>
     </MissingReturnType>
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="2">
       <code>endTest</code>
       <code>startTestSuite</code>
     </PossiblyUnusedMethod>
-    <RedundantConditionGivenDocblockType>
+    <RedundantConditionGivenDocblockType occurrences="1">
       <code>$result !== null</code>
     </RedundantConditionGivenDocblockType>
-    <UndefinedPropertyAssignment>
+    <UndefinedPropertyAssignment occurrences="1">
       <code>Blacklist::$blacklistedClassNames</code>
     </UndefinedPropertyAssignment>
-    <UndefinedPropertyFetch>
+    <UndefinedPropertyFetch occurrences="1">
       <code>Blacklist::$blacklistedClassNames</code>
     </UndefinedPropertyFetch>
   </file>
   <file src="library/Mockery/CompositeExpectation.php">
-    <MethodSignatureMustProvideReturnType>
-      <code>__toString</code>
-    </MethodSignatureMustProvideReturnType>
-    <MixedAssignment>
+    <MixedAssignment occurrences="6">
       <code>$exp</code>
       <code>$expectation</code>
       <code>$first</code>
@@ -265,34 +249,34 @@
       <code>$first</code>
       <code>$first</code>
     </MixedAssignment>
-    <MixedInferredReturnType>
+    <MixedInferredReturnType occurrences="5">
       <code>\Mockery\Expectation</code>
       <code>\Mockery\Expectation</code>
       <code>\Mockery\MockInterface|\Mockery\LegacyMockInterface</code>
       <code>int</code>
       <code>self</code>
     </MixedInferredReturnType>
-    <MixedMethodCall>
+    <MixedMethodCall occurrences="4">
       <code>getMock</code>
       <code>getMock</code>
       <code>getMock</code>
       <code>getOrderNumber</code>
     </MixedMethodCall>
-    <MixedReturnStatement>
-      <code><![CDATA[$first->getMock()]]></code>
-      <code><![CDATA[$first->getOrderNumber()]]></code>
-      <code><![CDATA[call_user_func_array([$this, 'andReturn'], $args)]]></code>
-      <code><![CDATA[call_user_func_array(array($first->getMock(), 'shouldNotReceive'), $args)]]></code>
-      <code><![CDATA[call_user_func_array(array($first->getMock(), 'shouldReceive'), $args)]]></code>
+    <MixedReturnStatement occurrences="5">
+      <code>$first-&gt;getMock()</code>
+      <code>$first-&gt;getOrderNumber()</code>
+      <code>call_user_func_array([$this, 'andReturn'], $args)</code>
+      <code>call_user_func_array(array($first-&gt;getMock(), 'shouldNotReceive'), $args)</code>
+      <code>call_user_func_array(array($first-&gt;getMock(), 'shouldReceive'), $args)</code>
     </MixedReturnStatement>
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="3">
       <code>mock</code>
       <code>shouldNotReceive</code>
       <code>shouldReceive</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="library/Mockery/Configuration.php">
-    <MissingParamType>
+    <MissingParamType occurrences="7">
       <code>$class</code>
       <code>$class</code>
       <code>$class</code>
@@ -301,11 +285,11 @@
       <code>$formatterCallback</code>
       <code>$method</code>
     </MissingParamType>
-    <MissingPropertyType>
+    <MissingPropertyType occurrences="2">
       <code>$_constantsMap</code>
       <code>$_reflectionCacheEnabled</code>
     </MissingPropertyType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="14">
       <code>allowMockingMethodsUnnecessarily</code>
       <code>allowMockingNonExistentMethods</code>
       <code>disableReflectionCache</code>
@@ -321,35 +305,31 @@
       <code>setInternalClassMethodParamMap</code>
       <code>setObjectFormatter</code>
     </MissingReturnType>
-    <MixedArgument>
+    <MixedArgument occurrences="7">
       <code>$class</code>
       <code>$class</code>
       <code>$class</code>
       <code>$class</code>
       <code>$method</code>
       <code>$method</code>
-      <code>$parentClass</code>
-      <code>$parentClass</code>
-      <code>$parentClass</code>
-      <code>$parentClass</code>
       <code>\Hamcrest_Matcher::class</code>
     </MixedArgument>
-    <MixedArrayAccess>
-      <code><![CDATA[$this->_internalClassParamMap[strtolower($class)][strtolower($method)]]]></code>
+    <MixedArrayAccess occurrences="1">
+      <code>$this-&gt;_internalClassParamMap[strtolower($class)][strtolower($method)]</code>
     </MixedArrayAccess>
-    <MixedArrayAssignment>
-      <code><![CDATA[$this->_internalClassParamMap[strtolower($class)][strtolower($method)]]]></code>
+    <MixedArrayAssignment occurrences="1">
+      <code>$this-&gt;_internalClassParamMap[strtolower($class)][strtolower($method)]</code>
     </MixedArrayAssignment>
-    <MixedArrayOffset>
-      <code><![CDATA[$this->_defaultMatchers[$type]]]></code>
-      <code><![CDATA[$this->_objectFormatters[$class]]]></code>
-      <code><![CDATA[$this->_objectFormatters[$type]]]></code>
+    <MixedArrayOffset occurrences="3">
+      <code>$this-&gt;_defaultMatchers[$type]</code>
+      <code>$this-&gt;_objectFormatters[$class]</code>
+      <code>$this-&gt;_objectFormatters[$type]</code>
     </MixedArrayOffset>
-    <MixedArrayTypeCoercion>
-      <code><![CDATA[$this->_defaultMatchers[$type]]]></code>
-      <code><![CDATA[$this->_objectFormatters[$type]]]></code>
+    <MixedArrayTypeCoercion occurrences="2">
+      <code>$this-&gt;_defaultMatchers[$type]</code>
+      <code>$this-&gt;_objectFormatters[$type]</code>
     </MixedArrayTypeCoercion>
-    <MixedAssignment>
+    <MixedAssignment occurrences="6">
       <code>$classes[]</code>
       <code>$classes[]</code>
       <code>$parentClass</code>
@@ -357,62 +337,60 @@
       <code>$type</code>
       <code>$type</code>
     </MixedAssignment>
-    <MixedInferredReturnType>
+    <MixedInferredReturnType occurrences="1">
       <code>array|null</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement>
-      <code><![CDATA[$this->_internalClassParamMap[strtolower($class)][strtolower($method)]]]></code>
+    <MixedReturnStatement occurrences="1">
+      <code>$this-&gt;_internalClassParamMap[strtolower($class)][strtolower($method)]</code>
     </MixedReturnStatement>
-    <PossiblyUndefinedVariable>
+    <PossiblyUndefinedVariable occurrences="2">
       <code>$classes</code>
       <code>$classes</code>
     </PossiblyUndefinedVariable>
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="12">
       <code>allowMockingMethodsUnnecessarily</code>
       <code>allowMockingNonExistentMethods</code>
       <code>disableReflectionCache</code>
       <code>enableReflectionCache</code>
       <code>getInternalClassMethodParamMap</code>
       <code>mockingMethodsUnnecessarilyAllowed</code>
+      <code>reflectionCacheEnabled</code>
       <code>resetInternalClassMethodParamMaps</code>
       <code>setConstantsMap</code>
       <code>setDefaultMatcher</code>
       <code>setInternalClassMethodParamMap</code>
       <code>setObjectFormatter</code>
     </PossiblyUnusedMethod>
-    <RedundantCastGivenDocblockType>
+    <RedundantCastGivenDocblockType occurrences="2">
       <code>(bool) $flag</code>
       <code>(bool) $flag</code>
     </RedundantCastGivenDocblockType>
-    <UndefinedClass>
+    <UndefinedClass occurrences="1">
       <code>\Hamcrest_Matcher</code>
     </UndefinedClass>
   </file>
   <file src="library/Mockery/Container.php">
-    <ArgumentTypeCoercion>
-      <code><![CDATA["Mockery\LegacyMockInterface"]]></code>
+    <ArgumentTypeCoercion occurrences="1">
+      <code>"Mockery\LegacyMockInterface"</code>
     </ArgumentTypeCoercion>
-    <DocblockTypeContradiction>
+    <DocblockTypeContradiction occurrences="3">
       <code>$arg instanceof MockConfigurationBuilder</code>
       <code>is_object($arg)</code>
       <code>is_string($arg)</code>
     </DocblockTypeContradiction>
-    <InvalidArrayOffset>
-      <code>$mocks[$index]</code>
-    </InvalidArrayOffset>
-    <InvalidStringClass>
+    <InvalidStringClass occurrences="1">
       <code>new $internalMockName()</code>
     </InvalidStringClass>
-    <LessSpecificReturnStatement>
+    <LessSpecificReturnStatement occurrences="1">
       <code>$mock</code>
     </LessSpecificReturnStatement>
-    <MissingParamType>
+    <MissingParamType occurrences="4">
       <code>$config</code>
       <code>$constructorArgs</code>
       <code>$mockName</code>
       <code>$reference</code>
     </MissingParamType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="6">
       <code>_getInstance</code>
       <code>checkForNamedMockClashes</code>
       <code>getGenerator</code>
@@ -420,28 +398,28 @@
       <code>instanceMock</code>
       <code>mockery_setGroup</code>
     </MissingReturnType>
-    <MixedArgument>
+    <MixedArgument occurrences="10">
       <code>$arg</code>
       <code>$blocks</code>
       <code>$constructorArgs</code>
-      <code><![CDATA[$def->getClassName()]]></code>
-      <code><![CDATA[$def->getClassName()]]></code>
+      <code>$def-&gt;getClassName()</code>
+      <code>$def-&gt;getClassName()</code>
       <code>$mock</code>
-      <code><![CDATA[$mock->mockery_thrownExceptions()]]></code>
+      <code>$mock-&gt;mockery_thrownExceptions()</code>
       <code>$mockName</code>
-      <code><![CDATA[\Mockery::getConfiguration()->getConstantsMap()]]></code>
-      <code><![CDATA[\Mockery::getConfiguration()->getInternalClassMethodParamMaps()]]></code>
+      <code>\Mockery::getConfiguration()-&gt;getConstantsMap()</code>
+      <code>\Mockery::getConfiguration()-&gt;getInternalClassMethodParamMaps()</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion>
+    <MixedArgumentTypeCoercion occurrences="1">
       <code>$keys</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayOffset>
-      <code><![CDATA[$this->_groups[$group]]]></code>
-      <code><![CDATA[$this->_mocks[$reference]]]></code>
-      <code><![CDATA[$this->_namedMocks[$name]]]></code>
-      <code><![CDATA[$this->_namedMocks[$name]]]></code>
+    <MixedArrayOffset occurrences="4">
+      <code>$this-&gt;_groups[$group]</code>
+      <code>$this-&gt;_mocks[$reference]</code>
+      <code>$this-&gt;_namedMocks[$name]</code>
+      <code>$this-&gt;_namedMocks[$name]</code>
     </MixedArrayOffset>
-    <MixedAssignment>
+    <MixedAssignment occurrences="12">
       <code>$blocks</code>
       <code>$config</code>
       <code>$count</code>
@@ -455,12 +433,12 @@
       <code>$mock</code>
       <code>$name</code>
     </MixedAssignment>
-    <MixedInferredReturnType>
+    <MixedInferredReturnType occurrences="3">
       <code>\Mockery\Mock</code>
       <code>\Mockery\Mock</code>
       <code>int</code>
     </MixedInferredReturnType>
-    <MixedMethodCall>
+    <MixedMethodCall occurrences="23">
       <code>atLeast</code>
       <code>byDefault</code>
       <code>generate</code>
@@ -485,137 +463,136 @@
       <code>shouldReceive</code>
       <code>shouldReceive</code>
     </MixedMethodCall>
-    <MixedOperand>
-      <code><![CDATA[$mock->mockery_getExpectationCount()]]></code>
+    <MixedOperand occurrences="2">
+      <code>$mock-&gt;mockery_getExpectationCount()</code>
       <code>$mockName</code>
     </MixedOperand>
-    <MixedReturnStatement>
+    <MixedReturnStatement occurrences="3">
       <code>$count</code>
       <code>$mocks[$index]</code>
-      <code><![CDATA[$this->_mocks[$reference]]]></code>
+      <code>$this-&gt;_mocks[$reference]</code>
     </MixedReturnStatement>
-    <MoreSpecificReturnType>
+    <MoreSpecificReturnType occurrences="1">
       <code>Mock</code>
     </MoreSpecificReturnType>
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="5">
       <code>instanceMock</code>
       <code>mockery_allocateOrder</code>
       <code>mockery_getCurrentOrder</code>
       <code>mockery_getGroups</code>
       <code>mockery_setGroup</code>
     </PossiblyUnusedMethod>
-    <PossiblyUnusedReturnValue>
+    <PossiblyUnusedReturnValue occurrences="2">
       <code>\Mockery\LegacyMockInterface|\Mockery\MockInterface</code>
       <code>int</code>
     </PossiblyUnusedReturnValue>
-    <RedundantCondition>
-      <code><![CDATA[!\Mockery::getConfiguration()->mockingNonExistentMethodsAllowed() && (!class_exists($type, true) && !interface_exists($type, true))]]></code>
-      <code><![CDATA[!\Mockery::getConfiguration()->mockingNonExistentMethodsAllowed() && (!class_exists($type, true) && !interface_exists($type, true))]]></code>
+    <RedundantCondition occurrences="2">
+      <code>!\Mockery::getConfiguration()-&gt;mockingNonExistentMethodsAllowed() &amp;&amp; (!class_exists($type, true) &amp;&amp; !interface_exists($type, true))</code>
+      <code>count($res) &gt; 0</code>
     </RedundantCondition>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[count($res) > 0]]></code>
+    <RedundantConditionGivenDocblockType occurrences="1">
       <code>is_array($arg)</code>
     </RedundantConditionGivenDocblockType>
-    <TypeDoesNotContainType>
-      <code><![CDATA[is_callable($finalArg) && is_object($finalArg)]]></code>
+    <TypeDoesNotContainType occurrences="2">
+      <code>is_callable($finalArg) &amp;&amp; is_object($finalArg)</code>
       <code>is_object($finalArg)</code>
     </TypeDoesNotContainType>
-    <UnusedVariable>
+    <UnusedVariable occurrences="1">
       <code>$class</code>
     </UnusedVariable>
   </file>
   <file src="library/Mockery/CountValidator/AtLeast.php">
-    <InvalidReturnType>
+    <InvalidReturnType occurrences="1">
       <code>bool</code>
     </InvalidReturnType>
-    <MixedMethodCall>
+    <MixedMethodCall occurrences="4">
       <code>setActualCount</code>
       <code>setExpectedCount</code>
       <code>setExpectedCountComparative</code>
       <code>setMethodName</code>
     </MixedMethodCall>
-    <UnusedClass>
+    <UnusedClass occurrences="1">
       <code>AtLeast</code>
     </UnusedClass>
   </file>
   <file src="library/Mockery/CountValidator/AtMost.php">
-    <InvalidReturnType>
+    <InvalidReturnType occurrences="1">
       <code>bool</code>
     </InvalidReturnType>
-    <MixedMethodCall>
+    <MixedMethodCall occurrences="4">
       <code>setActualCount</code>
       <code>setExpectedCount</code>
       <code>setExpectedCountComparative</code>
       <code>setMethodName</code>
     </MixedMethodCall>
-    <UnusedClass>
+    <UnusedClass occurrences="1">
       <code>AtMost</code>
     </UnusedClass>
   </file>
   <file src="library/Mockery/CountValidator/CountValidatorAbstract.php">
-    <PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullPropertyAssignmentValue occurrences="2">
       <code>null</code>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="3">
       <code>__construct</code>
       <code>isEligible</code>
       <code>validate</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="library/Mockery/CountValidator/Exact.php">
-    <InvalidReturnType>
+    <InvalidReturnType occurrences="1">
       <code>bool</code>
     </InvalidReturnType>
-    <MixedAssignment>
+    <MixedAssignment occurrences="1">
       <code>$because</code>
     </MixedAssignment>
-    <MixedMethodCall>
+    <MixedMethodCall occurrences="4">
       <code>setActualCount</code>
       <code>setExpectedCount</code>
       <code>setExpectedCountComparative</code>
       <code>setMethodName</code>
     </MixedMethodCall>
-    <MixedOperand>
-      <code><![CDATA[$this->_expectation->getExceptionMessage()]]></code>
+    <MixedOperand occurrences="1">
+      <code>$this-&gt;_expectation-&gt;getExceptionMessage()</code>
     </MixedOperand>
-    <UnusedClass>
+    <UnusedClass occurrences="1">
       <code>Exact</code>
     </UnusedClass>
   </file>
   <file src="library/Mockery/Exception/BadMethodCallException.php">
-    <MissingPropertyType>
+    <MissingPropertyType occurrences="1">
       <code>$dismissed</code>
     </MissingPropertyType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="2">
       <code>dismiss</code>
       <code>dismissed</code>
     </MissingReturnType>
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="2">
       <code>dismiss</code>
       <code>dismissed</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="library/Mockery/Exception/InvalidArgumentException.php">
-    <UnusedClass>
+    <UnusedClass occurrences="1">
       <code>InvalidArgumentException</code>
     </UnusedClass>
   </file>
   <file src="library/Mockery/Exception/InvalidCountException.php">
-    <MissingParamType>
+    <MissingParamType occurrences="4">
       <code>$comp</code>
       <code>$count</code>
       <code>$count</code>
       <code>$name</code>
     </MissingParamType>
-    <MissingPropertyType>
+    <MissingPropertyType occurrences="5">
       <code>$actual</code>
       <code>$expected</code>
       <code>$expectedComparative</code>
       <code>$method</code>
       <code>$mockObject</code>
     </MissingPropertyType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="11">
       <code>getActualCount</code>
       <code>getExpectedCount</code>
       <code>getExpectedCountComparative</code>
@@ -628,13 +605,13 @@
       <code>setMethodName</code>
       <code>setMock</code>
     </MissingReturnType>
-    <MixedMethodCall>
+    <MixedMethodCall occurrences="1">
       <code>mockery_getName</code>
     </MixedMethodCall>
-    <MixedOperand>
+    <MixedOperand occurrences="1">
       <code>$comp</code>
     </MixedOperand>
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="9">
       <code>getActualCount</code>
       <code>getExpectedCount</code>
       <code>getExpectedCountComparative</code>
@@ -647,18 +624,18 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="library/Mockery/Exception/InvalidOrderException.php">
-    <MissingParamType>
+    <MissingParamType occurrences="3">
       <code>$count</code>
       <code>$count</code>
       <code>$name</code>
     </MissingParamType>
-    <MissingPropertyType>
+    <MissingPropertyType occurrences="4">
       <code>$actual</code>
       <code>$expected</code>
       <code>$method</code>
       <code>$mockObject</code>
     </MissingPropertyType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="9">
       <code>getActualOrder</code>
       <code>getExpectedOrder</code>
       <code>getMethodName</code>
@@ -669,10 +646,10 @@
       <code>setMethodName</code>
       <code>setMock</code>
     </MissingReturnType>
-    <MixedMethodCall>
+    <MixedMethodCall occurrences="1">
       <code>mockery_getName</code>
     </MixedMethodCall>
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="7">
       <code>getActualOrder</code>
       <code>getExpectedOrder</code>
       <code>getMethodName</code>
@@ -683,16 +660,16 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="library/Mockery/Exception/NoMatchingExpectationException.php">
-    <MissingParamType>
+    <MissingParamType occurrences="2">
       <code>$count</code>
       <code>$name</code>
     </MissingParamType>
-    <MissingPropertyType>
+    <MissingPropertyType occurrences="3">
       <code>$actual</code>
       <code>$method</code>
       <code>$mockObject</code>
     </MissingPropertyType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="7">
       <code>getActualArguments</code>
       <code>getMethodName</code>
       <code>getMock</code>
@@ -701,10 +678,10 @@
       <code>setMethodName</code>
       <code>setMock</code>
     </MissingReturnType>
-    <MixedMethodCall>
+    <MixedMethodCall occurrences="1">
       <code>mockery_getName</code>
     </MixedMethodCall>
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="5">
       <code>getActualArguments</code>
       <code>getMethodName</code>
       <code>getMockName</code>
@@ -713,41 +690,38 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="library/Mockery/Expectation.php">
-    <DocblockTypeContradiction>
+    <DocblockTypeContradiction occurrences="3">
       <code>!is_int($index)</code>
       <code>is_int($limit)</code>
       <code>is_null($group)</code>
     </DocblockTypeContradiction>
-    <InvalidArgument>
+    <InvalidArgument occurrences="1">
       <code>$argsOrClosure</code>
     </InvalidArgument>
-    <InvalidReturnType>
+    <InvalidReturnType occurrences="2">
       <code>mixed</code>
       <code>self</code>
     </InvalidReturnType>
-    <InvalidStringClass>
+    <InvalidStringClass occurrences="2">
       <code>new $exception($message, $code, $previous)</code>
-      <code><![CDATA[new $this->_countValidatorClass($this, $limit)]]></code>
+      <code>new $this-&gt;_countValidatorClass($this, $limit)</code>
     </InvalidStringClass>
-    <MethodSignatureMustProvideReturnType>
-      <code>__toString</code>
-    </MethodSignatureMustProvideReturnType>
-    <MissingClosureParamType>
+    <MissingClosureParamType occurrences="2">
       <code>$args</code>
       <code>$args</code>
     </MissingClosureParamType>
-    <MissingClosureReturnType>
+    <MissingClosureReturnType occurrences="2">
       <code>function (...$args) use ($index) {</code>
       <code>static function () use ($args) {</code>
     </MissingClosureReturnType>
-    <MissingParamType>
+    <MissingParamType occurrences="5">
       <code>$code</code>
       <code>$exception</code>
       <code>$expectedArg</code>
       <code>$message</code>
       <code>$return</code>
     </MissingParamType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="7">
       <code>andReturnFalse</code>
       <code>andReturnTrue</code>
       <code>andThrows</code>
@@ -756,23 +730,27 @@
       <code>getName</code>
       <code>isAndAnyOtherArgumentsMatcher</code>
     </MissingReturnType>
-    <MixedArgument>
+    <MixedArgument occurrences="5">
       <code>$code</code>
       <code>$exception</code>
       <code>$message</code>
       <code>$values</code>
       <code>$values</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion>
-      <code><![CDATA[array_search($lastExpectedArgument, $this->_expectedArgs, true)]]></code>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>array_search($lastExpectedArgument, $this-&gt;_expectedArgs, true)</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment>
+    <MixedArrayAccess occurrences="1">
+      <code>$groups[$group]</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="16">
       <code>$arg</code>
       <code>$expectedArg</code>
       <code>$groups</code>
       <code>$lastExpectedArgument</code>
       <code>$matcher</code>
       <code>$newValidators[]</code>
+      <code>$param</code>
       <code>$result</code>
       <code>$result</code>
       <code>$result</code>
@@ -783,20 +761,20 @@
       <code>$value</code>
       <code>$values</code>
     </MixedAssignment>
-    <MixedClone>
+    <MixedClone occurrences="1">
       <code>clone $validator</code>
     </MixedClone>
-    <MixedFunctionCall>
-      <code><![CDATA[call_user_func_array(array_shift($this->_closureQueue), $args)]]></code>
-      <code><![CDATA[call_user_func_array(current($this->_closureQueue), $args)]]></code>
+    <MixedFunctionCall occurrences="2">
+      <code>call_user_func_array(array_shift($this-&gt;_closureQueue), $args)</code>
+      <code>call_user_func_array(current($this-&gt;_closureQueue), $args)</code>
     </MixedFunctionCall>
-    <MixedInferredReturnType>
+    <MixedInferredReturnType occurrences="4">
       <code>bool</code>
       <code>int</code>
       <code>self</code>
       <code>self</code>
     </MixedInferredReturnType>
-    <MixedMethodCall>
+    <MixedMethodCall occurrences="7">
       <code>isEligible</code>
       <code>mockery_allocateOrder</code>
       <code>mockery_allocateOrder</code>
@@ -805,25 +783,26 @@
       <code>new $matcher($expected)</code>
       <code>validate</code>
     </MixedMethodCall>
-    <MixedReturnStatement>
+    <MixedReturnStatement occurrences="3">
       <code>$result</code>
-      <code><![CDATA[call_user_func_array([$this, 'andReturn'], $args)]]></code>
-      <code><![CDATA[call_user_func_array(array($this, 'andSet'), func_get_args())]]></code>
+      <code>call_user_func_array([$this, 'andReturn'], $args)</code>
+      <code>call_user_func_array(array($this, 'andSet'), func_get_args())</code>
     </MixedReturnStatement>
-    <PossiblyFalseArgument>
-      <code><![CDATA[array_search($lastExpectedArgument, $this->_expectedArgs, true)]]></code>
+    <PossiblyFalseArgument occurrences="1">
+      <code>array_search($lastExpectedArgument, $this-&gt;_expectedArgs, true)</code>
     </PossiblyFalseArgument>
-    <PossiblyNullArgument>
+    <PossiblyNullArgument occurrences="2">
       <code>$group</code>
       <code>$group</code>
     </PossiblyNullArgument>
-    <PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullPropertyAssignmentValue occurrences="4">
       <code>null</code>
       <code>null</code>
       <code>null</code>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="24">
+      <code>__construct</code>
       <code>andReturnArg</code>
       <code>andReturnFalse</code>
       <code>andReturnNull</code>
@@ -848,42 +827,37 @@
       <code>withSomeOfArgs</code>
       <code>zeroOrMoreTimes</code>
     </PossiblyUnusedMethod>
-    <PossiblyUnusedProperty>
+    <PossiblyUnusedProperty occurrences="1">
       <code>$_returnValue</code>
     </PossiblyUnusedProperty>
-    <PossiblyUnusedReturnValue>
+    <PossiblyUnusedReturnValue occurrences="3">
       <code>mixed</code>
       <code>mixed</code>
       <code>self</code>
     </PossiblyUnusedReturnValue>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(array) $this->_expectedArgs]]></code>
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(array) $this-&gt;_expectedArgs</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType>
+    <RedundantConditionGivenDocblockType occurrences="1">
       <code>$argsOrClosure instanceof Closure</code>
     </RedundantConditionGivenDocblockType>
-    <TooManyArguments>
+    <TooManyArguments occurrences="1">
       <code>mockery_validateOrder</code>
     </TooManyArguments>
-    <UndefinedClass>
+    <UndefinedClass occurrences="1">
       <code>\Hamcrest_Matcher</code>
     </UndefinedClass>
-    <UndefinedInterfaceMethod>
+    <UndefinedInterfaceMethod occurrences="2">
       <code>mockery_callSubjectMethod</code>
       <code>mockery_returnValueForMethod</code>
     </UndefinedInterfaceMethod>
-    <UnusedDocblockParam>
-      <code>$args</code>
-      <code>$args</code>
-      <code>$name</code>
-    </UnusedDocblockParam>
   </file>
   <file src="library/Mockery/ExpectationDirector.php">
-    <MissingReturnType>
+    <MissingReturnType occurrences="2">
       <code>addExpectation</code>
       <code>makeExpectationDefault</code>
     </MissingReturnType>
-    <MixedAssignment>
+    <MixedAssignment occurrences="9">
       <code>$exp</code>
       <code>$exp</code>
       <code>$exp</code>
@@ -894,7 +868,7 @@
       <code>$expectation</code>
       <code>$last</code>
     </MixedAssignment>
-    <MixedMethodCall>
+    <MixedMethodCall occurrences="9">
       <code>isCallCountConstrained</code>
       <code>isEligible</code>
       <code>matchArgs</code>
@@ -905,84 +879,86 @@
       <code>verify</code>
       <code>verifyCall</code>
     </MixedMethodCall>
-    <PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullPropertyAssignmentValue occurrences="3">
       <code>null</code>
       <code>null</code>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="5">
+      <code>__construct</code>
+      <code>addExpectation</code>
       <code>call</code>
       <code>getExpectationCount</code>
       <code>verify</code>
     </PossiblyUnusedMethod>
-    <PossiblyUnusedProperty>
+    <PossiblyUnusedProperty occurrences="1">
       <code>$_expectedOrder</code>
     </PossiblyUnusedProperty>
-    <RawObjectIteration>
+    <RawObjectIteration occurrences="1">
       <code>$expectations</code>
     </RawObjectIteration>
   </file>
   <file src="library/Mockery/ExpectationInterface.php">
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="2">
       <code>andReturns</code>
       <code>getOrderNumber</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="library/Mockery/ExpectsHigherOrderMessage.php">
-    <MissingParamType>
+    <MissingParamType occurrences="2">
       <code>$args</code>
       <code>$method</code>
     </MissingParamType>
+    <PossiblyUnusedMethod occurrences="1">
+      <code>__construct</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="library/Mockery/Generator/CachingGenerator.php">
-    <MissingPropertyType>
+    <MissingPropertyType occurrences="1">
       <code>$cache</code>
     </MissingPropertyType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="1">
       <code>generate</code>
     </MissingReturnType>
-    <MixedArrayAccess>
-      <code><![CDATA[$this->cache[$hash]]]></code>
+    <MixedArrayAccess occurrences="1">
+      <code>$this-&gt;cache[$hash]</code>
     </MixedArrayAccess>
-    <MixedArrayAssignment>
-      <code><![CDATA[$this->cache[$hash]]]></code>
+    <MixedArrayAssignment occurrences="1">
+      <code>$this-&gt;cache[$hash]</code>
     </MixedArrayAssignment>
-    <MixedAssignment>
+    <MixedAssignment occurrences="1">
       <code>$definition</code>
     </MixedAssignment>
   </file>
   <file src="library/Mockery/Generator/DefinedTargetClass.php">
-    <ArgumentTypeCoercion>
+    <ArgumentTypeCoercion occurrences="1">
       <code>$name</code>
     </ArgumentTypeCoercion>
-    <MethodSignatureMustProvideReturnType>
-      <code>__toString</code>
-    </MethodSignatureMustProvideReturnType>
-    <MissingClosureParamType>
+    <MissingClosureParamType occurrences="2">
       <code>$interface</code>
       <code>$method</code>
     </MissingClosureParamType>
-    <MissingParamType>
+    <MissingParamType occurrences="2">
       <code>$alias</code>
       <code>$alias</code>
     </MissingParamType>
-    <MissingPropertyType>
+    <MissingPropertyType occurrences="2">
       <code>$name</code>
       <code>$rfc</code>
     </MissingPropertyType>
-    <MixedArgument>
+    <MixedArgument occurrences="5">
       <code>$interface</code>
       <code>$method</code>
-      <code><![CDATA[$this->rfc->getAttributes()]]></code>
-      <code><![CDATA[$this->rfc->getInterfaces()]]></code>
-      <code><![CDATA[$this->rfc->getMethods()]]></code>
+      <code>$this-&gt;rfc-&gt;getAttributes()</code>
+      <code>$this-&gt;rfc-&gt;getInterfaces()</code>
+      <code>$this-&gt;rfc-&gt;getMethods()</code>
     </MixedArgument>
-    <MixedAssignment>
+    <MixedAssignment occurrences="3">
       <code>$child</code>
       <code>$child</code>
       <code>$parent</code>
     </MixedAssignment>
-    <MixedInferredReturnType>
+    <MixedInferredReturnType occurrences="7">
       <code>getName</code>
       <code>getNamespaceName</code>
       <code>getShortName</code>
@@ -991,7 +967,7 @@
       <code>isAbstract</code>
       <code>isFinal</code>
     </MixedInferredReturnType>
-    <MixedMethodCall>
+    <MixedMethodCall occurrences="12">
       <code>getAttributes</code>
       <code>getInterfaces</code>
       <code>getMethods</code>
@@ -1005,34 +981,37 @@
       <code>isInternal</code>
       <code>isInternal</code>
     </MixedMethodCall>
-    <MixedReturnStatement>
-      <code><![CDATA[$this->name]]></code>
-      <code><![CDATA[$this->rfc->getNamespaceName()]]></code>
-      <code><![CDATA[$this->rfc->getShortName()]]></code>
-      <code><![CDATA[$this->rfc->implementsInterface($interface)]]></code>
-      <code><![CDATA[$this->rfc->inNamespace()]]></code>
-      <code><![CDATA[$this->rfc->isAbstract()]]></code>
-      <code><![CDATA[$this->rfc->isFinal()]]></code>
+    <MixedReturnStatement occurrences="7">
+      <code>$this-&gt;name</code>
+      <code>$this-&gt;rfc-&gt;getNamespaceName()</code>
+      <code>$this-&gt;rfc-&gt;getShortName()</code>
+      <code>$this-&gt;rfc-&gt;implementsInterface($interface)</code>
+      <code>$this-&gt;rfc-&gt;inNamespace()</code>
+      <code>$this-&gt;rfc-&gt;isAbstract()</code>
+      <code>$this-&gt;rfc-&gt;isFinal()</code>
     </MixedReturnStatement>
+    <UndefinedClass occurrences="1">
+      <code>ReflectionAttribute</code>
+    </UndefinedClass>
   </file>
   <file src="library/Mockery/Generator/Generator.php">
-    <MissingReturnType>
+    <MissingReturnType occurrences="1">
       <code>generate</code>
     </MissingReturnType>
   </file>
   <file src="library/Mockery/Generator/Method.php">
-    <MissingParamType>
+    <MissingParamType occurrences="2">
       <code>$args</code>
       <code>$method</code>
     </MissingParamType>
   </file>
   <file src="library/Mockery/Generator/MockConfiguration.php">
-    <MissingClosureParamType>
+    <MissingClosureParamType occurrences="3">
       <code>$method</code>
       <code>$method</code>
       <code>$method</code>
     </MissingClosureParamType>
-    <MissingParamType>
+    <MissingParamType occurrences="10">
       <code>$className</code>
       <code>$instanceMock</code>
       <code>$interfaces</code>
@@ -1044,7 +1023,7 @@
       <code>$targetInterface</code>
       <code>$targetTraitName</code>
     </MissingParamType>
-    <MissingPropertyType>
+    <MissingPropertyType occurrences="15">
       <code>$allMethods</code>
       <code>$blackListedMethods</code>
       <code>$constantsMap</code>
@@ -1061,7 +1040,7 @@
       <code>$targetTraits</code>
       <code>$whiteListedMethods</code>
     </MissingPropertyType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="26">
       <code>addTarget</code>
       <code>addTargetInterfaceName</code>
       <code>addTargetTraitName</code>
@@ -1089,12 +1068,13 @@
       <code>setTargetClassName</code>
       <code>setTargetObject</code>
     </MissingReturnType>
-    <MixedArgument>
+    <MixedArgument occurrences="34">
       <code>$alias</code>
-      <code><![CDATA[$class->getMethods()]]></code>
+      <code>$class-&gt;getMethods()</code>
       <code>$className</code>
-      <code><![CDATA[$method->getName()]]></code>
-      <code><![CDATA[$method->getName()]]></code>
+      <code>$className</code>
+      <code>$method-&gt;getName()</code>
+      <code>$method-&gt;getName()</code>
       <code>$methods</code>
       <code>$methods</code>
       <code>$methods</code>
@@ -1106,56 +1086,54 @@
       <code>$targetInterface</code>
       <code>$targetInterface</code>
       <code>$targetTrait</code>
-      <code><![CDATA[$this->blackListedMethods]]></code>
-      <code><![CDATA[$this->constantsMap]]></code>
-      <code><![CDATA[$this->getBlackListedMethods()]]></code>
-      <code><![CDATA[$this->getBlackListedMethods()]]></code>
-      <code><![CDATA[$this->getBlackListedMethods()]]></code>
-      <code><![CDATA[$this->getName()]]></code>
-      <code><![CDATA[$this->getName()]]></code>
-      <code><![CDATA[$this->getTargetObject()]]></code>
-      <code><![CDATA[$this->getWhiteListedMethods()]]></code>
-      <code><![CDATA[$this->getWhiteListedMethods()]]></code>
-      <code><![CDATA[$this->getWhiteListedMethods()]]></code>
-      <code><![CDATA[$this->parameterOverrides]]></code>
-      <code><![CDATA[$this->targetClassName]]></code>
-      <code><![CDATA[$this->targetClassName]]></code>
-      <code><![CDATA[$this->targetInterfaceNames]]></code>
-      <code><![CDATA[$this->targetInterfaces]]></code>
-      <code><![CDATA[$this->targetTraitNames]]></code>
-      <code><![CDATA[$this->targetTraits]]></code>
-      <code><![CDATA[$this->whiteListedMethods]]></code>
+      <code>$this-&gt;blackListedMethods</code>
+      <code>$this-&gt;constantsMap</code>
+      <code>$this-&gt;getBlackListedMethods()</code>
+      <code>$this-&gt;getBlackListedMethods()</code>
+      <code>$this-&gt;getName()</code>
+      <code>$this-&gt;getName()</code>
+      <code>$this-&gt;getTargetObject()</code>
+      <code>$this-&gt;getWhiteListedMethods()</code>
+      <code>$this-&gt;getWhiteListedMethods()</code>
+      <code>$this-&gt;parameterOverrides</code>
+      <code>$this-&gt;targetClassName</code>
+      <code>$this-&gt;targetClassName</code>
+      <code>$this-&gt;targetInterfaceNames</code>
+      <code>$this-&gt;targetInterfaces</code>
+      <code>$this-&gt;targetTraitNames</code>
+      <code>$this-&gt;targetTraits</code>
+      <code>$this-&gt;whiteListedMethods</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion>
+    <MixedArgumentTypeCoercion occurrences="4">
       <code>$interface</code>
       <code>$interface</code>
       <code>$interface</code>
       <code>$interface</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAccess>
+    <MixedArrayAccess occurrences="6">
       <code>$methods[$key]</code>
       <code>$params[1]</code>
       <code>$params[1]</code>
       <code>$target[0]</code>
-      <code><![CDATA[$this->getBlackListedMethods()]]></code>
-      <code><![CDATA[$this->getWhiteListedMethods()]]></code>
+      <code>$this-&gt;getBlackListedMethods()</code>
+      <code>$this-&gt;getWhiteListedMethods()</code>
     </MixedArrayAccess>
-    <MixedArrayAssignment>
+    <MixedArrayAssignment occurrences="10">
       <code>$classes[]</code>
       <code>$names[]</code>
-      <code><![CDATA[$this->targetInterfaceNames[]]]></code>
-      <code><![CDATA[$this->targetInterfaces[]]]></code>
-      <code><![CDATA[$this->targetInterfaces[]]]></code>
-      <code><![CDATA[$this->targetInterfaces[]]]></code>
-      <code><![CDATA[$this->targetInterfaces[]]]></code>
-      <code><![CDATA[$this->targetInterfaces[]]]></code>
-      <code><![CDATA[$this->targetTraitNames[]]]></code>
-      <code><![CDATA[$this->targetTraits[]]]></code>
+      <code>$this-&gt;targetInterfaceNames[]</code>
+      <code>$this-&gt;targetInterfaces[]</code>
+      <code>$this-&gt;targetInterfaces[]</code>
+      <code>$this-&gt;targetInterfaces[]</code>
+      <code>$this-&gt;targetInterfaces[]</code>
+      <code>$this-&gt;targetInterfaces[]</code>
+      <code>$this-&gt;targetTraitNames[]</code>
+      <code>$this-&gt;targetTraits[]</code>
     </MixedArrayAssignment>
-    <MixedArrayOffset>
+    <MixedArrayOffset occurrences="1">
       <code>$methods[$key]</code>
     </MixedArrayOffset>
-    <MixedAssignment>
+    <MixedAssignment occurrences="21">
       <code>$alias</code>
       <code>$class</code>
       <code>$className</code>
@@ -1178,7 +1156,7 @@
       <code>$targets[]</code>
       <code>$trait</code>
     </MixedAssignment>
-    <MixedMethodCall>
+    <MixedMethodCall occurrences="22">
       <code>addPart</code>
       <code>build</code>
       <code>getMethods</code>
@@ -1202,15 +1180,15 @@
       <code>isArray</code>
       <code>isFinal</code>
     </MixedMethodCall>
-    <MixedOperand>
+    <MixedOperand occurrences="1">
       <code>$target</code>
     </MixedOperand>
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="1">
       <code>getParameterOverrides</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="library/Mockery/Generator/MockConfigurationBuilder.php">
-    <MissingParamType>
+    <MissingParamType occurrences="7">
       <code>$blackListedMethod</code>
       <code>$instanceMock</code>
       <code>$mockDestructor</code>
@@ -1219,7 +1197,7 @@
       <code>$targets</code>
       <code>$whiteListedMethod</code>
     </MissingParamType>
-    <MissingPropertyType>
+    <MissingPropertyType occurrences="9">
       <code>$blackListedMethods</code>
       <code>$constantsMap</code>
       <code>$instanceMock</code>
@@ -1230,7 +1208,7 @@
       <code>$targets</code>
       <code>$whiteListedMethods</code>
     </MissingPropertyType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="14">
       <code>addBlackListedMethod</code>
       <code>addBlackListedMethods</code>
       <code>addTarget</code>
@@ -1246,310 +1224,303 @@
       <code>setParameterOverrides</code>
       <code>setWhiteListedMethods</code>
     </MissingReturnType>
-    <MixedArgument>
-      <code><![CDATA[$this->blackListedMethods]]></code>
-      <code><![CDATA[$this->blackListedMethods]]></code>
-      <code><![CDATA[$this->constantsMap]]></code>
-      <code><![CDATA[$this->parameterOverrides]]></code>
-      <code><![CDATA[$this->php7SemiReservedKeywords]]></code>
-      <code><![CDATA[$this->targets]]></code>
-      <code><![CDATA[$this->whiteListedMethods]]></code>
+    <MixedArgument occurrences="7">
+      <code>$this-&gt;blackListedMethods</code>
+      <code>$this-&gt;blackListedMethods</code>
+      <code>$this-&gt;constantsMap</code>
+      <code>$this-&gt;parameterOverrides</code>
+      <code>$this-&gt;php7SemiReservedKeywords</code>
+      <code>$this-&gt;targets</code>
+      <code>$this-&gt;whiteListedMethods</code>
     </MixedArgument>
-    <MixedArrayAssignment>
-      <code><![CDATA[$this->blackListedMethods[]]]></code>
-      <code><![CDATA[$this->targets[]]]></code>
-      <code><![CDATA[$this->whiteListedMethods[]]]></code>
+    <MixedArrayAssignment occurrences="3">
+      <code>$this-&gt;blackListedMethods[]</code>
+      <code>$this-&gt;targets[]</code>
+      <code>$this-&gt;whiteListedMethods[]</code>
     </MixedArrayAssignment>
-    <MixedAssignment>
+    <MixedAssignment occurrences="3">
       <code>$method</code>
       <code>$method</code>
       <code>$target</code>
     </MixedAssignment>
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="3">
       <code>addWhiteListedMethods</code>
       <code>setBlackListedMethods</code>
       <code>setWhiteListedMethods</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="library/Mockery/Generator/MockDefinition.php">
-    <MissingParamType>
+    <MissingParamType occurrences="1">
       <code>$code</code>
     </MissingParamType>
-    <MissingPropertyType>
+    <MissingPropertyType occurrences="2">
       <code>$code</code>
       <code>$config</code>
     </MissingPropertyType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="3">
       <code>getClassName</code>
       <code>getCode</code>
       <code>getConfig</code>
     </MissingReturnType>
-    <MixedMethodCall>
+    <MixedMethodCall occurrences="1">
       <code>getName</code>
     </MixedMethodCall>
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="1">
       <code>getConfig</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="library/Mockery/Generator/MockNameBuilder.php">
-    <MissingParamType>
+    <MissingParamType occurrences="1">
       <code>$part</code>
     </MissingParamType>
-    <MissingPropertyType>
+    <MissingPropertyType occurrences="2">
       <code>$mockCounter</code>
       <code>$parts</code>
     </MissingPropertyType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="2">
       <code>addPart</code>
       <code>build</code>
     </MissingReturnType>
-    <MixedArgument>
+    <MixedArgument occurrences="1">
       <code>$part</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion>
+    <MixedArgumentTypeCoercion occurrences="1">
       <code>$parts</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAssignment>
-      <code><![CDATA[$this->parts[]]]></code>
+    <MixedArrayAssignment occurrences="1">
+      <code>$this-&gt;parts[]</code>
     </MixedArrayAssignment>
-    <MixedAssignment>
+    <MixedAssignment occurrences="2">
       <code>$part</code>
       <code>static::$mockCounter</code>
     </MixedAssignment>
-    <MixedOperand>
+    <MixedOperand occurrences="1">
       <code>static::$mockCounter</code>
     </MixedOperand>
   </file>
   <file src="library/Mockery/Generator/Parameter.php">
-    <InvalidReturnStatement>
+    <InvalidReturnStatement occurrences="1">
       <code>\class_exists($typeHint) ? DefinedTargetClass::factory($typeHint, false) : null</code>
     </InvalidReturnStatement>
-    <InvalidReturnType>
+    <InvalidReturnType occurrences="1">
       <code>\ReflectionClass|null</code>
     </InvalidReturnType>
-    <MissingParamType>
+    <MissingParamType occurrences="1">
       <code>$method</code>
     </MissingParamType>
-    <PossiblyNullArgument>
+    <PossiblyNullArgument occurrences="1">
       <code>$typeHint</code>
     </PossiblyNullArgument>
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="3">
       <code>getClass</code>
       <code>getTypeHintAsString</code>
       <code>isArray</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="library/Mockery/Generator/StringManipulation/Pass/AvoidMethodClashPass.php">
-    <MissingClosureParamType>
+    <MissingClosureParamType occurrences="1">
       <code>$method</code>
     </MissingClosureParamType>
-    <MissingClosureReturnType>
+    <MissingClosureReturnType occurrences="1">
       <code>function ($method) {</code>
     </MissingClosureReturnType>
-    <MissingParamType>
+    <MissingParamType occurrences="1">
       <code>$code</code>
     </MissingParamType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="1">
       <code>apply</code>
     </MissingReturnType>
-    <MixedArgument>
+    <MixedArgument occurrences="2">
       <code>$code</code>
-      <code><![CDATA[$config->getMethodsToMock()]]></code>
+      <code>$config-&gt;getMethodsToMock()</code>
     </MixedArgument>
-    <MixedMethodCall>
+    <MixedMethodCall occurrences="1">
       <code>getName</code>
     </MixedMethodCall>
   </file>
   <file src="library/Mockery/Generator/StringManipulation/Pass/CallTypeHintPass.php">
-    <MissingParamType>
+    <MissingParamType occurrences="1">
       <code>$code</code>
     </MissingParamType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="1">
       <code>apply</code>
     </MissingReturnType>
-    <MixedArgument>
+    <MixedArgument occurrences="2">
       <code>$code</code>
       <code>$code</code>
     </MixedArgument>
   </file>
   <file src="library/Mockery/Generator/StringManipulation/Pass/ClassAttributesPass.php">
-    <MissingParamType>
+    <MissingParamType occurrences="1">
       <code>$code</code>
     </MissingParamType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="1">
       <code>apply</code>
     </MissingReturnType>
-    <MixedArgument>
+    <MixedArgument occurrences="1">
       <code>$code</code>
     </MixedArgument>
-    <MixedAssignment>
+    <MixedAssignment occurrences="1">
       <code>$class</code>
     </MixedAssignment>
-    <MixedMethodCall>
+    <MixedMethodCall occurrences="1">
       <code>getAttributes</code>
     </MixedMethodCall>
   </file>
   <file src="library/Mockery/Generator/StringManipulation/Pass/ClassNamePass.php">
-    <MissingParamType>
+    <MissingParamType occurrences="1">
       <code>$code</code>
     </MissingParamType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="1">
       <code>apply</code>
     </MissingReturnType>
-    <MixedArgument>
+    <MixedArgument occurrences="2">
       <code>$code</code>
       <code>$namespace</code>
     </MixedArgument>
-    <MixedAssignment>
+    <MixedAssignment occurrences="2">
       <code>$className</code>
       <code>$namespace</code>
     </MixedAssignment>
-    <MixedOperand>
+    <MixedOperand occurrences="1">
       <code>$className</code>
     </MixedOperand>
   </file>
   <file src="library/Mockery/Generator/StringManipulation/Pass/ClassPass.php">
-    <MissingParamType>
+    <MissingParamType occurrences="1">
       <code>$code</code>
     </MissingParamType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="1">
       <code>apply</code>
     </MissingReturnType>
-    <MixedArgument>
+    <MixedArgument occurrences="2">
       <code>$code</code>
-      <code><![CDATA[$target->getName()]]></code>
+      <code>$target-&gt;getName()</code>
     </MixedArgument>
-    <MixedAssignment>
+    <MixedAssignment occurrences="1">
       <code>$target</code>
     </MixedAssignment>
-    <MixedMethodCall>
+    <MixedMethodCall occurrences="2">
       <code>getName</code>
       <code>isFinal</code>
     </MixedMethodCall>
   </file>
   <file src="library/Mockery/Generator/StringManipulation/Pass/ConstantsPass.php">
-    <MissingParamType>
+    <MissingParamType occurrences="1">
       <code>$code</code>
     </MissingParamType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="1">
       <code>apply</code>
     </MissingReturnType>
-    <MixedArgument>
+    <MixedArgument occurrences="3">
       <code>$code</code>
       <code>$code</code>
       <code>$constant</code>
     </MixedArgument>
-    <MixedArrayAccess>
-      <code><![CDATA[$cm[$config->getName()]]]></code>
+    <MixedArrayAccess occurrences="1">
+      <code>$cm[$config-&gt;getName()]</code>
     </MixedArrayAccess>
-    <MixedArrayOffset>
-      <code><![CDATA[$cm[$config->getName()]]]></code>
-      <code><![CDATA[$cm[$config->getName()]]]></code>
+    <MixedArrayOffset occurrences="2">
+      <code>$cm[$config-&gt;getName()]</code>
+      <code>$cm[$config-&gt;getName()]</code>
     </MixedArrayOffset>
-    <MixedAssignment>
+    <MixedAssignment occurrences="4">
       <code>$cm</code>
       <code>$cm</code>
       <code>$constant</code>
       <code>$value</code>
     </MixedAssignment>
-    <PossiblyFalseArgument>
+    <PossiblyFalseArgument occurrences="1">
       <code>$i</code>
     </PossiblyFalseArgument>
   </file>
   <file src="library/Mockery/Generator/StringManipulation/Pass/InstanceMockPass.php">
-    <MissingParamType>
+    <MissingParamType occurrences="3">
       <code>$class</code>
       <code>$code</code>
       <code>$code</code>
     </MissingParamType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="2">
       <code>appendToClass</code>
       <code>apply</code>
     </MissingReturnType>
-    <MixedArgument>
+    <MixedArgument occurrences="2">
       <code>$class</code>
       <code>$class</code>
     </MixedArgument>
-    <MixedAssignment>
+    <MixedAssignment occurrences="1">
       <code>$code</code>
     </MixedAssignment>
-    <MixedOperand>
+    <MixedOperand occurrences="1">
       <code>$code</code>
     </MixedOperand>
-    <PossiblyFalseArgument>
+    <PossiblyFalseArgument occurrences="1">
       <code>$lastBrace</code>
     </PossiblyFalseArgument>
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="1">
       <code>apply</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="library/Mockery/Generator/StringManipulation/Pass/InterfacePass.php">
-    <MissingParamType>
+    <MissingParamType occurrences="1">
       <code>$code</code>
     </MissingParamType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="1">
       <code>apply</code>
     </MissingReturnType>
-    <MixedArgument>
+    <MixedArgument occurrences="3">
       <code>$code</code>
-      <code><![CDATA[$i->getName()]]></code>
-      <code><![CDATA[$i->getName()]]></code>
+      <code>$i-&gt;getName()</code>
+      <code>$i-&gt;getName()</code>
     </MixedArgument>
-    <MixedAssignment>
+    <MixedAssignment occurrences="1">
       <code>$i</code>
     </MixedAssignment>
-    <MixedMethodCall>
+    <MixedMethodCall occurrences="2">
       <code>getName</code>
       <code>getName</code>
     </MixedMethodCall>
-    <MixedOperand>
+    <MixedOperand occurrences="1">
       <code>$code</code>
     </MixedOperand>
   </file>
   <file src="library/Mockery/Generator/StringManipulation/Pass/MagicMethodTypeHintsPass.php">
-    <InvalidArgument>
-      <code>$code</code>
-      <code>$code</code>
-      <code>$code</code>
-      <code>$code</code>
-    </InvalidArgument>
-    <InvalidReturnStatement>
+    <InvalidReturnStatement occurrences="1">
       <code>$code</code>
     </InvalidReturnStatement>
-    <InvalidReturnType>
+    <InvalidReturnType occurrences="1">
       <code>string</code>
     </InvalidReturnType>
-    <MissingReturnType>
+    <InvalidScalarArgument occurrences="4">
+      <code>$code</code>
+      <code>$code</code>
+      <code>$code</code>
+      <code>$code</code>
+    </InvalidScalarArgument>
+    <MissingReturnType occurrences="1">
       <code>renderTypeHint</code>
     </MissingReturnType>
-    <MixedArgument>
-      <code><![CDATA[$config->getTargetClass()]]></code>
+    <MixedArgument occurrences="6">
+      <code>$config-&gt;getTargetClass()</code>
       <code>$interface</code>
       <code>$method</code>
-      <code><![CDATA[$method->getName()]]></code>
-      <code><![CDATA[$method->getName()]]></code>
-      <code><![CDATA[$method->getName()]]></code>
+      <code>$method-&gt;getName()</code>
+      <code>$method-&gt;getName()</code>
+      <code>$method-&gt;getName()</code>
     </MixedArgument>
-    <MixedAssignment>
+    <MixedAssignment occurrences="3">
       <code>$interface</code>
       <code>$method</code>
       <code>$name</code>
     </MixedAssignment>
-    <MixedOperand>
-      <code><![CDATA[$method->getName()]]></code>
+    <MixedOperand occurrences="3">
+      <code>$method-&gt;getName()</code>
       <code>$name</code>
-      <code><![CDATA[$this->renderTypeHint($parameter)]]></code>
+      <code>$this-&gt;renderTypeHint($parameter)</code>
     </MixedOperand>
   </file>
   <file src="library/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php">
-    <InvalidCast>
-      <code>$param</code>
-    </InvalidCast>
-    <InvalidMethodCall>
-      <code>getName</code>
-      <code>isPassedByReference</code>
-    </InvalidMethodCall>
-    <MissingParamType>
+    <MissingParamType occurrences="6">
       <code>$class</code>
       <code>$code</code>
       <code>$code</code>
@@ -1557,7 +1528,7 @@
       <code>$config</code>
       <code>$method</code>
     </MissingParamType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="6">
       <code>appendToClass</code>
       <code>apply</code>
       <code>renderMethodBody</code>
@@ -1565,34 +1536,30 @@
       <code>renderReturnType</code>
       <code>renderTypeHint</code>
     </MissingReturnType>
-    <MixedArgument>
+    <MixedArgument occurrences="11">
       <code>$class</code>
       <code>$class</code>
-      <code><![CDATA[$class->getName()]]></code>
-      <code><![CDATA[$class->getName()]]></code>
-      <code><![CDATA[$class->getName()]]></code>
+      <code>$class-&gt;getName()</code>
+      <code>$class-&gt;getName()</code>
+      <code>$class-&gt;getName()</code>
       <code>$method</code>
-      <code><![CDATA[$method->getParameters()]]></code>
-      <code><![CDATA[$overrides[$class_name][$method->getName()]]]></code>
-      <code><![CDATA[$overrides[strtolower($class->getName())][$method->getName()]]]></code>
-      <code><![CDATA[$param->__toString()]]></code>
-    </MixedArgument>
-    <MixedArgumentTypeCoercion>
+      <code>$method-&gt;getParameters()</code>
+      <code>$overrides[$class_name][$method-&gt;getName()]</code>
+      <code>$overrides[strtolower($class-&gt;getName())][$method-&gt;getName()]</code>
       <code>$param</code>
-    </MixedArgumentTypeCoercion>
-    <MixedArrayAccess>
+      <code>$param-&gt;__toString()</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="2">
       <code>$overrides[$class_name]</code>
-      <code><![CDATA[$overrides[$class_name][$method->getName()]]]></code>
-      <code><![CDATA[$overrides[strtolower($class->getName())]]]></code>
-      <code><![CDATA[$overrides[strtolower($class->getName())][$method->getName()]]]></code>
+      <code>$overrides[strtolower($class-&gt;getName())]</code>
     </MixedArrayAccess>
-    <MixedArrayOffset>
-      <code><![CDATA[$overrides[$class_name][$method->getName()]]]></code>
-      <code><![CDATA[$overrides[$class_name][$method->getName()]]]></code>
-      <code><![CDATA[$overrides[strtolower($class->getName())][$method->getName()]]]></code>
-      <code><![CDATA[$overrides[strtolower($class->getName())][$method->getName()]]]></code>
+    <MixedArrayOffset occurrences="4">
+      <code>$overrides[$class_name][$method-&gt;getName()]</code>
+      <code>$overrides[$class_name][$method-&gt;getName()]</code>
+      <code>$overrides[strtolower($class-&gt;getName())][$method-&gt;getName()]</code>
+      <code>$overrides[strtolower($class-&gt;getName())][$method-&gt;getName()]</code>
     </MixedArrayOffset>
-    <MixedAssignment>
+    <MixedAssignment occurrences="10">
       <code>$class</code>
       <code>$class</code>
       <code>$code</code>
@@ -1600,10 +1567,13 @@
       <code>$method</code>
       <code>$overrides</code>
       <code>$overrides</code>
+      <code>$param</code>
+      <code>$param</code>
       <code>$paramDef</code>
     </MixedAssignment>
-    <MixedMethodCall>
+    <MixedMethodCall occurrences="19">
       <code>getDeclaringClass</code>
+      <code>getName</code>
       <code>getName</code>
       <code>getName</code>
       <code>getName</code>
@@ -1615,185 +1585,169 @@
       <code>getParameters</code>
       <code>getReturnType</code>
       <code>isInternal</code>
+      <code>isPassedByReference</code>
       <code>isProtected</code>
       <code>isPublic</code>
       <code>isStatic</code>
       <code>isStatic</code>
       <code>returnsReference</code>
     </MixedMethodCall>
-    <MixedOperand>
+    <MixedOperand occurrences="6">
       <code>$code</code>
-      <code><![CDATA[$method->getName()]]></code>
+      <code>$method-&gt;getName()</code>
       <code>$paramDef</code>
-      <code><![CDATA[$this->renderMethodBody($method, $config)]]></code>
-      <code><![CDATA[$this->renderParams($method, $config)]]></code>
-      <code><![CDATA[$this->renderReturnType($method)]]></code>
+      <code>$this-&gt;renderMethodBody($method, $config)</code>
+      <code>$this-&gt;renderParams($method, $config)</code>
+      <code>$this-&gt;renderReturnType($method)</code>
     </MixedOperand>
-    <PossiblyFalseArgument>
+    <PossiblyFalseArgument occurrences="1">
       <code>$lastBrace</code>
     </PossiblyFalseArgument>
-    <TypeDoesNotContainType>
-      <code><![CDATA[strpos($param, '&') !== false]]></code>
-    </TypeDoesNotContainType>
+    <UndefinedFunction occurrences="1">
+      <code>enum_exists($prefix)</code>
+    </UndefinedFunction>
   </file>
   <file src="library/Mockery/Generator/StringManipulation/Pass/Pass.php">
-    <MissingParamType>
+    <MissingParamType occurrences="1">
       <code>$code</code>
     </MissingParamType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="1">
       <code>apply</code>
     </MissingReturnType>
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="1">
       <code>apply</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="library/Mockery/Generator/StringManipulation/Pass/RemoveBuiltinMethodsThatAreFinalPass.php">
-    <MissingParamType>
+    <MissingParamType occurrences="1">
       <code>$code</code>
     </MissingParamType>
-    <MissingPropertyType>
+    <MissingPropertyType occurrences="1">
       <code>$methods</code>
     </MissingPropertyType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="1">
       <code>apply</code>
     </MissingReturnType>
-    <MixedArgument>
+    <MixedArgument occurrences="2">
       <code>$code</code>
-      <code><![CDATA[$this->methods[$method->getName()]]]></code>
+      <code>$this-&gt;methods[$method-&gt;getName()]</code>
     </MixedArgument>
-    <MixedArrayAccess>
-      <code><![CDATA[$this->methods[$method->getName()]]]></code>
+    <MixedArrayAccess occurrences="1">
+      <code>$this-&gt;methods[$method-&gt;getName()]</code>
     </MixedArrayAccess>
-    <MixedArrayOffset>
-      <code><![CDATA[$this->methods[$method->getName()]]]></code>
-      <code><![CDATA[$this->methods[$method->getName()]]]></code>
+    <MixedArrayOffset occurrences="2">
+      <code>$this-&gt;methods[$method-&gt;getName()]</code>
+      <code>$this-&gt;methods[$method-&gt;getName()]</code>
     </MixedArrayOffset>
-    <MixedAssignment>
+    <MixedAssignment occurrences="2">
       <code>$method</code>
       <code>$target</code>
     </MixedAssignment>
-    <MixedMethodCall>
+    <MixedMethodCall occurrences="4">
       <code>getMethods</code>
       <code>getName</code>
       <code>getName</code>
       <code>isFinal</code>
     </MixedMethodCall>
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="1">
       <code>apply</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="library/Mockery/Generator/StringManipulation/Pass/RemoveDestructorPass.php">
-    <MissingParamType>
+    <MissingParamType occurrences="1">
       <code>$code</code>
     </MissingParamType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="1">
       <code>apply</code>
     </MissingReturnType>
-    <MixedArgument>
+    <MixedArgument occurrences="1">
       <code>$code</code>
     </MixedArgument>
-    <MixedAssignment>
+    <MixedAssignment occurrences="1">
       <code>$target</code>
     </MixedAssignment>
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="1">
       <code>apply</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="library/Mockery/Generator/StringManipulation/Pass/RemoveUnserializeForInternalSerializableClassesPass.php">
-    <MissingParamType>
+    <MissingParamType occurrences="3">
       <code>$class</code>
       <code>$code</code>
       <code>$code</code>
     </MissingParamType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="2">
       <code>appendToClass</code>
       <code>apply</code>
     </MissingReturnType>
-    <MixedArgument>
+    <MixedArgument occurrences="2">
       <code>$class</code>
       <code>$class</code>
     </MixedArgument>
-    <MixedAssignment>
+    <MixedAssignment occurrences="2">
       <code>$code</code>
       <code>$target</code>
     </MixedAssignment>
-    <MixedMethodCall>
+    <MixedMethodCall occurrences="2">
       <code>hasInternalAncestor</code>
       <code>implementsInterface</code>
     </MixedMethodCall>
-    <MixedOperand>
+    <MixedOperand occurrences="1">
       <code>$code</code>
     </MixedOperand>
-    <PossiblyFalseArgument>
+    <PossiblyFalseArgument occurrences="1">
       <code>$lastBrace</code>
     </PossiblyFalseArgument>
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="1">
       <code>apply</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="library/Mockery/Generator/StringManipulation/Pass/TraitPass.php">
-    <MissingClosureParamType>
+    <MissingClosureParamType occurrences="1">
       <code>$trait</code>
     </MissingClosureParamType>
-    <MissingParamType>
+    <MissingParamType occurrences="1">
       <code>$code</code>
     </MissingParamType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="1">
       <code>apply</code>
     </MissingReturnType>
-    <MixedArgument>
+    <MixedArgument occurrences="3">
       <code>$code</code>
-      <code><![CDATA[$trait->getName()]]></code>
+      <code>$trait-&gt;getName()</code>
       <code>$traits</code>
     </MixedArgument>
-    <MixedAssignment>
+    <MixedAssignment occurrences="1">
       <code>$traits</code>
     </MixedAssignment>
-    <MixedMethodCall>
+    <MixedMethodCall occurrences="1">
       <code>getName</code>
     </MixedMethodCall>
   </file>
   <file src="library/Mockery/Generator/StringManipulationGenerator.php">
-    <MissingReturnType>
+    <MissingReturnType occurrences="2">
       <code>addPass</code>
       <code>generate</code>
     </MissingReturnType>
-    <MixedArgument>
+    <MixedArgument occurrences="1">
       <code>$namedConfig</code>
     </MixedArgument>
-    <MixedAssignment>
+    <MixedAssignment occurrences="4">
       <code>$className</code>
       <code>$code</code>
       <code>$namedConfig</code>
       <code>$pass</code>
     </MixedAssignment>
-    <MixedMethodCall>
+    <MixedMethodCall occurrences="1">
       <code>apply</code>
     </MixedMethodCall>
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="1">
       <code>addPass</code>
     </PossiblyUnusedMethod>
-    <UnsafeInstantiation>
-      <code>new static([
-            new CallTypeHintPass(),
-            new MagicMethodTypeHintsPass(),
-            new ClassPass(),
-            new TraitPass(),
-            new ClassNamePass(),
-            new InstanceMockPass(),
-            new InterfacePass(),
-            new AvoidMethodClashPass(),
-            new MethodDefinitionPass(),
-            new RemoveUnserializeForInternalSerializableClassesPass(),
-            new RemoveBuiltinMethodsThatAreFinalPass(),
-            new RemoveDestructorPass(),
-            new ConstantsPass(),
-            new ClassAttributesPass(),
-        ])</code>
-    </UnsafeInstantiation>
+    <UnsafeInstantiation occurrences="1"/>
   </file>
   <file src="library/Mockery/Generator/TargetClassInterface.php">
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="6">
       <code>getAttributes</code>
       <code>getShortName</code>
       <code>hasInternalAncestor</code>
@@ -1803,100 +1757,86 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="library/Mockery/Generator/UndefinedTargetClass.php">
-    <MethodSignatureMustProvideReturnType>
-      <code>__toString</code>
-    </MethodSignatureMustProvideReturnType>
-    <MissingParamType>
+    <MissingParamType occurrences="1">
       <code>$name</code>
     </MissingParamType>
-    <MissingPropertyType>
+    <MissingPropertyType occurrences="1">
       <code>$name</code>
     </MissingPropertyType>
-    <MixedInferredReturnType>
+    <MixedInferredReturnType occurrences="1">
       <code>getName</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement>
-      <code><![CDATA[$this->name]]></code>
-      <code><![CDATA[$this->name]]></code>
+    <MixedReturnStatement occurrences="1">
+      <code>$this-&gt;name</code>
     </MixedReturnStatement>
   </file>
   <file src="library/Mockery/HigherOrderMessage.php">
-    <MissingParamType>
+    <MissingParamType occurrences="3">
       <code>$args</code>
       <code>$method</code>
       <code>$method</code>
     </MissingParamType>
-    <MissingPropertyType>
+    <MissingPropertyType occurrences="1">
       <code>$method</code>
     </MissingPropertyType>
-    <MixedAssignment>
+    <MixedAssignment occurrences="1">
       <code>$expectation</code>
     </MixedAssignment>
-    <MixedInferredReturnType>
+    <MixedInferredReturnType occurrences="1">
       <code>\Mockery\Expectation</code>
     </MixedInferredReturnType>
-    <MixedMethodCall>
+    <MixedMethodCall occurrences="1">
       <code>withArgs</code>
     </MixedMethodCall>
-    <MixedReturnStatement>
-      <code><![CDATA[$expectation->withArgs($args)]]></code>
-      <code><![CDATA[$this->mock->{$this->method}($method, $args)]]></code>
+    <MixedReturnStatement occurrences="2">
+      <code>$expectation-&gt;withArgs($args)</code>
+      <code>$this-&gt;mock-&gt;{$this-&gt;method}($method, $args)</code>
     </MixedReturnStatement>
   </file>
   <file src="library/Mockery/Instantiator.php">
-    <InvalidArgument>
-      <code><![CDATA[function ($code, $message, $file, $line) use ($reflectionClass, & $error) {
-            $msg = sprintf(
-                'Could not produce an instance of "%s" via un-serialization, since an error was triggered in file "%s" at line "%d"',
-                $reflectionClass->getName(),
-                $file,
-                $line
-            );
-
-            $error = new UnexpectedValueException($msg, 0, new \Exception($message, $code));
-        }]]></code>
-    </InvalidArgument>
-    <MissingClosureReturnType>
+    <InvalidArgument occurrences="1"/>
+    <MissingClosureReturnType occurrences="1">
       <code>function () use ($serializedString) {</code>
     </MissingClosureReturnType>
-    <MissingParamType>
+    <MissingParamType occurrences="1">
       <code>$className</code>
     </MissingParamType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="1">
       <code>instantiate</code>
     </MissingReturnType>
-    <MixedArgument>
+    <MixedArgument occurrences="1">
       <code>$className</code>
     </MixedArgument>
-    <MixedAssignment>
+    <MixedAssignment occurrences="1">
       <code>$instance</code>
     </MixedAssignment>
-    <UnusedMethod>
+    <UnusedMethod occurrences="1">
       <code>hasInternalAncestors</code>
     </UnusedMethod>
-    <UnusedVariable>
+    <UnusedVariable occurrences="1">
       <code>$error</code>
     </UnusedVariable>
   </file>
   <file src="library/Mockery/LegacyMockInterface.php">
-    <MissingParamType>
+    <MissingParamType occurrences="3">
       <code>$method</code>
       <code>$method</code>
       <code>$method</code>
     </MissingParamType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="3">
       <code>mockery_setCurrentOrder</code>
       <code>mockery_setGroup</code>
       <code>shouldAllowMockingMethod</code>
     </MissingReturnType>
-    <PossiblyInvalidDocblockTag>
+    <PossiblyInvalidDocblockTag occurrences="4">
       <code>@var array $args</code>
       <code>@var string $method</code>
       <code>@var string $method</code>
       <code>@var string $method</code>
     </PossiblyInvalidDocblockTag>
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="23">
       <code>byDefault</code>
+      <code>makePartial</code>
       <code>mockery_allocateOrder</code>
       <code>mockery_findExpectation</code>
       <code>mockery_getCurrentOrder</code>
@@ -1904,6 +1844,8 @@
       <code>mockery_getGroups</code>
       <code>mockery_getMockableProperties</code>
       <code>mockery_init</code>
+      <code>mockery_setCurrentOrder</code>
+      <code>mockery_setExpectationsFor</code>
       <code>mockery_setGroup</code>
       <code>mockery_teardown</code>
       <code>mockery_verify</code>
@@ -1911,511 +1853,251 @@
       <code>shouldAllowMockingProtectedMethods</code>
       <code>shouldDeferMissing</code>
       <code>shouldHaveBeenCalled</code>
+      <code>shouldHaveReceived</code>
+      <code>shouldIgnoreMissing</code>
       <code>shouldNotHaveBeenCalled</code>
+      <code>shouldNotHaveReceived</code>
       <code>shouldNotReceive</code>
     </PossiblyUnusedMethod>
-    <PossiblyUnusedReturnValue>
-      <code>\Mockery\ExpectationDirector|null</code>
-      <code>static</code>
-    </PossiblyUnusedReturnValue>
-    <UndefinedDocblockClass>
+    <UndefinedDocblockClass occurrences="2">
       <code>null|array|Closure</code>
       <code>null|array|Closure</code>
     </UndefinedDocblockClass>
   </file>
   <file src="library/Mockery/Loader/EvalLoader.php">
-    <MissingReturnType>
+    <MissingReturnType occurrences="1">
       <code>load</code>
     </MissingReturnType>
-    <MixedArgument>
-      <code><![CDATA[$definition->getClassName()]]></code>
+    <MixedArgument occurrences="1">
+      <code>$definition-&gt;getClassName()</code>
     </MixedArgument>
-    <MixedOperand>
-      <code><![CDATA[$definition->getCode()]]></code>
+    <MixedOperand occurrences="1">
+      <code>$definition-&gt;getCode()</code>
     </MixedOperand>
   </file>
   <file src="library/Mockery/Loader/Loader.php">
-    <MissingReturnType>
+    <MissingReturnType occurrences="1">
       <code>load</code>
     </MissingReturnType>
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="1">
       <code>load</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="library/Mockery/Loader/RequireLoader.php">
-    <MissingParamType>
+    <MissingParamType occurrences="1">
       <code>$path</code>
     </MissingParamType>
-    <MissingPropertyType>
+    <MissingPropertyType occurrences="1">
       <code>$path</code>
     </MissingPropertyType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="1">
       <code>load</code>
     </MissingReturnType>
-    <MixedArgument>
-      <code><![CDATA[$definition->getClassName()]]></code>
-      <code><![CDATA[$definition->getCode()]]></code>
+    <MixedArgument occurrences="3">
+      <code>$definition-&gt;getClassName()</code>
+      <code>$definition-&gt;getCode()</code>
       <code>$path</code>
     </MixedArgument>
-    <MixedOperand>
-      <code><![CDATA[$this->path]]></code>
+    <MixedOperand occurrences="1">
+      <code>$this-&gt;path</code>
     </MixedOperand>
-    <UnresolvableInclude>
+    <UnresolvableInclude occurrences="1">
       <code>require $tmpfname</code>
     </UnresolvableInclude>
-    <UnusedClass>
+    <UnusedClass occurrences="1">
       <code>RequireLoader</code>
     </UnusedClass>
   </file>
-  <file src="library/Mockery/Matcher/AndAnyOtherArgs.php">
-    <MethodSignatureMustProvideReturnType>
-      <code>__toString</code>
-    </MethodSignatureMustProvideReturnType>
-  </file>
-  <file src="library/Mockery/Matcher/Any.php">
-    <MethodSignatureMustProvideReturnType>
-      <code>__toString</code>
-    </MethodSignatureMustProvideReturnType>
-  </file>
-  <file src="library/Mockery/Matcher/AnyArgs.php">
-    <MethodSignatureMustProvideReturnType>
-      <code>__toString</code>
-    </MethodSignatureMustProvideReturnType>
-  </file>
   <file src="library/Mockery/Matcher/AnyOf.php">
-    <MethodSignatureMustProvideReturnType>
-      <code>__toString</code>
-    </MethodSignatureMustProvideReturnType>
-    <MixedArgument>
-      <code><![CDATA[$this->_expected]]></code>
+    <MixedArgument occurrences="1">
+      <code>$this-&gt;_expected</code>
     </MixedArgument>
   </file>
   <file src="library/Mockery/Matcher/Closure.php">
-    <MethodSignatureMustProvideReturnType>
-      <code>__toString</code>
-    </MethodSignatureMustProvideReturnType>
-    <MixedAssignment>
+    <MixedAssignment occurrences="2">
       <code>$closure</code>
       <code>$result</code>
     </MixedAssignment>
-    <MixedFunctionCall>
+    <MixedFunctionCall occurrences="1">
       <code>$closure($actual)</code>
     </MixedFunctionCall>
   </file>
   <file src="library/Mockery/Matcher/Contains.php">
-    <MethodSignatureMustProvideReturnType>
-      <code>__toString</code>
-    </MethodSignatureMustProvideReturnType>
-    <MixedArgument>
+    <MixedArgument occurrences="1">
       <code>$actual</code>
     </MixedArgument>
-    <MixedAssignment>
+    <MixedAssignment occurrences="3">
       <code>$exp</code>
       <code>$v</code>
+      <code>$val</code>
     </MixedAssignment>
   </file>
   <file src="library/Mockery/Matcher/Ducktype.php">
-    <MethodSignatureMustProvideReturnType>
-      <code>__toString</code>
-    </MethodSignatureMustProvideReturnType>
-    <MixedArgument>
+    <MixedArgument occurrences="2">
       <code>$method</code>
-      <code><![CDATA[$this->_expected]]></code>
+      <code>$this-&gt;_expected</code>
     </MixedArgument>
-    <MixedAssignment>
+    <MixedAssignment occurrences="1">
       <code>$method</code>
     </MixedAssignment>
   </file>
   <file src="library/Mockery/Matcher/HasKey.php">
-    <MethodSignatureMustProvideReturnType>
-      <code>__toString</code>
-    </MethodSignatureMustProvideReturnType>
-    <MixedArgument>
+    <MixedArgument occurrences="2">
       <code>$actual</code>
-      <code><![CDATA[$this->_expected]]></code>
+      <code>$this-&gt;_expected</code>
     </MixedArgument>
   </file>
   <file src="library/Mockery/Matcher/HasValue.php">
-    <MethodSignatureMustProvideReturnType>
-      <code>__toString</code>
-    </MethodSignatureMustProvideReturnType>
-    <MixedArgument>
+    <MixedArgument occurrences="1">
       <code>$actual</code>
     </MixedArgument>
   </file>
   <file src="library/Mockery/Matcher/IsEqual.php">
-    <MethodSignatureMustProvideReturnType>
-      <code>__toString</code>
-    </MethodSignatureMustProvideReturnType>
-    <UnusedClass>
+    <UnusedClass occurrences="1">
       <code>IsEqual</code>
     </UnusedClass>
   </file>
   <file src="library/Mockery/Matcher/IsSame.php">
-    <MethodSignatureMustProvideReturnType>
-      <code>__toString</code>
-    </MethodSignatureMustProvideReturnType>
-    <UnusedClass>
+    <UnusedClass occurrences="1">
       <code>IsSame</code>
     </UnusedClass>
   </file>
-  <file src="library/Mockery/Matcher/MatcherAbstract.php">
-    <MethodSignatureMustProvideReturnType>
-      <code>__toString</code>
-    </MethodSignatureMustProvideReturnType>
-  </file>
   <file src="library/Mockery/Matcher/MultiArgumentClosure.php">
-    <MethodSignatureMustProvideReturnType>
-      <code>__toString</code>
-    </MethodSignatureMustProvideReturnType>
-    <MixedAssignment>
+    <MixedAssignment occurrences="1">
       <code>$closure</code>
     </MixedAssignment>
-    <MixedFunctionCall>
+    <MixedFunctionCall occurrences="1">
       <code>call_user_func_array($closure, $actual)</code>
     </MixedFunctionCall>
   </file>
-  <file src="library/Mockery/Matcher/MustBe.php">
-    <MethodSignatureMustProvideReturnType>
-      <code>__toString</code>
-    </MethodSignatureMustProvideReturnType>
-  </file>
   <file src="library/Mockery/Matcher/NoArgs.php">
-    <MethodSignatureMustProvideReturnType>
-      <code>__toString</code>
-    </MethodSignatureMustProvideReturnType>
-    <MixedArgument>
+    <MixedArgument occurrences="1">
       <code>$actual</code>
     </MixedArgument>
   </file>
-  <file src="library/Mockery/Matcher/Not.php">
-    <MethodSignatureMustProvideReturnType>
-      <code>__toString</code>
-    </MethodSignatureMustProvideReturnType>
-  </file>
   <file src="library/Mockery/Matcher/NotAnyOf.php">
-    <MethodSignatureMustProvideReturnType>
-      <code>__toString</code>
-    </MethodSignatureMustProvideReturnType>
-    <MixedAssignment>
+    <MixedAssignment occurrences="1">
       <code>$exp</code>
     </MixedAssignment>
   </file>
   <file src="library/Mockery/Matcher/Pattern.php">
-    <MethodSignatureMustProvideReturnType>
-      <code>__toString</code>
-    </MethodSignatureMustProvideReturnType>
-    <MixedArgument>
-      <code><![CDATA[$this->_expected]]></code>
+    <MixedArgument occurrences="1">
+      <code>$this-&gt;_expected</code>
     </MixedArgument>
   </file>
   <file src="library/Mockery/Matcher/Subset.php">
-    <MethodSignatureMustProvideReturnType>
-      <code>__toString</code>
-    </MethodSignatureMustProvideReturnType>
-    <MissingPropertyType>
+    <MissingPropertyType occurrences="1">
       <code>$strict</code>
     </MissingPropertyType>
-    <MixedAssignment>
+    <MixedAssignment occurrences="1">
       <code>$v</code>
     </MixedAssignment>
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="2">
       <code>loose</code>
       <code>strict</code>
     </PossiblyUnusedMethod>
-    <UnsafeInstantiation>
+    <UnsafeInstantiation occurrences="2">
       <code>new static($expected, false)</code>
       <code>new static($expected, true)</code>
     </UnsafeInstantiation>
   </file>
   <file src="library/Mockery/Matcher/Type.php">
-    <MethodSignatureMustProvideReturnType>
-      <code>__toString</code>
-    </MethodSignatureMustProvideReturnType>
-    <MixedArgument>
-      <code><![CDATA[$this->_expected]]></code>
-      <code><![CDATA[$this->_expected]]></code>
+    <MixedArgument occurrences="2">
+      <code>$this-&gt;_expected</code>
+      <code>$this-&gt;_expected</code>
     </MixedArgument>
-    <MixedInferredReturnType>
+    <MixedInferredReturnType occurrences="1">
       <code>bool</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement>
+    <MixedReturnStatement occurrences="1">
       <code>$function($actual)</code>
     </MixedReturnStatement>
-    <TypeDoesNotContainType>
+    <TypeDoesNotContainType occurrences="1">
       <code>function_exists($function)</code>
     </TypeDoesNotContainType>
   </file>
   <file src="library/Mockery/MethodCall.php">
-    <MissingParamType>
+    <MissingParamType occurrences="2">
       <code>$args</code>
       <code>$method</code>
     </MissingParamType>
-    <MissingPropertyType>
+    <MissingPropertyType occurrences="2">
       <code>$args</code>
       <code>$method</code>
     </MissingPropertyType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="2">
       <code>getArgs</code>
       <code>getMethod</code>
     </MissingReturnType>
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="3">
+      <code>__construct</code>
       <code>getArgs</code>
       <code>getMethod</code>
     </PossiblyUnusedMethod>
-  </file>
-  <file src="library/Mockery/Mock.php">
-    <MethodSignatureMustProvideReturnType>
-      <code>__toString</code>
-    </MethodSignatureMustProvideReturnType>
-    <MissingClosureParamType>
-      <code>$method</code>
-    </MissingClosureParamType>
-    <MissingClosureReturnType>
-      <code>function ($method) {</code>
-      <code>function () { yield; }</code>
-    </MissingClosureReturnType>
-    <MissingParamType>
-      <code>$method</code>
-      <code>$method</code>
-      <code>$method</code>
-      <code>$method</code>
-      <code>$method</code>
-      <code>$method</code>
-      <code>$method</code>
-      <code>$method</code>
-      <code>$name</code>
-      <code>$name</code>
-    </MissingParamType>
-    <MissingPropertyType>
-      <code>$_mockery_allowMockingProtectedMethods</code>
-      <code>$_mockery_instanceMock</code>
-      <code>$_mockery_receivedMethodCalls</code>
-    </MissingPropertyType>
-    <MissingReturnType>
-      <code>_mockery_constructorCalled</code>
-      <code>_mockery_findExpectedMethodHandler</code>
-      <code>_mockery_getReceivedMethodCalls</code>
-      <code>_mockery_handleMethodCall</code>
-      <code>_mockery_handleStaticMethodCall</code>
-      <code>asUndefined</code>
-      <code>hasMethodOverloadingInParentClass</code>
-      <code>mockery_getExpectations</code>
-      <code>mockery_getMethod</code>
-      <code>mockery_isInstance</code>
-      <code>mockery_setCurrentOrder</code>
-      <code>mockery_setGroup</code>
-    </MissingReturnType>
-    <MixedArrayOffset>
-      <code><![CDATA[$this->_mockery_expectations[$method]]]></code>
-      <code><![CDATA[$this->_mockery_expectations[$method]]]></code>
-      <code><![CDATA[$this->_mockery_expectations[$method]]]></code>
-      <code><![CDATA[$this->_mockery_expectations[$method]]]></code>
-      <code><![CDATA[$this->_mockery_groups[$group]]]></code>
-    </MixedArrayOffset>
-    <MixedAssignment>
-      <code>$allowMockingProtectedMethods</code>
-      <code>$count</code>
-      <code>$director</code>
-      <code>$director</code>
-      <code>$director</code>
-      <code>$director</code>
-      <code>$exp</code>
-      <code>$expectation</code>
-      <code>$exps</code>
-      <code>$handler</code>
-      <code>$method</code>
-      <code>$method</code>
-      <code>$method</code>
-      <code>$method</code>
-      <code>$prototype</code>
-      <code>$returnValue</code>
-      <code>$rm</code>
-      <code>$rm</code>
-      <code>$rm</code>
-    </MixedAssignment>
-    <MixedInferredReturnType>
-      <code>\Mockery\ExpectationDirector|null</code>
-      <code>\Mockery\ExpectationInterface|\Mockery\Expectation|ExpectsHigherOrderMessage</code>
-      <code>\Mockery\ExpectationInterface|\Mockery\Expectation|\Mockery\HigherOrderMessage</code>
-      <code>\Mockery\Expectation|null</code>
-      <code>int</code>
-    </MixedInferredReturnType>
-    <MixedMethodCall>
-      <code>byDefault</code>
-      <code>call</code>
-      <code>findExpectation</code>
-      <code>getExpectationCount</code>
-      <code>getExpectations</code>
-      <code>getName</code>
-      <code>getName</code>
-      <code>getName</code>
-      <code>getName</code>
-      <code>getPrototype</code>
-      <code>isAbstract</code>
-      <code>isAbstract</code>
-      <code>isPrivate</code>
-      <code>isProtected</code>
-      <code>isProtected</code>
-      <code>isProtected</code>
-      <code>isPublic</code>
-      <code>isPublic</code>
-      <code>never</code>
-      <code>push</code>
-      <code>setActualOrder</code>
-      <code>setExpectedOrder</code>
-      <code>setMethodName</code>
-      <code>verify</code>
-    </MixedMethodCall>
-    <MixedOperand>
-      <code>$count</code>
-      <code>$method</code>
-      <code>$method</code>
-      <code>$method</code>
-      <code>$method</code>
-      <code>$method</code>
-      <code>$method</code>
-      <code>$method</code>
-    </MixedOperand>
-    <MixedReturnStatement>
-      <code>$count</code>
-      <code><![CDATA[$director->findExpectation($args)]]></code>
-      <code>$expectation</code>
-      <code><![CDATA[$this->__call('__toString', array())]]></code>
-      <code><![CDATA[$this->_mockery_expectations[$method]]]></code>
-      <code><![CDATA[$this->shouldReceive($something)->once()]]></code>
-    </MixedReturnStatement>
-    <MixedReturnTypeCoercion>
-      <code><![CDATA[$this->_mockery_mockableMethods]]></code>
-      <code>string[]</code>
-    </MixedReturnTypeCoercion>
-    <MoreSpecificImplementedParamType>
-      <code>$methodNames</code>
-      <code>$methodNames</code>
-    </MoreSpecificImplementedParamType>
-    <PossiblyInvalidDocblockTag>
-      <code>@var array $args</code>
-      <code>@var string $method</code>
-      <code>@var string $method</code>
-      <code>@var string $method</code>
-    </PossiblyInvalidDocblockTag>
-    <PossiblyNullPropertyAssignmentValue>
-      <code>null</code>
-      <code>null</code>
-      <code>null</code>
-    </PossiblyNullPropertyAssignmentValue>
-    <PossiblyUnusedMethod>
-      <code>__callStatic</code>
-      <code>_mockery_constructorCalled</code>
-      <code>asUndefined</code>
-      <code>mockery_callSubjectMethod</code>
-      <code>mockery_getExpectations</code>
-      <code>mockery_thrownExceptions</code>
-    </PossiblyUnusedMethod>
-    <PossiblyUnusedProperty>
-      <code>$_mockery_name</code>
-    </PossiblyUnusedProperty>
-    <PossiblyUnusedReturnValue>
-      <code>\Mockery\ExpectationDirector|null</code>
-    </PossiblyUnusedReturnValue>
-    <RedundantCondition>
-      <code><![CDATA[$i->getName() !== 'Stringable']]></code>
-    </RedundantCondition>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[!is_null($this->_mockery_partial)]]></code>
-      <code><![CDATA[isset($this->_mockery_partial)]]></code>
-    </RedundantConditionGivenDocblockType>
-    <TooManyArguments>
-      <code>shouldIgnoreMissing</code>
-      <code>shouldIgnoreMissing</code>
-    </TooManyArguments>
-    <UndefinedInterfaceMethod>
-      <code>once</code>
-    </UndefinedInterfaceMethod>
-    <UndefinedMagicMethod>
-      <code>andReturn</code>
-      <code>once</code>
-    </UndefinedMagicMethod>
   </file>
   <file src="library/Mockery/MockInterface.php">
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="2">
       <code>allows</code>
       <code>expects</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="library/Mockery/ReceivedMethodCalls.php">
-    <MissingPropertyType>
+    <MissingPropertyType occurrences="1">
       <code>$methodCalls</code>
     </MissingPropertyType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="2">
       <code>push</code>
       <code>verify</code>
     </MissingReturnType>
-    <MixedArgument>
-      <code><![CDATA[$methodCall->getArgs()]]></code>
-      <code><![CDATA[$methodCall->getArgs()]]></code>
+    <MixedArgument occurrences="2">
+      <code>$methodCall-&gt;getArgs()</code>
+      <code>$methodCall-&gt;getArgs()</code>
     </MixedArgument>
-    <MixedArrayAssignment>
-      <code><![CDATA[$this->methodCalls[]]]></code>
+    <MixedArrayAssignment occurrences="1">
+      <code>$this-&gt;methodCalls[]</code>
     </MixedArrayAssignment>
-    <MixedAssignment>
+    <MixedAssignment occurrences="1">
       <code>$methodCall</code>
     </MixedAssignment>
-    <MixedMethodCall>
+    <MixedMethodCall occurrences="3">
       <code>getArgs</code>
       <code>getArgs</code>
       <code>getMethod</code>
     </MixedMethodCall>
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="1">
       <code>push</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="library/Mockery/Reflector.php">
-    <MixedArgument>
-      <code>$typeHint</code>
-    </MixedArgument>
-    <MixedAssignment>
-      <code>$typeHint</code>
+    <MixedAssignment occurrences="2">
+      <code>$type</code>
+      <code>$type</code>
     </MixedAssignment>
-    <MixedReturnTypeCoercion>
-      <code><![CDATA[[
-                [
-                    'typeHint' => $typeHint,
-                    'isPrimitive' => in_array($typeHint, ['array', 'bool', 'int', 'float', 'null', 'object', 'string']),
-                ],
-            ]]]></code>
-      <code><![CDATA[list<array{typeHint: string, isPrimitive: bool}>]]></code>
-    </MixedReturnTypeCoercion>
-    <PossiblyNullArgument>
+    <MixedInferredReturnType occurrences="2">
+      <code>list&lt;array{typeHint: string, isPrimitive: bool}&gt;</code>
+      <code>string</code>
+    </MixedInferredReturnType>
+    <PossiblyNullArgument occurrences="1">
       <code>$declaringClass</code>
     </PossiblyNullArgument>
-    <RedundantCondition>
-      <code><![CDATA[is_null($type) && method_exists($method, 'getTentativeReturnType')]]></code>
-      <code><![CDATA[is_null($type) && method_exists($method, 'getTentativeReturnType')]]></code>
-    </RedundantCondition>
-    <UndefinedMethod>
-      <code>getName</code>
-      <code>isBuiltin</code>
-    </UndefinedMethod>
-    <UnusedDocblockParam>
-      <code>$param</code>
-      <code>$param</code>
-    </UnusedDocblockParam>
+    <PossiblyUnusedMethod occurrences="1">
+      <code>getSimplestReturnType</code>
+    </PossiblyUnusedMethod>
+    <UndefinedClass occurrences="2">
+      <code>\ReflectionIntersectionType</code>
+      <code>\ReflectionUnionType</code>
+    </UndefinedClass>
+    <UnusedParam occurrences="1">
+      <code>$declaringClass</code>
+    </UnusedParam>
   </file>
   <file src="library/Mockery/Undefined.php">
-    <MethodSignatureMustProvideReturnType>
-      <code>__toString</code>
-    </MethodSignatureMustProvideReturnType>
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="1">
       <code>__call</code>
     </PossiblyUnusedMethod>
-    <PossiblyUnusedParam>
-      <code>$args</code>
-      <code>$method</code>
-    </PossiblyUnusedParam>
   </file>
   <file src="library/Mockery/VerificationDirector.php">
-    <MissingParamType>
+    <MissingParamType occurrences="9">
       <code>$args</code>
       <code>$args</code>
       <code>$args</code>
@@ -2426,7 +2108,7 @@
       <code>$method</code>
       <code>$minimum</code>
     </MissingParamType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="13">
       <code>atLeast</code>
       <code>atMost</code>
       <code>between</code>
@@ -2441,7 +2123,7 @@
       <code>withArgs</code>
       <code>withNoArgs</code>
     </MissingReturnType>
-    <PossiblyUnusedMethod>
+    <PossiblyUnusedMethod occurrences="10">
       <code>atLeast</code>
       <code>atMost</code>
       <code>between</code>
@@ -2455,17 +2137,17 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="library/Mockery/VerificationExpectation.php">
-    <MissingReturnType>
+    <MissingReturnType occurrences="1">
       <code>clearCountValidators</code>
     </MissingReturnType>
   </file>
   <file src="library/helpers.php">
-    <MissingParamType>
+    <MissingParamType occurrences="3">
       <code>$args</code>
       <code>$args</code>
       <code>$args</code>
     </MissingParamType>
-    <MissingReturnType>
+    <MissingReturnType occurrences="6">
       <code>andAnyOtherArgs</code>
       <code>andAnyOthers</code>
       <code>anyArgs</code>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
-    phpVersion="8.2"
+    phpVersion="7.3"
     findUnusedBaselineEntry="true"
     findUnusedCode="true"
     errorBaseline="psalm-baseline.xml"
@@ -12,22 +12,11 @@
     <projectFiles>
         <directory name="library"/>
         <ignoreFiles>
+            <file name="library/Mockery/Mock.php" />
             <directory name="tests"/>
             <directory name="vendor"/>
         </ignoreFiles>
     </projectFiles>
-    <issueHandlers>
-        <PossiblyInvalidArgument>
-            <errorLevel type="suppress">
-                <file name="library/Mockery/Mock.php" />
-            </errorLevel>
-        </PossiblyInvalidArgument>
-        <MixedArgument>
-            <errorLevel type="suppress">
-                <file name="library/Mockery/Mock.php" />
-            </errorLevel>
-        </MixedArgument>
-    </issueHandlers>
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
     </plugins>

--- a/tests/Mockery/Matcher/SubsetTest.php
+++ b/tests/Mockery/Matcher/SubsetTest.php
@@ -22,9 +22,11 @@ namespace tests\Mockery\Matcher;
 
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\Matcher\Subset;
+use test\Mockery\RegExpCompatability;
 
 class SubsetTest extends MockeryTestCase
 {
+    use RegExpCompatability;
     /** @test */
     public function it_matches_a_shallow_subset()
     {
@@ -115,7 +117,7 @@ class SubsetTest extends MockeryTestCase
         ];
 
         foreach ($tests as $pattern) {
-            $this->assertMatchesRegularExpression($pattern, $actual);
+            self::assertMatchesRegEx($pattern, $actual);
         }
     }
 }


### PR DESCRIPTION
This pull request addresses compatibility issues with PHP 7.3, 

We have reviewed the reported problems and made necessary adjustments to align with PHP 7.3's syntax and requirements.

Our aim is to maintain broad compatibility and offer a seamless experience for users using older PHP versions.

Please review the changes, and if there are any additional concerns, kindly let us know.

Thank you