### PR TITLE
Fix misspelling in docs

### DIFF
--- a/docs/reference/spies.rst
+++ b/docs/reference/spies.rst
@@ -18,7 +18,7 @@ Spies also allow us to follow the more familiar Arrange-Act-Assert or
 Given-When-Then style within our tests. With mocks, we have to follow a less
 familiar style, something along the lines of Arrange-Expect-Act-Assert, where
 we have to tell our mocks what to expect before we act on the SUT, then assert
-that those expectations where met:
+that those expectations were met:
 
 .. code-block:: php
 


### PR DESCRIPTION
This change fixes a misspelled word in the documentation page for spies.