### PR TITLE
Autoload Test Fixtures Based on PHP Runtime Version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,6 +73,7 @@
             "test\\": "tests/"
         },
         "files": [
+            "fixtures/autoload.php",
             "vendor/hamcrest/hamcrest-php/hamcrest/Hamcrest.php"
         ]
     },

--- a/fixtures/autoload.php
+++ b/fixtures/autoload.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+if (!function_exists('recursiveGlob')) {
+    function globRecursively($pattern)
+    {
+        $files = glob($pattern) ?: [];
+        foreach (glob(dirname($pattern) . '/*', GLOB_ONLYDIR | GLOB_NOSORT) ?: [] as $dir) {
+            $files = array_merge($files, globRecursively($dir . '/' . basename($pattern)));
+        }
+        return $files;
+    }
+}
+
+// Autoload test fixtures for supported PHP versions (current and previous)
+
+$phpVersions = [
+    'PHP83' => 80300,
+    'PHP82' => 80200,
+    'PHP81' => 80100,
+    'PHP80' => 80000,
+    'PHP74' => 70400,
+    'PHP73' => 70300,
+    'PHP72' => 70200,
+];
+
+$allVersions = implode('|', array_keys($phpVersions));
+
+$currentSupportedVersion = implode('|', array_keys(array_filter($phpVersions, static function (int $version): bool {
+    return PHP_VERSION_ID >= $version;
+})));
+
+$allTestsAndFixtures = globRecursively(dirname(__DIR__) . '/fixtures/*.php');
+
+$currentSupportedVersionTestsAndFixtures = array_filter(
+    $allTestsAndFixtures,
+    static function (string $filePath) use ($currentSupportedVersion): bool {
+        return preg_match('#' . $currentSupportedVersion . '#', $filePath) === 1;
+    }
+);
+
+$allPhpVersionTestsAndFixtures = array_filter(
+    $allTestsAndFixtures,
+    static function (string $filePath) use ($allVersions): bool {
+        return preg_match('#' . $allVersions . '#', $filePath) === 1;
+    }
+);
+
+$excludedPhpVersions = array_diff($allPhpVersionTestsAndFixtures, $currentSupportedVersionTestsAndFixtures);
+
+$autoloadTestsAndFixtures = array_diff($allTestsAndFixtures, $excludedPhpVersions);
+
+array_map(
+    static function (string $file): void {
+        if (!file_exists($file)) {
+            return;
+        }
+
+        require_once $file;
+    },
+    $autoloadTestsAndFixtures
+);

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -981,6 +981,9 @@
       <code>isInternal</code>
       <code>isInternal</code>
     </MixedMethodCall>
+    <MixedOperand occurrences="1">
+      <code>$attribute-&gt;getName()</code>
+    </MixedOperand>
     <MixedReturnStatement occurrences="7">
       <code>$this-&gt;name</code>
       <code>$this-&gt;rfc-&gt;getNamespaceName()</code>
@@ -990,9 +993,6 @@
       <code>$this-&gt;rfc-&gt;isAbstract()</code>
       <code>$this-&gt;rfc-&gt;isFinal()</code>
     </MixedReturnStatement>
-    <UndefinedClass occurrences="1">
-      <code>ReflectionAttribute</code>
-    </UndefinedClass>
   </file>
   <file src="library/Mockery/Generator/Generator.php">
     <MissingReturnType occurrences="1">
@@ -1603,9 +1603,6 @@
     <PossiblyFalseArgument occurrences="1">
       <code>$lastBrace</code>
     </PossiblyFalseArgument>
-    <UndefinedFunction occurrences="1">
-      <code>enum_exists($prefix)</code>
-    </UndefinedFunction>
   </file>
   <file src="library/Mockery/Generator/StringManipulation/Pass/Pass.php">
     <MissingParamType occurrences="1">
@@ -1893,16 +1890,17 @@
     <MissingReturnType occurrences="1">
       <code>load</code>
     </MissingReturnType>
-    <MixedArgument occurrences="3">
+    <MixedArgument occurrences="4">
       <code>$definition-&gt;getClassName()</code>
       <code>$definition-&gt;getCode()</code>
       <code>$path</code>
+      <code>$this-&gt;path</code>
     </MixedArgument>
     <MixedOperand occurrences="1">
       <code>$this-&gt;path</code>
     </MixedOperand>
     <UnresolvableInclude occurrences="1">
-      <code>require $tmpfname</code>
+      <code>require $fileName</code>
     </UnresolvableInclude>
     <UnusedClass occurrences="1">
       <code>RequireLoader</code>
@@ -2069,27 +2067,35 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="library/Mockery/Reflector.php">
-    <MixedAssignment occurrences="2">
+    <LessSpecificReturnStatement occurrences="1"/>
+    <MixedArgument occurrences="4">
+      <code>$innterType</code>
+      <code>$type-&gt;getTypes()</code>
+      <code>$type-&gt;getTypes()</code>
+      <code>$typeHint</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="4">
+      <code>$innterType</code>
       <code>$type</code>
       <code>$type</code>
+      <code>$typeHint</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
+    <MoreSpecificReturnType occurrences="1">
       <code>list&lt;array{typeHint: string, isPrimitive: bool}&gt;</code>
-      <code>string</code>
-    </MixedInferredReturnType>
+    </MoreSpecificReturnType>
     <PossiblyNullArgument occurrences="1">
       <code>$declaringClass</code>
     </PossiblyNullArgument>
     <PossiblyUnusedMethod occurrences="1">
       <code>getSimplestReturnType</code>
     </PossiblyUnusedMethod>
-    <UndefinedClass occurrences="2">
-      <code>\ReflectionIntersectionType</code>
-      <code>\ReflectionUnionType</code>
-    </UndefinedClass>
-    <UnusedParam occurrences="1">
-      <code>$declaringClass</code>
-    </UnusedParam>
+    <RedundantCondition occurrences="2">
+      <code>!$type instanceof ReflectionType &amp;&amp; method_exists($method, 'getTentativeReturnType')</code>
+      <code>!$type instanceof ReflectionType &amp;&amp; method_exists($method, 'getTentativeReturnType')</code>
+    </RedundantCondition>
+    <UndefinedMethod occurrences="1">
+      <code>getName</code>
+    </UndefinedMethod>
   </file>
   <file src="library/Mockery/Undefined.php">
     <PossiblyUnusedMethod occurrences="1">


### PR DESCRIPTION
This pull request adds functionality to autoload test fixtures based on the runtime version of PHP. 

This will help ensure that the correct fixtures are loaded when running tests on different PHP versions.

Please review the changes, and if there are any additional concerns, kindly let us know.

Thank you