### PR TITLE
Replace `+` Array Union Operator with `array_merge`

### DIFF
--- a/library/Mockery/Reflector.php
+++ b/library/Mockery/Reflector.php
@@ -259,7 +259,7 @@ class Reflector
 
             $intersect = array_intersect(self::TRAVERSABLE_ARRAY, $types);
             if (self::TRAVERSABLE_ARRAY === $intersect) {
-                $types = self::ITERABLE + array_diff($types, self::TRAVERSABLE_ARRAY);
+                $types = array_merge(self::ITERABLE, array_diff($types, self::TRAVERSABLE_ARRAY));
             }
 
             return implode(


### PR DESCRIPTION
Fix #1323 - https://3v4l.org/JFpUQ

> The + operator returns the right-hand array appended to the left-hand array; for keys that exist in both arrays, the elements from the left-hand array will be used, and the matching elements from the right-hand array will be ignored.

https://www.php.net/manual/en/language.operators.array.php

> Merges the elements of one or more arrays together so that the values of one are appended to the end of the previous one. It returns the resulting array.

> If the input arrays have the same string keys, then the later value for that key will overwrite the previous one. If, however, the arrays contain numeric keys, the later value will not overwrite the original value, but will be appended.

> Values in the input arrays with numeric keys will be renumbered with incrementing keys starting from zero in the result array.

https://www.php.net/manual/en/function.array-merge.php