### PR TITLE
Prevent `shouldNotReceive` from getting overridden by invocation count methods

### DIFF
--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -41,6 +41,13 @@ class Expectation implements ExpectationInterface
     protected $_because = null;
 
     /**
+     * Expected count of calls to this expectation
+     *
+     * @var int
+     */
+    protected $_expectedCount = -1;
+
+    /**
      * Arguments expected by this expectation
      *
      * @var array
@@ -719,6 +726,13 @@ class Expectation implements ExpectationInterface
         if (!is_int($limit)) {
             throw new \InvalidArgumentException('The passed Times limit should be an integer value');
         }
+
+        if ($this->_expectedCount === 0) {
+            throw new \InvalidArgumentException('\Mockery\Expectation::shouldNotReceive() method does not accept chaining additional invocation count methods.');
+        }
+
+        $this->_expectedCount = $limit;
+
         $this->_countValidators[$this->_countValidatorClass] = new $this->_countValidatorClass($this, $limit);
 
         if ('Mockery\CountValidator\Exact' !== $this->_countValidatorClass) {

--- a/tests/Unit/Regression/Issue1328Test.php
+++ b/tests/Unit/Regression/Issue1328Test.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Mockery\Tests\Unit\Issues;
+
+use DateTime;
+use Mockery;
+use Mockery\Exception\InvalidCountException;
+use PHPUnit\Framework\TestCase;
+
+final class Issue1328Test extends TestCase
+{
+    public function testShouldFailWithAnInvocationCountError(): void
+    {
+        $this->expectException(InvalidCountException::class);
+
+        $mock = Mockery::mock(DateTime::class);
+
+        $mock->shouldNotReceive("format");
+
+        $mock->format("Y");
+
+        Mockery::close();
+    }
+
+    public function testShouldFailWithAnInvocationCountErrorWhenInvocationCountChanges(): void
+    {
+        $this->expectException(InvalidCountException::class);
+
+        $mock = Mockery::mock(DateTime::class);
+
+        $mock->shouldNotReceive("format")->once();
+
+        $mock->format("Y");
+
+        Mockery::close();
+    }
+}

--- a/tests/Unit/Regression/Issue1328Test.php
+++ b/tests/Unit/Regression/Issue1328Test.php
@@ -3,6 +3,7 @@
 namespace Mockery\Tests\Unit\Issues;
 
 use DateTime;
+use InvalidArgumentException;
 use Mockery;
 use Mockery\Exception\InvalidCountException;
 use PHPUnit\Framework\TestCase;
@@ -22,13 +23,26 @@ final class Issue1328Test extends TestCase
         Mockery::close();
     }
 
-    public function testShouldFailWithAnInvocationCountErrorWhenInvocationCountChanges(): void
+    public function testThrowsInvalidArgumentExceptionWhenInvocationCountChanges(): void
     {
-        $this->expectException(InvalidCountException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $mock = Mockery::mock(DateTime::class);
 
         $mock->shouldNotReceive("format")->once();
+
+        $mock->format("Y");
+
+        Mockery::close();
+    }
+
+    public function testThrowsInvalidArgumentExceptionForChainingAdditionalInvocationCountMethod(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $mock = Mockery::mock(DateTime::class);
+
+        $mock->shouldNotReceive("format")->times(0);
 
         $mock->format("Y");
 


### PR DESCRIPTION
Resolves #1328 

Currently, to indicate that an expectation is `never` expected to be called, Mockery internally sets the invocation count to `0` using `Mocker\Expectation::never()` which is equivalent to `times(0)`.

So adding additional `once()`,`twice()`, `times(n)` invocation count methods will change the expectation behavior from `shouldNotReceive` to `shouldReceive`.

a quick solution was to throw an Expectation.

```php
throw new \InvalidArgumentException(
'shouldNotReceive() method does not accept chaining additional invocation count methods.'
);
```

Should we handle this differently?