### PR TITLE
Setup PHP 8.4 CI Tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,9 +15,9 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         dependencies: ['lowest','highest','locked']
-        dev: ['8.3']
+        dev: ['8.3', '8.4']
 
     continue-on-error: ${{ matrix.php == matrix.dev || matrix.dependencies == 'lowest' }}
 


### PR DESCRIPTION
This patch enables testing `PHP 8.4` via the following changes:

 - Add `8.4`  to `.github/workflows/tests.yml`