### PR TITLE
Add `.readthedocs.yml` configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,24 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools we might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Build documentation in additional formats such as PDF and ePub
+formats: all
+
+# Build requirements for our documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,7 @@ import os
 # ones.
 extensions = [
     'sphinx.ext.todo',
+    'sphinx_rtd_theme',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -256,7 +257,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
     import sphinx_rtd_theme
     html_theme = 'sphinx_rtd_theme'
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-    print sphinx_rtd_theme.get_html_theme_path()
+    print(sphinx_rtd_theme.get_html_theme_path())
 
 # load PhpLexer
 from sphinx.highlighting import lexers

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -9,6 +9,7 @@ Reference
     argument_validation
     alternative_should_receive_syntax
     spies
+    instance_mocking
     partial_mocks
     protected_methods
     public_properties

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,8 @@
+mock==1.0.1
+alabaster>=0.7,<0.8,!=0.7.5
+commonmark==0.9.1
+recommonmark==0.5.0
+sphinx<2
+sphinx-rtd-theme<0.5
+readthedocs-sphinx-ext<2.3
+jinja2<3.1.0


### PR DESCRIPTION
This patch resolves failing documentation build process for docs.mockery.io, via the following changes:

 - [Add .readthedocs.yml](https://github.com/mockery/mockery/commit/f1f12c42abcd559e0af2d1413c097a5094a477fd)
 - [Add requirements.txt](https://github.com/mockery/mockery/commit/9926379aee4d564a666c527b81a9e80122387725)
 - [Update conf.py](https://github.com/mockery/mockery/commit/4260ba611b58b7ae8a01b394b06f02f75c6d00d3)

<img width="835" alt="image" src="https://github.com/mockery/mockery/assets/9754361/95b38830-63f4-480d-b056-3acbcfb81dbb">
