### PR TITLE
Update psalm-baseline.xml

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.15.0@5c774aca4746caf3d239d9c8cadb9f882ca29352">
+<files psalm-version="5.17.0@c620f6e80d0abfca532b00bda366062aaedf6e5d">
   <file src="library/Mockery.php">
     <ArgumentTypeCoercion>
       <code>$expectation</code>
@@ -439,7 +439,6 @@
                 );]]></code>
     </MissingThrowsDocblock>
     <MixedArgument>
-      <code>$arg</code>
       <code>$blocks</code>
       <code>$constructorArgs</code>
       <code><![CDATA[$def->getClassName()]]></code>
@@ -515,6 +514,9 @@
     <MoreSpecificReturnType>
       <code>Mock</code>
     </MoreSpecificReturnType>
+    <NoValue>
+      <code>$arg</code>
+    </NoValue>
     <PossiblyUndefinedIntArrayOffset>
       <code>$parts[1]</code>
     </PossiblyUndefinedIntArrayOffset>
@@ -538,6 +540,7 @@
       <code>is_array($arg)</code>
     </RedundantConditionGivenDocblockType>
     <TypeDoesNotContainType>
+      <code><![CDATA[$arg === 'null']]></code>
       <code><![CDATA[is_callable($finalArg) && is_object($finalArg)]]></code>
       <code>is_object($finalArg)</code>
     </TypeDoesNotContainType>
@@ -1175,7 +1178,6 @@
       <code>$methods</code>
       <code>$methods</code>
       <code>$methods</code>
-      <code>$names</code>
       <code>$target</code>
       <code>$target</code>
       <code>$target</code>
@@ -1218,7 +1220,6 @@
     </MixedArrayAccess>
     <MixedArrayAssignment>
       <code>$classes[]</code>
-      <code>$names[]</code>
       <code><![CDATA[$this->targetInterfaceNames[]]]></code>
       <code><![CDATA[$this->targetInterfaces[]]]></code>
       <code><![CDATA[$this->targetInterfaces[]]]></code>
@@ -1951,18 +1952,6 @@
     </MixedReturnStatement>
   </file>
   <file src="library/Mockery/Instantiator.php">
-    <InvalidArgument>
-      <code><![CDATA[function ($code, $message, $file, $line) use ($reflectionClass, & $error) {
-            $msg = sprintf(
-                'Could not produce an instance of "%s" via un-serialization, since an error was triggered in file "%s" at line "%d"',
-                $reflectionClass->getName(),
-                $file,
-                $line
-            );
-
-            $error = new UnexpectedValueException($msg, 0, new \Exception($message, $code));
-        }]]></code>
-    </InvalidArgument>
     <MissingClosureReturnType>
       <code>function () use ($serializedString) {</code>
     </MissingClosureReturnType>
@@ -1978,16 +1967,27 @@
     </MissingThrowsDocblock>
     <MixedArgument>
       <code>$className</code>
+      <code><![CDATA[function ($code, $message, $file, $line) use ($reflectionClass, & $error) {
+            $msg = sprintf(
+                'Could not produce an instance of "%s" via un-serialization, since an error was triggered in file "%s" at line "%d"',
+                $reflectionClass->getName(),
+                $file,
+                $line
+            );
+
+            $error = new UnexpectedValueException($msg, 0, new \Exception($message, $code));
+        }]]></code>
     </MixedArgument>
     <MixedAssignment>
       <code>$instance</code>
     </MixedAssignment>
+    <UndefinedVariable>
+      <code>$error</code>
+      <code>$error</code>
+    </UndefinedVariable>
     <UnusedMethod>
       <code>hasInternalAncestors</code>
     </UnusedMethod>
-    <UnusedVariable>
-      <code>$error</code>
-    </UnusedVariable>
   </file>
   <file src="library/Mockery/LegacyMockInterface.php">
     <MissingParamType>


### PR DESCRIPTION
This patch temporarily suppresses psalm errors by adding legacy psalm issues to `psalm-baseline.xml`.